### PR TITLE
Let MIGraphX EP check padding constant and handle proper mods of pad operator

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -472,14 +472,6 @@ static bool IsUnsupportedOpMode(const GraphViewer& graph_viewer, const Node* nod
       return true;
     }
 
-    // input value only applied to constant mode
-    if (mode == "constant") {
-      if (args.size() == 3) {
-        if (!canEvalNodeArgument(graph_viewer, node, {2}, input_nodes)) {
-          return true;
-        }
-      }
-    }
   } else if (optype == "Range") {
     auto arg_num = node->InputDefs().size();
     std::vector<std::size_t> vec(arg_num);

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -461,13 +461,13 @@ static bool IsUnsupportedOpMode(const GraphViewer& graph_viewer, const Node* nod
     }
 
     const auto& attributes = node->GetAttributes();
-    // Pad only support reflect and constant mode currently
+    // Pad only support reflect, constant and edge mode currently
     auto mode_attr = attributes.find("mode");
     std::string mode = "constant";
     if (mode_attr != attributes.end()) {
       mode = (*mode_attr).second.s();
     }
-    static const std::set<std::string> allowed_modes = {"constant", "reflect"};
+    static const std::set<std::string> allowed_modes = {"constant", "reflect", "edge"};
     if (allowed_modes.count(mode) == 0) {
       return true;
     }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -461,7 +461,7 @@ static bool IsUnsupportedOpMode(const GraphViewer& graph_viewer, const Node* nod
     }
 
     const auto& attributes = node->GetAttributes();
-    // Pad only support constant mode
+    // Pad only support reflect and constant mode currently
     auto mode_attr = attributes.find("mode");
     std::string mode = "constant";
     if (mode_attr != attributes.end()) {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Related to issue highlighted in https://github.com/ROCm/onnxruntime/pull/183

We don't need to add an extra check as as MIGraphX supports constant value inputs and thus we should be passed to MIGraphX instead of adding extra checks for it in the EP

example of what sin parse_pad in MIGraphX

<img width="731" height="505" alt="image" src="https://github.com/user-attachments/assets/1b3b694e-d1be-40cc-98df-80c6bb0b5b16" />

Furthermore MIGraphX actually supports constant, reflect and edge padding currently, this wasn't reflected in the check here correctly. Adding this in to ensure the operator isn't prematurely exiting. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Remove dead code that's not needed and causes issues with a case where the padding constant is empty. 
This cleans up dead code but also ensures we're compliant with MIGraphX code currently used.


