### PR TITLE
Move seting env variable to mgx provider

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
@@ -99,6 +99,12 @@ struct ProviderInfo_MIGraphX_Impl final : ProviderInfo_MIGraphX {
 struct MIGraphX_Provider final : Provider {
   void* GetInfo() override { return &g_info; }
 
+  MIGraphX_Provider() {
+#ifdef _WIN32
+    ::SetEnvironmentVariable("MIGRAPHX_MLIR_USE_SPECIFIC_OPS", "dot,convolution,fused,attention");
+#endif
+  }
+
   virtual ~MIGraphX_Provider() = default;
 
   std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory(int device_id) override {

--- a/onnxruntime/core/session/utils.cc
+++ b/onnxruntime/core/session/utils.cc
@@ -131,13 +131,7 @@ static OrtStatus* CreateSessionAndLoadModelImpl(_In_ const OrtSessionOptions* op
   // quick check here to decide load path. InferenceSession will provide error message for invalid values.
   // TODO: Could move to a helper
   const Env& os_env = Env::Default();  // OS environment (!= ORT environment)
-#ifdef USE_MIGRAPHX
-#ifdef _WIN32
-  ::SetEnvironmentVariable("MIGRAPHX_MLIR_USE_SPECIFIC_OPS", "attention");
-#else
-  setenv("MIGRAPHX_MLIR_USE_SPECIFIC_OPS", "attention", 1);
-#endif
-#endif
+
   bool load_config_from_model =
       os_env.GetEnvironmentVar(inference_session_utils::kOrtLoadConfigFromModelEnvVar) == "1";
 


### PR DESCRIPTION
Changes:

- Setting MIGRAPHX_MLIR_USE_SPECIFIC_OPS env variable (for MIGraphX execution) moved from core onnx code to migraphx provider code
- Set env variable for windows only
- Change value of env variable


