### PR TITLE
Update MIGX EP to poll MIGraphX API for Onnx operators

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -843,6 +843,16 @@ static std::vector<NodeIndex>
 GetUnsupportedNodeIndices(const GraphViewer& graph_viewer,
                           /*out*/ std::unordered_set<std::string>& mgx_required_initializers,
                           const logging::Logger& logger) {
+
+#if HIP_VERSION_MAJOR > 7 || (HIP_VERSION_MAJOR == 7 && HIP_VERSION_MINOR >= 2)
+  // In ROCm 7.2 onward we'll query the MIGraphX API to get the supported op list
+  static std::set<std::string> mgx_supported_ops{}
+  auto list = migraphx::get_onnx_operators();
+  for(const auto& name : list)
+  {
+    mgx_supported_ops.emplace(name);
+  }
+#else
   static std::set<std::string> mgx_supported_ops = {"Abs",
                                                     "Acos",
                                                     "Acosh",
@@ -1003,6 +1013,8 @@ GetUnsupportedNodeIndices(const GraphViewer& graph_viewer,
                                                     "Upsample",
                                                     "Where",
                                                     "Xor"};
+#endif
+
   std::vector<NodeIndex> unsupported_nodes_idx;
   for (const auto& node_idx : graph_viewer.GetNodesInTopologicalOrder()) {
     if (IsNodeSupported(mgx_supported_ops, graph_viewer, node_idx, logger)) {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add support to use MIGraphX API to tell the EP which onnx operators are supported within MIGraphX EP


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Used so we can easily scale what onnx operators are supported based on the version of MIGraphX installed on the system instead of hard coding a filter for them.
