### PR TITLE
Skip MultiHeadAttentionTest for ROCmEP

### DIFF
--- a/onnxruntime/test/contrib_ops/multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/multihead_attention_op_test.cc
@@ -476,6 +476,7 @@ TEST(MultiHeadAttentionTest, CrossAttention_Batch1_HeadSize32_LeftSidePadding_Ma
 }
 
 TEST(MultiHeadAttentionTest, CrossAttention_Batch2_HeadSize32_NoBias_NoMask_PackedKV) {
+  ROCM_GTEST_SKIP("ROCm MHA does not support mask");
   MIGX_GTEST_SKIP("MIGX MHA does not support Packed KV");
   AttentionTestData data;
   GetCrossAttentionData_Batch2_HeadSize32_NoBias_NoMask_PackedKV(data);
@@ -483,6 +484,7 @@ TEST(MultiHeadAttentionTest, CrossAttention_Batch2_HeadSize32_NoBias_NoMask_Pack
 }
 
 TEST(MultiHeadAttentionTest, SelfAttention_Batch2_HeadSize32_NoBias_NoMask_PackedQKV) {
+  ROCM_GTEST_SKIP("ROCm MHA does not support mask");
   MIGX_GTEST_SKIP("MIGX MHA does not support Packed QKV");
   AttentionTestData data;
   GetSelfAttentionData_Batch2_HeadSize32_NoBias_NoMask_PackedQKV(data);


### PR DESCRIPTION
The rest of the test suite is skipped for ROCm. Adding skips for new tests.

### Description
<!-- Describe your changes. -->
Add skips for ROCm for relevant tests in suite MultiHeadAttentionTest to match the rest of the suite.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Enable consistency in test results and intents.
