### PR TITLE
Fixing dump model ops feature issue on Windows

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1089,7 +1089,7 @@ MIGraphXExecutionProvider::GetCapability(const GraphViewer& graph_viewer,
   // dump onnx file if environment var is set
   if (dump_model_ops_) {
     std::string model_name = graph_viewer.Name() + ".onnx";
-    std::ofstream ofs(model_name);
+    std::ofstream ofs(model_name, std::ios::binary);
     ofs.write(onnx_string_buffer.c_str(), onnx_string_buffer.size());
     ofs.close();
   }
@@ -1343,7 +1343,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
     if (dump_model_ops_) {
       std::string onnx_name = fused_node.Name() + ".onnx";
-      std::ofstream ofs(onnx_name);
+      std::ofstream ofs(onnx_name, std::ios::binary);
       ofs.write(onnx_string_buffer.data(), onnx_string_buffer.size());
       ofs.close();
     }


### PR DESCRIPTION
Fixing dump model ops feature on Windows. The issue was reproduceable on Windows because of different rules for saving binary format onnx files.

Solving this issue gives us opportunity to generate onnx models after optimizations in ORT and before compile mode in GPU EP.


