### PR TITLE
Fix dump model ops windows for ROCm 7.1

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1079,9 +1079,13 @@ MIGraphXExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_v
   // dump onnx file if environment var is set
   if (dump_model_ops_) {
     std::string model_name = graph_viewer.Name() + ".onnx";
-    std::ofstream ofs(model_name);
+    std::ofstream ofs(model_name, std::ios::binary);
+    if (!ofs.is_open()) {
+      ORT_THROW("Failed to open file to dump ONNX model: " + model_name);
+    }
     ofs.write(onnx_string_buffer.c_str(), onnx_string_buffer.size());
     ofs.close();
+    LOGS_DEFAULT(INFO) << "ONNX model dumped to " << model_name;
   }
 
   // This is a list of initializers that migraphx considers as constants.
@@ -1333,9 +1337,13 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
     if (dump_model_ops_) {
       std::string onnx_name = fused_node.Name() + ".onnx";
-      std::ofstream ofs(onnx_name);
+      std::ofstream ofs(onnx_name, std::ios::binary);
+      if (!ofs.is_open()) {
+        ORT_THROW("Failed to open file to dump ONNX model: " + onnx_name);
+      }
       ofs.write(onnx_string_buffer.data(), onnx_string_buffer.size());
       ofs.close();
+      LOGS_DEFAULT(INFO) << "ONNX model dumped to " << onnx_name;
     }
 
     std::vector<std::string> input_names, output_names;


### PR DESCRIPTION
Fixing dump model ops feature for MIGraphX EP on Windows. The feature wasn't functional because of saving format rules on Windows which are opposite from Linux.

Current state of the feature gives us opportunity to generate and save onnx model after subgraph optimizations before compiling it. On this way we can look how model graph looks like after optimizations and we can use the optimized model.


