### PR TITLE
Fix for unsupported Pad node with empty string for constant_value 

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
@@ -134,6 +134,11 @@ inline bool canEvalNodeArgument(const GraphViewer& graph,
       continue;
     }
 
+    const auto& optype = node->OpType();
+    if (optype == "Pad" && input_name == "" && index == 2) {
+      continue;
+    }
+
     // Input cannot be constant folded
     if (IsGraphInput(graph, input_name)) {
       return false;


### PR DESCRIPTION
### Description
For model sam-vit-base_fp16::vision, the pad nodes in this model is unsupported because the constant_value is empty:
<img width="763" height="498" alt="pastedImage_10_21_2025__19_00_18_37" src="https://github.com/user-attachments/assets/bafc1540-2d17-40c9-859f-b3e47603bbd6" />

When it checks IsUnsupportedOpMode here, it looks at index {2} to see if it can be evaluated:
[onnxruntime/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc at wml-main · ROCm/onnxruntime](https://github.com/ROCm/onnxruntime/blob/wml-main/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc#L478) 

The constant_value input name is empty string, so it cannot find the corresponding node with empty string name, so canEvalNodeArgument returns false here:
[onnxruntime/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h at wml-main · ROCm/onnxruntime](https://github.com/ROCm/onnxruntime/blob/wml-main/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h#L147)
<img width="912" height="571" alt="pastedImage_10_21_2025__19_04_26_546" src="https://github.com/user-attachments/assets/fd2e30e2-9680-4b74-8433-0f7652dcc16d" />

According to documentation here constant_value could be empty string:
https://github.com/onnx/onnx/blob/main/docs/Operators.md#inputs-2---4-2

This change adds another case in canEvalNodeArgument for index 2 when it is a Pad node for empty constant_value


