### PR TITLE
Cherry pick: Update build.py to disallow running as root user by default. (#15164)

### DIFF
--- a/dockerfiles/Dockerfile.arm32v7
+++ b/dockerfiles/Dockerfile.arm32v7
@@ -9,7 +9,7 @@ MAINTAINER Changming Sun "chasun@microsoft.com"
 ADD . /code
 
 RUN /code/dockerfiles/scripts/install_fedora_arm32.sh
-RUN cd /code && ./build.sh --skip_submodule_sync --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER)
+RUN cd /code && ./build.sh --allow_running_as_root --skip_submodule_sync --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER)
 
 FROM arm64v8/centos:7
 COPY --from=0 /code/build/Linux/Release/dist /root

--- a/dockerfiles/Dockerfile.arm64
+++ b/dockerfiles/Dockerfile.arm64
@@ -9,7 +9,7 @@ MAINTAINER Changming Sun "chasun@microsoft.com"
 ADD . /code
 
 
-RUN /code/dockerfiles/scripts/install_centos_arm64.sh && cd /code && CC=/opt/rh/devtoolset-10/root/usr/bin/gcc CXX=/opt/rh/devtoolset-10/root/usr/bin/g++ ./build.sh --skip_submodule_sync --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 
+RUN /code/dockerfiles/scripts/install_centos_arm64.sh && cd /code && CC=/opt/rh/devtoolset-10/root/usr/bin/gcc CXX=/opt/rh/devtoolset-10/root/usr/bin/g++ ./build.sh --allow_running_as_root --skip_submodule_sync --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER)
 
 FROM arm64v8/centos:7
 COPY --from=0 /code/build/Linux/Release/dist /root

--- a/dockerfiles/Dockerfile.cuda
+++ b/dockerfiles/Dockerfile.cuda
@@ -13,7 +13,7 @@ ADD . /code
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-certificates g++ python3-numpy gcc make git python3-setuptools python3-wheel python3-pip aria2 && aria2c -q -d /tmp -o cmake-3.24.3-linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3-linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.24.3-linux-x86_64.tar.gz --strip=1 -C /usr
 
-RUN cd /code && /bin/bash ./build.sh --skip_submodule_sync --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_cuda --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 'CMAKE_CUDA_ARCHITECTURES=52;60;61;70;75;86'
+RUN cd /code && /bin/bash ./build.sh --allow_running_as_root --skip_submodule_sync --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_cuda --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 'CMAKE_CUDA_ARCHITECTURES=52;60;61;70;75;86'
 
 FROM nvcr.io/nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04
 ENV	    DEBIAN_FRONTEND=noninteractive

--- a/dockerfiles/Dockerfile.migraphx
+++ b/dockerfiles/Dockerfile.migraphx
@@ -9,6 +9,9 @@ FROM ubuntu:18.04
 
 ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
 ARG ONNXRUNTIME_BRANCH=main
+ARG ROCM_VERSION=5.4
+# MIGraphX version should be the same as ROCm version
+ARG MIGRAPHX_VERSION=rocm-5.4.0
 ENV DEBIAN_FRONTEND noninteractive
 ENV MIGRAPHX_DISABLE_FAST_GELU=1
 
@@ -21,11 +24,11 @@ ENV LANG C.UTF-8
 # Install rocm
 RUN apt-get update && apt-get install -y gnupg2 --no-install-recommends curl && \
   curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
-  sh -c 'echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/4.5.2/ ubuntu main > /etc/apt/sources.list.d/rocm.list'
+  sh -c 'echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/${ROCM_VERSION}/ ubuntu main > /etc/apt/sources.list.d/rocm.list'
 
 RUN apt-get update &&\
-    apt-get install -y sudo git bash build-essential rocm-dev libpython3.6-dev python3-pip miopen-hip \
-    rocblas half aria2 libnuma-dev
+    apt-get install -y sudo git bash build-essential rocm-dev python3-dev python3-pip miopen-hip \
+    rocblas half aria2 libnuma-dev pkg-config
 
 RUN aria2c -q -d /tmp -o cmake-3.24.3-linux-x86_64.tar.gz \
 https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3-linux-x86_64.tar.gz &&\
@@ -38,8 +41,8 @@ ENV PATH /opt/miniconda/bin:/code/cmake-3.24.3-linux-x86_64/bin:${PATH}
 
 # Install MIGraphX from source
 RUN mkdir -p /migraphx
-RUN cd /migraphx && git clone --depth=1 --branch migraphx_for_ort https://github.com/ROCmSoftwarePlatform/AMDMIGraphX src
-RUN cd /migraphx && rbuild package --cxx /opt/rocm-4.5.2/llvm/bin/clang++ -d /migraphx/deps -B /migraphx/build -S /migraphx/src/ -DPYTHON_EXECUTABLE=/usr/bin/python3
+RUN cd /migraphx && git clone --depth=1 --branch ${MIGRAPHX_VERSION} https://github.com/ROCmSoftwarePlatform/AMDMIGraphX src
+RUN cd /migraphx && rbuild package --cxx /opt/rocm/llvm/bin/clang++ -d /migraphx/deps -B /migraphx/build -S /migraphx/src/ -DPYTHON_EXECUTABLE=/usr/bin/python3
 RUN dpkg -i /migraphx/build/*.deb
 RUN rm -rf /migraphx
 
@@ -53,6 +56,6 @@ WORKDIR /code
 RUN git clone --single-branch --branch ${ONNXRUNTIME_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime &&\
     /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh &&\
     cd onnxruntime  &&\
-    /bin/sh ./build.sh --cmake_extra_defines ONNXRUNTIME_VERSION=`cat ./VERSION_NUMBER` --config Release --parallel \
-            --skip_tests --build_wheel --use_rocm --rocm_version=4.5.2 --rocm_home /opt/rocm --use_migraphx &&\
+    /bin/sh ./build.sh --allow_running_as_root --cmake_extra_defines ONNXRUNTIME_VERSION=`cat ./VERSION_NUMBER` --config Release --parallel \
+            --skip_tests --build_wheel --use_rocm --rocm_version=${ROCM_VERSION} --rocm_home /opt/rocm --use_migraphx &&\
     pip install /code/onnxruntime/build/Linux/Release/dist/*.whl

--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -27,7 +27,7 @@ RUN ln -s cmake-* cmake-dir
 RUN python3 -m pip install wheel
 ENV PATH=${WORKDIR_PATH}/cmake-dir/bin:$PATH
 RUN pip3 install onnx
-RUN cd onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino ${DEVICE} --build_shared_lib --build_wheel
+RUN cd onnxruntime && ./build.sh --allow_running_as_root --config Release --update --build --parallel --use_openvino ${DEVICE} --build_shared_lib --build_wheel
 
 #Steps to download sources
 RUN cat /etc/apt/sources.list | sed 's/^# deb-src/deb-src/g' > ./temp; mv temp /etc/apt/sources.list

--- a/dockerfiles/Dockerfile.openvino-centos7
+++ b/dockerfiles/Dockerfile.openvino-centos7
@@ -96,7 +96,7 @@ RUN yum update -y && \
     pip3 install numpy wheel setuptools cython && \
     git clone --recursive -b ${ONNXRUNTIME_BRANCH} ${ONNXRUNTIME_REPO} && \
     pip3 install onnx && \
-    cd /code/onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino ${DEVICE} --build_shared_lib --build_wheel && \
+    cd /code/onnxruntime && ./build.sh --allow_running_as_root --config Release --update --build --parallel --use_openvino ${DEVICE} --build_shared_lib --build_wheel && \
     pip3 install /code/onnxruntime/build/Linux/Release/dist/*-linux_x86_64.whl && \
 # Clean up
     cd  $MY_ROOT && rm -rf onnxruntime Python-3* && \

--- a/dockerfiles/Dockerfile.openvino-csharp
+++ b/dockerfiles/Dockerfile.openvino-csharp
@@ -43,7 +43,7 @@ ENV WORKDIR_PATH=/home/openvino
 WORKDIR $WORKDIR_PATH
 ENV DEBIAN_FRONTEND noninteractive
 
-ARG DEVICE=CPU_FP32 
+ARG DEVICE=CPU_FP32
 ARG ONNXRUNTIME_REPO=https://github.com/microsoft/onnxruntime.git
 ARG ONNXRUNTIME_BRANCH=main
 
@@ -55,7 +55,7 @@ RUN apt update; apt install -y --no-install-recommends git protobuf-compiler lib
     unattended-upgrade && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git clone --recursive -b ${ONNXRUNTIME_BRANCH} ${ONNXRUNTIME_REPO} 
+RUN git clone --recursive -b ${ONNXRUNTIME_BRANCH} ${ONNXRUNTIME_REPO}
 RUN /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh
 RUN ln -s cmake-* cmake-dir
 RUN python3 -m pip install wheel
@@ -65,7 +65,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN apt install locales && \
     locale-gen en_US en_US.UTF-8 && \
     dpkg-reconfigure locales
-RUN cd onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino ${DEVICE} --build_nuget --build_shared_lib
+RUN cd onnxruntime && ./build.sh --allow_running_as_root --config Release --update --build --parallel --use_openvino ${DEVICE} --build_nuget --build_shared_lib
 RUN cp /home/openvino/onnxruntime/build/Linux/Release/Microsoft.ML.OnnxRuntime.Managed* /home/openvino/onnxruntime/build/Linux/Release/nuget-artifacts
 
 # Deploy stage
@@ -88,4 +88,3 @@ USER ${BUILD_USER}
 ENV PATH=${WORKDIR_PATH}/miniconda/bin:${WORKDIR_PATH}/cmake-dir/bin:$PATH
 ENV IE_PLUGINS_PATH=${INTEL_OPENVINO_DIR}/runtime/lib/intel64
 ENV LD_LIBRARY_PATH=/opt/intel/opencl:${INTEL_OPENVINO_DIR}/runtime/3rdparty/tbb/lib:${IE_PLUGINS_PATH}:${LD_LIBRARY_PATH}
-

--- a/dockerfiles/Dockerfile.openvino-rhel8
+++ b/dockerfiles/Dockerfile.openvino-rhel8
@@ -18,7 +18,7 @@ ENV OpenCV_DIR=${INTEL_OPENVINO_DIR}/extras/opencv/cmake
 ENV LD_LIBRARY_PATH=${INTEL_OPENVINO_DIR}/extras/opencv/lib:${LD_LIBRARY_PATH}
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/lib:/usr/local/lib64:/usr/lib64:/lib64:${LD_LIBRARY_PATH}
 
-# Install packages 
+# Install packages
 RUN yum install -y yum-utils autoconf automake libtool unzip udev wget zlib-devel libffi-devel openssl-devel git make gcc && \
     yum clean packages &&  yum clean all && rm -rf /var/cache/yum && \
 # Install python 3.8
@@ -30,7 +30,7 @@ RUN yum install -y yum-utils autoconf automake libtool unzip udev wget zlib-deve
     cd /opt/ && wget https://github.com/libusb/libusb/archive/v1.0.22.zip && \
     unzip v1.0.22.zip && rm -rf v1.0.22.zip && cd  /opt/libusb-1.0.22 && \
 # bootstrap steps
-    ./bootstrap.sh && \ 
+    ./bootstrap.sh && \
     ./configure --disable-udev --enable-shared && \
     make -j4 && \
 # configure libusb1.0.22
@@ -55,7 +55,7 @@ RUN yum install -y yum-utils autoconf automake libtool unzip udev wget zlib-deve
 #Install protobuf
     cd $MY_ROOT && \
     git clone https://github.com/protocolbuffers/protobuf.git && \
-    cd protobuf && \ 
+    cd protobuf && \
     git checkout v3.16.0 && \
     git submodule update --init --recursive && \
     mkdir build_source && cd build_source && \
@@ -68,7 +68,7 @@ RUN yum install -y yum-utils autoconf automake libtool unzip udev wget zlib-deve
     git clone --recursive -b ${ONNXRUNTIME_BRANCH} ${ONNXRUNTIME_REPO} && \
     pip3 install onnx && \
     source /opt/intel/openvino_2022.2.0.7713/setupvars.sh && \
-    cd /code/onnxruntime && ./build.sh --config Release --update --build --parallel --use_openvino ${DEVICE} --build_shared_lib --build_wheel && \
+    cd /code/onnxruntime && ./build.sh --allow_running_as_root --config Release --update --build --parallel --use_openvino ${DEVICE} --build_shared_lib --build_wheel && \
     pip3 install /code/onnxruntime/build/Linux/Release/dist/*-linux_x86_64.whl && \
 # Clean up
     cd ${MY_ROOT} && rm -rf onnxruntime && rm -rf Python-3.8.9 && rm -rf protobuf

--- a/dockerfiles/Dockerfile.rocm
+++ b/dockerfiles/Dockerfile.rocm
@@ -15,7 +15,7 @@ WORKDIR /code
 # Prepare onnxruntime repository & build onnxruntime
 RUN git clone --single-branch --branch ${ONNXRUNTIME_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime &&\
     cd onnxruntime &&\
-    /bin/sh ./build.sh --config Release --build_wheel --update --build --parallel --cmake_extra_defines\
+    /bin/sh ./build.sh --allow_running_as_root --config Release --build_wheel --update --build --parallel --cmake_extra_defines\
             ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm &&\
     pip install /code/onnxruntime/build/Linux/Release/dist/*.whl &&\
     cd ..

--- a/dockerfiles/Dockerfile.source
+++ b/dockerfiles/Dockerfile.source
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-certificates g++ python3-numpy gcc make git python3-setuptools python3-wheel python3-pip aria2 && aria2c -q -d /tmp -o cmake-3.24.3-linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3-linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.24.3-linux-x86_64.tar.gz --strip=1 -C /usr
 
 # Prepare onnxruntime repository & build onnxruntime
-RUN cd /code && /bin/bash ./build.sh --skip_submodule_sync --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 
+RUN cd /code && /bin/bash ./build.sh --allow_running_as_root --skip_submodule_sync --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER)
 
 FROM ubuntu:18.04
 COPY --from=0 /code/build/Linux/Release/dist /root

--- a/dockerfiles/Dockerfile.tensorrt
+++ b/dockerfiles/Dockerfile.tensorrt
@@ -25,6 +25,6 @@ RUN git clone --single-branch --branch ${ONNXRUNTIME_BRANCH} --recursive ${ONNXR
     trt_version=${TRT_VERSION:0:3} &&\
     /bin/sh onnxruntime/dockerfiles/scripts/checkout_submodules.sh ${trt_version} &&\
     cd onnxruntime &&\
-    /bin/sh build.sh --parallel --build_shared_lib --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_tensorrt --tensorrt_home /usr/lib/x86_64-linux-gnu/ --config Release --build_wheel --skip_tests --skip_submodule_sync --cmake_extra_defines '"CMAKE_CUDA_ARCHITECTURES='${CMAKE_CUDA_ARCHITECTURES}'"' &&\
+    /bin/sh build.sh --allow_running_as_root --parallel --build_shared_lib --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_tensorrt --tensorrt_home /usr/lib/x86_64-linux-gnu/ --config Release --build_wheel --skip_tests --skip_submodule_sync --cmake_extra_defines '"CMAKE_CUDA_ARCHITECTURES='${CMAKE_CUDA_ARCHITECTURES}'"' &&\
     pip install /code/onnxruntime/build/Linux/Release/dist/*.whl &&\
     cd ..

--- a/dockerfiles/Dockerfile.vitisai
+++ b/dockerfiles/Dockerfile.vitisai
@@ -38,7 +38,7 @@ RUN . $VAI_ROOT/conda/etc/profile.d/conda.sh &&\
     cp onnxruntime/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt &&\
     cp onnxruntime/ThirdPartyNotices.txt /code/ThirdPartyNotices.txt &&\
     cd onnxruntime &&\
-    /bin/sh ./build.sh --config RelWithDebInfo --enable_pybind --build_wheel --use_vitisai --parallel --update --build --build_shared_lib &&\
+    /bin/sh ./build.sh --allow_running_as_root --config RelWithDebInfo --enable_pybind --build_wheel --use_vitisai --parallel --update --build --build_shared_lib &&\
     pip install /code/onnxruntime/build/Linux/RelWithDebInfo/dist/*-linux_x86_64.whl &&\
     cd .. &&\
     rm -rf onnxruntime cmake-3.24.3-linux-x86_64

--- a/tools/android_custom_build/build_custom_android_package.py
+++ b/tools/android_custom_build/build_custom_android_package.py
@@ -3,13 +3,26 @@
 # Licensed under the MIT License.
 
 import argparse
+import os
 import pathlib
+import shlex
 import shutil
 import subprocess
+import sys
 
 SCRIPT_DIR = pathlib.Path(__file__).parent.resolve()
 DEFAULT_OPS_CONFIG_RELATIVE_PATH = "tools/ci_build/github/android/mobile_package.required_operators.config"
 DEFAULT_BUILD_SETTINGS_RELATIVE_PATH = "tools/ci_build/github/android/default_mobile_aar_build_settings.json"
+
+
+def is_windows():
+    return sys.platform.startswith("win")
+
+
+def run(cmd_arg_list, **kwargs):
+    print(f"Running command:\n  {shlex.join(cmd_arg_list)}")
+    kwargs.update({"check": True})
+    return subprocess.run(cmd_arg_list, **kwargs)
 
 
 def parse_args():
@@ -68,6 +81,13 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--docker_container_name",
+        help="The name of the Docker container that is run (given to the --name option of `docker run`). "
+        "If unspecified, the container will be automatically removed. "
+        "Keeping the container may be useful for debugging.",
+    )
+
+    parser.add_argument(
         "--docker_path",
         default=shutil.which("docker"),
         help="The path to docker. If unspecified, docker should be in PATH.",
@@ -84,26 +104,25 @@ def parse_args():
 def main():
     args = parse_args()
 
-    docker_build_args = []
+    docker_build_image_args = []
     if args.onnxruntime_branch_or_tag:
-        docker_build_args += ["--build-arg", f"ONNXRUNTIME_BRANCH_OR_TAG={args.onnxruntime_branch_or_tag}"]
+        docker_build_image_args += ["--build-arg", f"ONNXRUNTIME_BRANCH_OR_TAG={args.onnxruntime_branch_or_tag}"]
     if args.onnxruntime_repo_url:
-        docker_build_args += ["--build-arg", f"ONNXRUNTIME_REPO={args.onnxruntime_repo_url}"]
+        docker_build_image_args += ["--build-arg", f"ONNXRUNTIME_REPO={args.onnxruntime_repo_url}"]
+    if not is_windows():
+        docker_build_image_args += ["--build-arg", f"BUILD_UID={os.geteuid()}"]
 
-    docker_build_cmd = (
-        [
-            args.docker_path,
-            "build",
-            "--tag",
-            args.docker_image_tag,
-            "--file",
-            str(SCRIPT_DIR / "Dockerfile"),
-        ]
-        + docker_build_args
-        + [str(SCRIPT_DIR)]
-    )
+    docker_build_image_cmd = [
+        args.docker_path,
+        "build",
+        "--tag",
+        args.docker_image_tag,
+        "--file",
+        str(SCRIPT_DIR / "Dockerfile"),
+        *docker_build_image_args,
+    ] + [str(SCRIPT_DIR)]
 
-    subprocess.run(docker_build_cmd, check=True)
+    run(docker_build_image_cmd)
 
     working_dir = args.working_dir
     working_dir.mkdir(parents=True, exist_ok=True)
@@ -132,23 +151,22 @@ def main():
         else f"/workspace/onnxruntime/{DEFAULT_BUILD_SETTINGS_RELATIVE_PATH}"
     )
 
-    docker_run_cmd = [
-        args.docker_path,
-        "run",
-        "--rm",
-        "-it",
-        f"--volume={str(working_dir)}:/workspace/shared",
+    # enable use of Ctrl-C to stop when running interactively
+    docker_run_interactive_args = ["-it"] if sys.stdin.isatty() else []
+
+    docker_container_build_cmd = [args.docker_path, "run", *docker_run_interactive_args] + [
+        f"--name={args.docker_container_name}" if args.docker_container_name is not None else "--rm",
+        f"--volume={working_dir}:/workspace/shared",
         args.docker_image_tag,
-        "/usr/bin/env",
-        "python3",
-        "/workspace/onnxruntime/tools/ci_build/github/android/build_aar_package.py",
-        "--build_dir=/workspace/shared/output",
-        f"--config={args.config}",
-        f"--include_ops_by_config={container_ops_config_file}",
+        "/bin/bash",
+        "/workspace/scripts/build.sh",
+        args.config,
+        container_ops_config_file,
         container_build_settings_file,
+        "/workspace/shared/output",
     ]
 
-    subprocess.run(docker_run_cmd, check=True)
+    run(docker_container_build_cmd)
 
     print("Finished building Android package at '{}'.".format(output_dir / "aar_out"))
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -666,6 +666,13 @@ def parse_arguments():
 
     parser.add_argument("--use_xnnpack", action="store_true", help="Enable xnnpack EP.")
 
+    if not is_windows():
+        parser.add_argument(
+            "--allow_running_as_root",
+            action="store_true",
+            help="Allow build to be run as root user. This is not allowed by default.",
+        )
+
     args = parser.parse_args()
     if args.android_sdk_path:
         args.android_sdk_path = os.path.normpath(args.android_sdk_path)
@@ -2389,6 +2396,15 @@ def main():
     log.debug("Command line arguments:\n  {}".format(" ".join(shlex.quote(arg) for arg in sys.argv[1:])))
 
     args = parse_arguments()
+
+    if not is_windows():
+        if not args.allow_running_as_root:
+            is_root_user = os.geteuid() == 0
+            if is_root_user:
+                raise BuildError(
+                    "Running as root is not allowed. If you really want to do that, use '--allow_running_as_root'."
+                )
+
     cmake_extra_defines = normalize_arg_list(args.cmake_extra_defines)
     cross_compiling = args.arm or args.arm64 or args.arm64ec or args.android
 


### PR DESCRIPTION
Try to address intermittent permissions issues that show up in non-transient CI environments.

###Description

Update build.py to disallow running as root user by default.

###Motivation and Context

Try to address intermittent permissions issues that show up in non-transient CI environments.
