### PR TITLE
[MIGraphX EP] Bugfix for toVector Function causing rollover with int64_t inputs

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -359,11 +359,11 @@ static bool getMIGraphXType(ONNXTensorElementDataType type,
   return true;
 }
 
-std::vector<int> toVector(const ONNX_NAMESPACE::int64s& nums) {
-  std::vector<int> result;
-  int num = nums.size();
-  for (int i = 0; i < num; ++i) {
-    result.push_back(static_cast<int>(nums[i]));
+std::vector<int64_t> toVector(const ONNX_NAMESPACE::int64s& nums) {
+  std::vector<int64_t> result;
+  size_t num = nums.size();
+  for (size_t i = 0; i < num; ++i) {
+    result.push_back(nums[i]);
   }
 
   return result;
@@ -528,6 +528,7 @@ static bool IsUnsupportedOpMode(const GraphViewer& graph_viewer, const Node* nod
     if (attributes.count("starts") > 0 && attributes.count("ends") > 0) {
       auto starts = toVector((*attributes.find("starts")).second.ints());
       auto ends = toVector((*attributes.find("ends")).second.ints());
+
       for (std::size_t i = 0; i < starts.size(); ++i) {
         if (starts.at(i) > ends.at(i)) {
           return true;


### PR DESCRIPTION
[MIGraphX EP] Bugfix for toVector Function causing rollover with int64_t inputs
* Bug Fix: large integers incorrectly converted to -1 in IsUnsupportedOpMode() function
- prevent casting of int64 to int32 in IsUnsupportedOpMode() function for "Slice" operator

* remove testing code

* refactor to use toVector() function