### PR TITLE
Resolve issue with GroupQueryAttention operator on RDNA architectures

### DIFF
--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
@@ -2469,8 +2469,8 @@ ROCMExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
 
     auto& device_prop = GetDeviceProp();
     if (std::string_view(node.Name()).find("GroupQueryAttention") != std::string_view::npos &&
-        std::string_view(device_prop.gcnArchName).find("gfx90a") == std::string_view::npos &&
-        std::string_view(device_prop.gcnArchName).find("gfx942") == std::string_view::npos){
+        (std::string_view(device_prop.gcnArchName).find("gfx11") != std::string_view::npos ||
+        std::string_view(device_prop.gcnArchName).find("gfx12") != std::string_view::npos)){
       LOGS(logger, WARNING)
         << "Node " << node.Name() << " moved to CPU execution, not supported on "
         << device_prop.gcnArchName << " arch.";


### PR DESCRIPTION

### Description
- GroupQueryAttention node is bypassed for GPU execution on RDNA architectures, redirecting its execution to the CPU



### Motivation and Context
- The change is necessary due to compatibility issues with RDNA architectures, where executing GroupQueryAttention on the GPU results in a core dump. By rerouting the execution to the CPU, we prevent these crashes and maintain system stability
- **Note**: This is a temporary workaround. Support for GroupQueryAttention on RDNA architectures will be enabled in the composable kernel in the future.


