### PR TITLE
Add gfx1151 and gfx1152 to supported HIP architectures for ROCm6.4

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -339,7 +339,7 @@ if (onnxruntime_USE_ROCM)
     if (ROCM_VERSION_DEV VERSION_LESS "6.2")
       message(FATAL_ERROR "CMAKE_HIP_ARCHITECTURES is not set when ROCm version < 6.2")
     else()
-      set(CMAKE_HIP_ARCHITECTURES "gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx942;gfx1200;gfx1201;gfx1150")
+      set(CMAKE_HIP_ARCHITECTURES "gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx942;gfx1200;gfx1201;gfx1150;gfx1151;gfx1152")
     endif()
   endif()
 


### PR DESCRIPTION
### Description
To run MIGraphX EP with ROCm6.4 on Linux on gfx1151 and gfx1152 architectures, they must be added to CMAKE_HIP_ARCHITECTURES.

### Motivation and Context
Expanding MIGraphX EP for more AMD platforms