### PR TITLE
Don't build 'composable_kernel' for unsupported archs.

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -718,6 +718,11 @@ def generate_build_tree(
         cmake_args.append("-Donnxruntime_ROCM_VERSION=" + args.rocm_version)
         if args.rocm_gfx_arch:
             cmake_args.append("-DCMAKE_HIP_ARCHITECTURES=" + args.rocm_gfx_arch)
+            # 'Composable kernel/tile' is only supported for some architectures.
+            if not ("gfx942" in args.rocm_gfx_arch
+                    or "gfx90a" in args.rocm_gfx_arch
+                    or "gfx950" in args.rocm_gfx_arch):
+                cmake_args.append("-Donnxruntime_USE_COMPOSABLE_KERNEL=OFF")
     if args.use_tensorrt or args.use_nv_tensorrt_rtx:
         cmake_args.append("-Donnxruntime_TENSORRT_HOME=" + tensorrt_home)
 


### PR DESCRIPTION
'composable_kernel/tile' is only supported by some architectures, namely gfx942/gfx90a/gfx950 (according to [cmake/external/composable_kernel.cmake](https://github.com/ROCm/onnxruntime/blob/cf26ff76b1ba50428108a11eb6e34c01bfc82cc6/cmake/external/composable_kernel.cmake#L68).
If we try to build ORT for ROCm provider for unsupported architecture, build will fail.
Hence let's not build `composable_kernel` for unsupported architecture.

MS dropped ROCm EP for onnxruntime, yet we want to support and test it for ROCm 7.0. Therefore, I believe we don't need to push these changes into MS' main branch.