### PR TITLE
Add gfx1151 and gfx1152 to supported HIP architectures for ROCm7.0

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -343,7 +343,7 @@ if (onnxruntime_USE_ROCM)
     if (ROCM_VERSION_DEV VERSION_LESS "6.2")
       message(FATAL_ERROR "CMAKE_HIP_ARCHITECTURES is not set when ROCm version < 6.2")
     else()
-      set(CMAKE_HIP_ARCHITECTURES "gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx942;gfx950;gfx1200;gfx1201;gfx1150")
+      set(CMAKE_HIP_ARCHITECTURES "gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx942;gfx950;gfx1200;gfx1201;gfx1150;gfx1151;gfx1152")
     endif()
   endif()
 
@@ -975,7 +975,7 @@ if (onnxruntime_USE_JSEP)
     list(APPEND ONNXRUNTIME_PROVIDER_NAMES js)
 endif()
 if (onnxruntime_USE_QNN OR onnxruntime_USE_QNN_INTERFACE)
-    
+
     if(onnxruntime_USE_QNN)
         list(APPEND ORT_PROVIDER_FLAGS -DUSE_QNN=1)
     else()

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -975,7 +975,7 @@ if (onnxruntime_USE_JSEP)
     list(APPEND ONNXRUNTIME_PROVIDER_NAMES js)
 endif()
 if (onnxruntime_USE_QNN OR onnxruntime_USE_QNN_INTERFACE)
-
+    
     if(onnxruntime_USE_QNN)
         list(APPEND ORT_PROVIDER_FLAGS -DUSE_QNN=1)
     else()


### PR DESCRIPTION
### Description
To run MIGraphX EP with ROCm6.4 on Linux on gfx1151 and gfx1152 architectures, they must be added to CMAKE_HIP_ARCHITECTURES.

### Motivation and Context
Expanding MIGraphX EP for more AMD platforms
