### PR TITLE
Skip MHA tests that fail on NaviXX targets

### DIFF
--- a/onnxruntime/test/contrib_ops/multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/multihead_attention_op_test.cc
@@ -484,6 +484,7 @@ TEST(MultiHeadAttentionTest, CrossAttention_Batch2_HeadSize32_RightSidePadding_M
 }
 
 TEST(MultiHeadAttentionTest, CrossAttention_Batch2_HeadSize32_RightSidePadding_Mask2D) {
+  ROCM_GTEST_SKIP("ROCm MHA skip");
   AttentionTestData data;
   GetCrossAttentionData_Batch2_HeadSize32_RightSidePadding(data, false);
   RunMultiHeadAttentionTests(data, true);


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add MHA test skips for ROCm due to NaviXX


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Skip tests for MHA due to failures on NAVI3X.

