### PR TITLE
SWDEV-558359 - [Topaz][Gigapixel][Performance] The clc 512x512 models are running with overall lower performance for MIGraphX EP than for DirectML EP

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -705,13 +705,13 @@ std::unique_ptr<IndexedSubGraph> MIGraphXExecutionProvider::GetSubGraph(const st
   for (const auto& index : graph_nodes_index) {
     node_set.insert(index);
     // If the subgraph contains an If node, skip fusion
-    if (graph.GetNode(index)->OpType() == std::string("If")) {
+    if (graph.GetNode(index)->OpType() == "If") {
       is_skip_fuse = true;
     }
   }
 
   // If the parent graph is an If node, skip fusion
-  if ((graph.ParentNode() != nullptr && graph.ParentNode()->OpType() == std::string("If"))) {
+  if ((graph.ParentNode() != nullptr && graph.ParentNode()->OpType() == "If")) {
       is_skip_fuse = true;
   }
 
@@ -724,11 +724,12 @@ std::unique_ptr<IndexedSubGraph> MIGraphXExecutionProvider::GetSubGraph(const st
   // Find inputs and outputs of the subgraph
   std::unique_ptr<IndexedSubGraph> sub_graph = onnxruntime::IndexedSubGraph::Create();
   std::unordered_map<const NodeArg*, int> fused_inputs, fused_outputs, fused_outputs_to_add, graph_outputs_to_add;
-  std::unordered_set<const NodeArg*> erased;
-  int input_order = 0;
-  int output_order = 0;
 
   if (!is_skip_fuse) {
+    std::unordered_set<const NodeArg*> erased;
+    int input_order = 0;
+    int output_order = 0;
+
     for (const auto& index : graph_nodes_index) {
       sub_graph->Nodes().push_back(index);
       const auto& node = graph.GetNode(index);
@@ -769,7 +770,7 @@ std::unique_ptr<IndexedSubGraph> MIGraphXExecutionProvider::GetSubGraph(const st
 
           // Account for implicit inputs for "If" operator destination indexing
           // Addresses an index out of bounds issue but "If" operator still has functional issues.
-          if (it->GetNode().OpType() == std::string("If")) {
+          if (it->GetNode().OpType() == "If") {
             size_t num_of_explicit_inputs = it->GetNode().InputDefs().size();
             if (num_of_explicit_inputs > arg_index) {
               output = input_defs.at(arg_index);

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -539,10 +539,11 @@ static bool IsUnsupportedOpMode(const onnxruntime::GraphViewer& graph_viewer, co
 
     const auto& attributes = node->GetAttributes();
     if (attributes.count("starts") > 0 && attributes.count("ends") > 0) {
-      auto starts = toVector((*attributes.find("starts")).second.ints());
-      auto ends = toVector((*attributes.find("ends")).second.ints());
+      const ONNX_NAMESPACE::int64s& starts = (*attributes.find("starts")).second.ints();
+      const ONNX_NAMESPACE::int64s& ends = (*attributes.find("ends")).second.ints();
+
       for (std::size_t i = 0; i < starts.size(); ++i) {
-        if (starts.at(i) > ends.at(i)) {
+        if (starts[i] > ends[i]) {
           return true;
         }
       }
@@ -1072,6 +1073,7 @@ GetUnsupportedNodeIndices(const GraphViewer& graph_viewer,
               } },
                                                  true);
     } else {
+      std::string unsupported = graph_viewer.GetNode(node_idx)->Name();
       unsupported_nodes_idx.push_back(node_idx);
     }
   }


### PR DESCRIPTION
### Description
Bug Fix: large integers incorrectly converted to -1 in IsUnsupportedOpMode() function
- prevent casting of int64 to int32 in IsUnsupportedOpMode() function for "Slice" operator



### Motivation and Context

Currently clc models in topaz underperform DML by 52x and the root cause is due to the "Slice" node being flagged as unsupported.

This change fixes an issue where start and end attributes for the slice node were being converted to -1 instead of their real int64 value. The -1 end or start value was causing migraphx/onnxruntime to incorrectly flag this node as unsupported.

Local testing on my machine suggests inference time goes from 90 seconds to 3 seconds which is massive boost in performance and closes the gap between DML and Migraphx performance considerably.


