### PR TITLE
Fix for Full Onnx Graph with Dangling nodes

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -82,7 +82,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   std::shared_ptr<KernelRegistry> GetKernelRegistry() const override;
   std::unique_ptr<onnxruntime::IDataTransfer> GetDataTransfer() const override;
 
-  std::unique_ptr<IndexedSubGraph> GetSubGraph(const std::vector<std::size_t>& graph_nodes_index, const GraphViewer& graph) const;
+  std::unique_ptr<IndexedSubGraph> GetSubGraph(const std::vector<std::size_t>& graph_nodes_index, const GraphViewer& graph, bool is_graph_split) const;
   void RegisterStreamHandlers(IStreamCommandHandleRegistry& stream_handle_registry, AllocatorMap& allocators) const override;
   OrtDevice GetOrtDeviceByMemType(OrtMemType mem_type) const override;
   std::vector<AllocatorPtr> CreatePreferredAllocators() override;


### PR DESCRIPTION
Fixes an issue seen in a customer model

### Description
<!-- Describe your changes. -->

Fixes an issue seen when a full graph is given to GetSubGraph() in the EP and that graph contains dangling outputs on some of the intermediate nodes in the graph. This results in those node errornously being added to the output graph. 

This change adds a bypass for the final graph output if we know that the graph isnt partitioned and run entirely on MIgraphX EP to throw away any outputs dangling. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
fixes issue where graph generates  extra outputs

Related to bug opened on OnnxRt turns out issue is on our side in the EP - https://github.com/microsoft/onnxruntime/issues/26176