### PR TITLE
Fixing env variable for int8 calibration table

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -210,7 +210,7 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
   }
 
   if (int8_enable_ || fp8_enable_) {
-    int8_calibration_cache_available_ = !info.int8_calibration_table_name.empty();
+    int8_calibration_cache_available_ = !int8_calibration_table_name_.empty();
   }
 
   // Load INT8 calibration table

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -209,12 +209,12 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
         int8_use_native_migraphx_calibration_table_env.empty() ? info.int8_use_native_calibration_table : std::stoi(int8_use_native_migraphx_calibration_table_env) != 0;
   }
 
-  if (int8_enable_ || fp8_enable_) {
-    int8_calibration_cache_available_ = !int8_calibration_table_name_.empty();
-  }
+  int8_calibration_cache_available_ =
+    (int8_enable_ || fp8_enable_) && !int8_calibration_table_name_.empty();
+
 
   // Load INT8 calibration table
-  if ((int8_enable_ || fp8_enable_) && int8_calibration_cache_available_) {
+  if (int8_calibration_cache_available_) {
     std::unordered_map<std::string, float> dynamic_range_map;
     auto calibration_cache_path = GetCachePath(calibration_cache_path_, int8_calibration_table_name_);
     if (!ReadDynamicRange(calibration_cache_path, int8_use_native_calibration_table_, dynamic_range_map)) {


### PR DESCRIPTION
This change is needed when using MIGraphX environment variables inside scripts.
Previously, if we set:
`os.environ["ORT_MIGRAPHX_INT8_CALIBRATION_TABLE_NAME"] = "calibration.flatbuffers"`
the int8_calibration_cache_available_ flag was not set correctly. We only encoded values from provider_options because we used info.int8_calibration_table_name, so the env var was ignored.


