### PR TITLE
Padded/sliced dynamic batch, cache inprovements and parallel model precompiled load Improvements to MIGraphX EP

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -826,6 +826,7 @@ typedef struct OrtMIGraphXProviderOptions {
    *   \note If a ::OrtArenaCfg has been applied, it will override this field
    */
   int migraphx_arena_extend_strategy;
+  size_t migraphx_max_dynamic_batch;                //Max Dynamic batch size. Default 0 = disabled, nonzero = enabled
 
   // This is the legacy struct and don't add new fields here.
 } OrtMIGraphXProviderOptions;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -2901,20 +2901,24 @@ static void execute_standard_path(
   const auto& map_input_name_index = mgx_state->input_name_indexes;
 
   // Check if this is the first run with dynamic batch enabled
-  if (mgx_state->has_dynamic_batch && mgx_state->max_dynamic_batch > 0) {
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] *** FIRST RUN DETECTED ***";
+  // NOTE: max_dynamic_batch > 0 means compilation was deferred to runtime (not precompiled)
+  // If precompilation happened during Compile(), max_dynamic_batch will be > 0 but defer_compilation = false
+  // In that case, the programs are already in cache and we can skip runtime compilation
+  if (mgx_state->has_dynamic_batch && mgx_state->max_dynamic_batch > 0 && mgx_state->defer_compilation) {
+    // Runtime compilation path - used when precompilation was not possible (e.g., non-pure dynamic batch)
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] *** RUNTIME COMPILATION REQUIRED ***";
     LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] max_dynamic_batch=" 
                        << mgx_state->max_dynamic_batch;
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Initiating compilation of all power-of-two batch models";
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Initiating runtime compilation of power-of-two batch models";
     
-    // Compile all power-of-two batch models
+    // Compile all power-of-two batch models at runtime
     compile_dynamic_batch_models(mgx_state, model_cache_path, model_path, mxr_filename_prefix, ctx);
     
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Compilation complete, max_dynamic_batch now = " 
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Runtime compilation complete, max_dynamic_batch now = " 
                        << mgx_state->max_dynamic_batch;
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Proceeding with normal execution using closest power-of-two batch";
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Proceeding with execution using closest power-of-two batch";
   } else if (mgx_state->has_dynamic_batch) {
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Dynamic batch enabled but max_dynamic_batch = 0 (already compiled)";
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Dynamic batch enabled, models already precompiled";
   }
 
   // Extract current batch size from first input
@@ -3231,6 +3235,418 @@ static std::unordered_map<std::string, std::size_t> get_input_name_map(
   return input_name_index;
 }
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// PRECOMPILATION HELPER FUNCTIONS - Move compilation from compute_func to Compile()
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Check if model has only dynamic batch dimension (all other dimensions are static)
+// Returns true if ONLY the batch dimension (dim 0) is symbolic/dynamic for all inputs
+static inline bool has_only_dynamic_batch_dimension(
+    const std::vector<std::string>& input_names,
+    const std::vector<const NodeArg*>& input_tensor,
+    const InitializedTensorSet& initializers)
+{
+  // Build a map from input name to NodeArg* for correct name-based lookup
+  // This is necessary because input_tensor (from main_graph.GetInputs()) may have
+  // different ordering than input_names (from graph_body_viewer)
+  std::unordered_map<std::string, const NodeArg*> name_to_nodearg;
+  for (const auto* nodearg : input_tensor) {
+    if (nodearg != nullptr) {
+      name_to_nodearg[nodearg->Name()] = nodearg;
+    }
+  }
+  
+  for (const auto& name : input_names) {
+    // Skip initializers/constants
+    if (initializers.count(name) > 0) {
+      continue;
+    }
+    
+    // Find the NodeArg by NAME (not position!)
+    auto it = name_to_nodearg.find(name);
+    if (it != name_to_nodearg.end()) {
+      auto tensor_shape = it->second->Shape();
+      if (tensor_shape != nullptr && tensor_shape->dim_size() > 0) {
+        for (int j = 0; j < tensor_shape->dim_size(); ++j) {
+          const auto& dim = tensor_shape->dim(j);
+          bool is_symbolic = !dim.has_dim_value();
+          
+          if (j == 0) {
+            // Batch dimension - should be symbolic for dynamic batch
+            // It's OK if it's static too (we'll just precompile for that shape)
+            continue;
+          } else {
+            // Non-batch dimension - should be static
+            if (is_symbolic) {
+              LOGS_DEFAULT(VERBOSE) << "[has_only_dynamic_batch_dimension] Input '" << name
+                                    << "' has symbolic non-batch dimension " << j << " - NOT a pure dynamic batch model";
+              return false;
+            }
+          }
+        }
+      }
+    }
+  }
+  return true;
+}
+
+// Extract base shapes (non-batch dimensions) from graph definition
+// Returns a tuple of:
+//   - bool: true if extraction was successful (all non-batch dims are concrete), false if symbolic dims found
+//   - vector of input names
+//   - vector of corresponding base shapes (non-batch dimensions)
+// IMPORTANT: Does NOT default symbolic dimensions to any value - returns failure instead
+static inline std::tuple<bool, std::vector<std::string>, std::vector<std::vector<std::int64_t>>>
+extract_base_shapes_from_graph(
+    const std::vector<std::string>& input_names,
+    const std::vector<const NodeArg*>& input_tensor,
+    const InitializedTensorSet& initializers,
+    const std::unordered_map<std::string, std::size_t>& input_name_index)
+{
+  std::vector<std::string> ordered_names;
+  std::vector<std::vector<std::int64_t>> base_shapes;
+  bool all_concrete = true;
+  
+  LOGS_DEFAULT(VERBOSE) << "[extract_base_shapes_from_graph] input_names size: " << input_names.size()
+                        << ", input_tensor size: " << input_tensor.size()
+                        << ", input_name_index size: " << input_name_index.size();
+  
+  // Build a map from input name to NodeArg* for O(1) lookup
+  // This is necessary because input_tensor comes from main_graph.GetInputs() which may have
+  // different ordering than input_names (from graph_body_viewer)
+  std::unordered_map<std::string, const NodeArg*> name_to_nodearg;
+  for (const auto* nodearg : input_tensor) {
+    if (nodearg != nullptr) {
+      name_to_nodearg[nodearg->Name()] = nodearg;
+      LOGS_DEFAULT(VERBOSE) << "[extract_base_shapes_from_graph] Indexed NodeArg: '" << nodearg->Name() << "'";
+    }
+  }
+  
+  // Process inputs in the order they appear in input_name_index (map order for hash consistency)
+  for (const auto& [name, idx] : input_name_index) {
+    // Skip initializers/constants
+    if (initializers.count(name) > 0) {
+      LOGS_DEFAULT(VERBOSE) << "[extract_base_shapes_from_graph] Skipping initializer: '" << name << "'";
+      continue;
+    }
+    
+    ordered_names.push_back(name);
+    
+    // Find the corresponding NodeArg by NAME (not position!)
+    std::vector<std::int64_t> base_shape;
+    auto it = name_to_nodearg.find(name);
+    if (it != name_to_nodearg.end()) {
+      const NodeArg* nodearg = it->second;
+      auto tensor_shape = nodearg->Shape();
+      if (tensor_shape != nullptr && tensor_shape->dim_size() > 1) {
+        LOGS_DEFAULT(VERBOSE) << "[extract_base_shapes_from_graph] Processing input '" << name 
+                              << "' with " << tensor_shape->dim_size() << " dimensions";
+        // Extract non-batch dimensions (skip dim 0)
+        for (int j = 1; j < tensor_shape->dim_size(); ++j) {
+          const auto& dim = tensor_shape->dim(j);
+          if (dim.has_dim_value()) {
+            base_shape.push_back(dim.dim_value());
+            LOGS_DEFAULT(VERBOSE) << "[extract_base_shapes_from_graph]   dim[" << j << "] = " << dim.dim_value();
+          } else {
+            // Symbolic non-batch dimension found - cannot precompile
+            // Do NOT default to any value - mark as failure
+            LOGS_DEFAULT(WARNING) << "[extract_base_shapes_from_graph] Input '" << name
+                                  << "' dim " << j << " is symbolic - cannot extract concrete base shapes";
+            all_concrete = false;
+          }
+        }
+      } else if (tensor_shape != nullptr && tensor_shape->dim_size() == 1) {
+        // Single dimension input (just batch) - no base shape needed
+        LOGS_DEFAULT(VERBOSE) << "[extract_base_shapes_from_graph] Input '" << name 
+                              << "' has only 1 dimension (batch only) - empty base shape";
+      } else {
+        LOGS_DEFAULT(WARNING) << "[extract_base_shapes_from_graph] Input '" << name 
+                              << "' has null or empty shape";
+      }
+    } else {
+      LOGS_DEFAULT(WARNING) << "[extract_base_shapes_from_graph] Input '" << name 
+                            << "' not found in NodeArg map - may be subgraph-only input";
+    }
+    base_shapes.push_back(base_shape);
+    
+    // Log the extracted base shape
+    std::ostringstream ss;
+    ss << "[";
+    for (std::size_t k = 0; k < base_shape.size(); ++k) {
+      if (k > 0) ss << ", ";
+      ss << base_shape[k];
+    }
+    ss << "]";
+    LOGS_DEFAULT(VERBOSE) << "[extract_base_shapes_from_graph] Input '" << name << "' base_shape: " << ss.str();
+  }
+  
+  if (all_concrete) {
+    LOGS_DEFAULT(VERBOSE) << "[extract_base_shapes_from_graph] Successfully extracted " << ordered_names.size() 
+                          << " input base shapes (all concrete)";
+  } else {
+    LOGS_DEFAULT(WARNING) << "[extract_base_shapes_from_graph] Failed - found symbolic non-batch dimensions";
+  }
+  return {all_concrete, ordered_names, base_shapes};
+}
+
+// Compile a single model for a specific batch size and cache it
+// Returns the cache hash for the compiled program
+static inline std::string precompile_model_for_batch(
+    std::size_t batch_size,
+    const std::vector<std::string>& input_names,
+    const std::vector<std::vector<std::int64_t>>& all_input_base_shapes,
+    const std::string& onnx_string,
+    migraphx::onnx_options& options,
+    const migraphx::target& t,
+    bool fp16_enable,
+    bool bf16_enable,
+    bool int8_enable,
+    bool fp8_enable,
+    bool int8_calibration_cache_available,
+    std::unordered_map<std::string, float>& dynamic_range_map,
+    bool exhaustive_tune,
+    const std::filesystem::path& model_path,
+    const std::filesystem::path& model_cache_path,
+    const std::string& mxr_filename_prefix,
+    std::unordered_map<std::string, migraphx::program>& cached_programs)
+{
+  // Build cache key for this batch size
+  std::vector<std::int64_t> batch_shape_key;
+  for (std::size_t i = 0; i < input_names.size(); ++i) {
+    batch_shape_key.push_back(static_cast<std::int64_t>(batch_size));
+    batch_shape_key.insert(batch_shape_key.end(), 
+                          all_input_base_shapes[i].begin(), 
+                          all_input_base_shapes[i].end());
+  }
+  auto cache_hash = make_hash(batch_shape_key);
+  
+  LOGS_DEFAULT(VERBOSE) << "[precompile_model_for_batch] Batch " << batch_size << " -> hash: " << cache_hash;
+  
+  // Check if already cached in memory
+  if (cached_programs.find(cache_hash) != cached_programs.end()) {
+    LOGS_DEFAULT(VERBOSE) << "[precompile_model_for_batch] ✓ Batch " << batch_size << " already cached";
+    return cache_hash;
+  }
+  
+  // Build disk cache file path
+  std::filesystem::path batch_cache_file;
+  if (!model_cache_path.empty()) {
+    batch_cache_file = model_cache_path / (mxr_filename_prefix + cache_hash + ".mxr");
+  }
+  
+  LOGS_DEFAULT(VERBOSE) << "[precompile_model_for_batch] Compiling/loading batch " << batch_size << "...";
+  
+  // Load or compile the model
+  migraphx::program batch_prog = load_or_compile_model(
+      batch_cache_file,
+      onnx_string,
+      options,
+      t,
+      fp16_enable,
+      bf16_enable,
+      int8_enable,
+      fp8_enable,
+      int8_calibration_cache_available,
+      dynamic_range_map,
+      exhaustive_tune,
+      model_path,
+      nullptr,  // ctx not needed for precompilation
+      nullptr,  // map_input_name_index not needed
+      input_names,
+      all_input_base_shapes,
+      batch_size);
+  
+  // Store in memory cache
+  cached_programs[cache_hash] = std::move(batch_prog);
+  LOGS_DEFAULT(VERBOSE) << "[precompile_model_for_batch] ✓ Stored batch " << batch_size << " in cache";
+  
+  return cache_hash;
+}
+
+// Precompile all power-of-two batch models during Compile() phase
+// This moves compilation from compute_func() to initialization time
+static inline void precompile_all_dynamic_batch_models(
+    const std::vector<std::size_t>& power_of_two_batch_sizes,
+    const std::vector<std::string>& input_names,
+    const std::vector<std::vector<std::int64_t>>& all_input_base_shapes,
+    const std::string& onnx_string,
+    migraphx::onnx_options& options,
+    const migraphx::target& t,
+    bool fp16_enable,
+    bool bf16_enable,
+    bool int8_enable,
+    bool fp8_enable,
+    bool int8_calibration_cache_available,
+    std::unordered_map<std::string, float>& dynamic_range_map,
+    bool exhaustive_tune,
+    const std::filesystem::path& model_path,
+    const std::filesystem::path& model_cache_path,
+    const std::string& mxr_filename_prefix,
+    std::unordered_map<std::string, migraphx::program>& cached_programs)
+{
+  LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] Precompiling " 
+                     << power_of_two_batch_sizes.size() << " power-of-two batch models...";
+  
+  for (const auto& batch_size : power_of_two_batch_sizes) {
+    precompile_model_for_batch(
+        batch_size,
+        input_names,
+        all_input_base_shapes,
+        onnx_string,
+        options,
+        t,
+        fp16_enable,
+        bf16_enable,
+        int8_enable,
+        fp8_enable,
+        int8_calibration_cache_available,
+        dynamic_range_map,
+        exhaustive_tune,
+        model_path,
+        model_cache_path,
+        mxr_filename_prefix,
+        cached_programs);
+  }
+  
+  LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] ✓ Precompiled " 
+                     << cached_programs.size() << " models";
+}
+
+// Precompile static model (no dynamic batching) during Compile() phase
+// IMPORTANT: This function should ONLY be called when all dimensions are concrete.
+// The caller must verify this before calling - symbolic dimensions are NOT allowed.
+static inline void precompile_static_model(
+    const std::vector<std::string>& input_names,
+    const std::vector<const NodeArg*>& input_tensor,
+    const InitializedTensorSet& initializers,
+    const std::unordered_map<std::string, std::size_t>& input_name_index,
+    const std::string& onnx_string,
+    migraphx::onnx_options& options,
+    const migraphx::target& t,
+    bool fp16_enable,
+    bool bf16_enable,
+    bool int8_enable,
+    bool fp8_enable,
+    bool int8_calibration_cache_available,
+    std::unordered_map<std::string, float>& dynamic_range_map,
+    bool exhaustive_tune,
+    const std::filesystem::path& model_path,
+    const std::filesystem::path& model_cache_path,
+    const std::string& mxr_filename_prefix,
+    std::unordered_map<std::string, migraphx::program>& cached_programs)
+{
+  LOGS_DEFAULT(INFO) << "[precompile_static_model] Precompiling static model...";
+  
+  // Build a map from input name to NodeArg* for correct name-based lookup
+  // This is necessary because input_tensor (from main_graph.GetInputs()) may have
+  // different ordering than input_names (from graph_body_viewer)
+  std::unordered_map<std::string, const NodeArg*> name_to_nodearg;
+  for (const auto* nodearg : input_tensor) {
+    if (nodearg != nullptr) {
+      name_to_nodearg[nodearg->Name()] = nodearg;
+    }
+  }
+  
+  // Build full shapes (including batch dimension) from graph definition
+  // All dimensions must be concrete - no defaulting of symbolic dims
+  std::vector<std::int64_t> shape_key;
+  std::vector<std::string> ordered_names;
+  std::vector<std::vector<std::int64_t>> full_shapes;
+  
+  for (const auto& [name, idx] : input_name_index) {
+    // Skip initializers/constants
+    if (initializers.count(name) > 0) {
+      continue;
+    }
+    
+    ordered_names.push_back(name);
+    
+    // Find the corresponding NodeArg by NAME (not position!)
+    std::vector<std::int64_t> shape;
+    auto it = name_to_nodearg.find(name);
+    if (it != name_to_nodearg.end()) {
+      auto tensor_shape = it->second->Shape();
+      if (tensor_shape != nullptr && tensor_shape->dim_size() > 0) {
+        for (int j = 0; j < tensor_shape->dim_size(); ++j) {
+          const auto& dim = tensor_shape->dim(j);
+          if (dim.has_dim_value()) {
+            shape.push_back(dim.dim_value());
+            shape_key.push_back(dim.dim_value());
+          } else {
+            // Symbolic dimension found - this should NOT happen!
+            // The caller should have verified all dims are concrete before calling.
+            LOGS_DEFAULT(ERROR) << "[precompile_static_model] Unexpected symbolic dimension in input '"
+                                << name << "' dim " << j << " - aborting precompilation";
+            return;  // Abort precompilation
+          }
+        }
+      }
+    } else {
+      LOGS_DEFAULT(WARNING) << "[precompile_static_model] Input '" << name 
+                            << "' not found in NodeArg map - skipping";
+    }
+    full_shapes.push_back(shape);
+  }
+  
+  if (shape_key.empty()) {
+    LOGS_DEFAULT(VERBOSE) << "[precompile_static_model] No model inputs to compile";
+    return;
+  }
+  
+  auto cache_hash = make_hash(shape_key);
+  
+  // Check if already cached
+  if (cached_programs.find(cache_hash) != cached_programs.end()) {
+    LOGS_DEFAULT(VERBOSE) << "[precompile_static_model] ✓ Model already cached with hash: " << cache_hash;
+    return;
+  }
+  
+  // Build disk cache file path
+  std::filesystem::path cache_file;
+  if (!model_cache_path.empty()) {
+    cache_file = model_cache_path / (mxr_filename_prefix + cache_hash + ".mxr");
+  }
+  
+  LOGS_DEFAULT(INFO) << "[precompile_static_model] Loading/compiling model (hash: " << cache_hash << ")...";
+  
+  // Extract base shapes (without batch) for compilation
+  std::vector<std::vector<std::int64_t>> base_shapes;
+  std::int64_t batch_size = 1;
+  for (const auto& shape : full_shapes) {
+    if (!shape.empty()) {
+      batch_size = shape[0];
+      std::vector<std::int64_t> base(shape.begin() + 1, shape.end());
+      base_shapes.push_back(base);
+    } else {
+      base_shapes.push_back({});
+    }
+  }
+  
+  // Load or compile
+  migraphx::program prog = load_or_compile_model(
+      cache_file,
+      onnx_string,
+      options,
+      t,
+      fp16_enable,
+      bf16_enable,
+      int8_enable,
+      fp8_enable,
+      int8_calibration_cache_available,
+      dynamic_range_map,
+      exhaustive_tune,
+      model_path,
+      nullptr,
+      nullptr,
+      ordered_names,
+      base_shapes,
+      static_cast<std::size_t>(batch_size));
+  
+  // Store in cache
+  cached_programs[cache_hash] = std::move(prog);
+  LOGS_DEFAULT(INFO) << "[precompile_static_model] ✓ Static model precompiled and cached";
+}
+
 constexpr std::uint64_t MIGraphX_Version =
     ((MIGRAPHX_VERSION_MAJOR << 16) | (MIGRAPHX_VERSION_MINOR << 8) | MIGRAPHX_VERSION_PATCH);
 
@@ -3278,25 +3694,228 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     const auto& initializers = graph_body_viewer.GetAllInitializedTensors();
     migraphx::onnx_options options = get_program_parameter_options(input_names, input_tensor, initializers);
 
-    // always defer compilation to compute for first inference
-    // This is done as if the modic has static input shapes but batch changes we'll need to do an update anyway
-    // In the case of dynamic shapes, like with dynamic batch or sequence length we wont know input shapes until runtime
-    map_defer_compilation_[fused_node.Name()] = true;
+    // Initialize the cached_programs map for this node if not already done
+    if (cached_programs_.find(fused_node.Name()) == cached_programs_.end()) {
+      cached_programs_[fused_node.Name()] = std::unordered_map<std::string, migraphx::program>();
+    }
+    
+    // ═══════════════════════════════════════════════════════════════════════════
+    // PRECOMPILATION: Compile models during Compile() phase instead of compute_func()
+    // ═══════════════════════════════════════════════════════════════════════════
+    // 
+    // Precompilation rules:
+    // 1. max_dynamic_batch > 0 AND all non-batch dims are concrete:
+    //    -> Precompile all power-of-two batch models (symbolic batch dim is OK)
+    // 2. max_dynamic_batch > 0 AND some non-batch dims are symbolic:
+    //    -> Defer to runtime (cannot precompile without concrete non-batch shapes)
+    // 3. max_dynamic_batch == 0 AND all dims are concrete:
+    //    -> Precompile static model with concrete shapes
+    // 4. max_dynamic_batch == 0 AND some dims are symbolic:
+    //    -> Defer to runtime (cannot precompile with symbolic dimensions)
+    //
+    // IMPORTANT: We do NOT default symbolic dimensions to any value.
+    // Precompilation only happens when we have concrete shapes from the graph.
+    // ═══════════════════════════════════════════════════════════════════════════
+    
+    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ════════════════════════════════════════════════════";
+    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Starting precompilation decision for node '" << fused_node.Name() << "'";
+    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] max_dynamic_batch_ = " << max_dynamic_batch_;
+    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Number of inputs: " << input_names.size();
+    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Number of input tensors: " << input_tensor.size();
+    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Number of initializers: " << initializers.size();
+    
+    // Log all input shapes from graph definition
+    for (std::size_t i = 0; i < input_names.size(); ++i) {
+      if (initializers.count(input_names[i]) > 0) {
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Input[" << i << "] '" << input_names[i] << "' -> INITIALIZER (skipped)";
+        continue;
+      }
+      if (i < input_tensor.size()) {
+        auto tensor_shape = input_tensor[i]->Shape();
+        if (tensor_shape != nullptr) {
+          std::ostringstream ss;
+          ss << "[";
+          for (int j = 0; j < tensor_shape->dim_size(); ++j) {
+            if (j > 0) ss << ", ";
+            const auto& dim = tensor_shape->dim(j);
+            if (dim.has_dim_value()) {
+              ss << dim.dim_value();
+            } else if (dim.has_dim_param()) {
+              ss << "'" << dim.dim_param() << "'";
+            } else {
+              ss << "?";
+            }
+          }
+          ss << "]";
+          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Input[" << i << "] '" << input_names[i] << "' shape: " << ss.str();
+        } else {
+          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Input[" << i << "] '" << input_names[i] << "' shape: NULL";
+        }
+      }
+    }
+    
+    // Check if model has only dynamic batch dimension (other dims are static)
+    bool only_dynamic_batch = has_only_dynamic_batch_dimension(input_names, input_tensor, initializers);
+    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] only_dynamic_batch = " << (only_dynamic_batch ? "true" : "false");
+    
+    if (max_dynamic_batch_ > 0) {
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Mode: DYNAMIC BATCH (max_dynamic_batch=" << max_dynamic_batch_ << ")";
+      
+      // Dynamic batch mode - try to precompile if all non-batch dimensions are concrete
+      if (only_dynamic_batch) {
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Model has only dynamic batch dimension - attempting to extract base shapes";
+        
+        // Extract base shapes - this will FAIL if any non-batch dim is symbolic
+        auto [shapes_valid, ordered_names, base_shapes] = extract_base_shapes_from_graph(
+            input_names, input_tensor, initializers, input_name_index);
+        
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] extract_base_shapes_from_graph result: shapes_valid=" 
+                              << (shapes_valid ? "true" : "false");
+        
+        if (shapes_valid) {
+          // Log extracted base shapes
+          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Successfully extracted " << ordered_names.size() << " base shapes:";
+          for (std::size_t i = 0; i < ordered_names.size(); ++i) {
+            std::ostringstream ss;
+            ss << "[";
+            for (std::size_t j = 0; j < base_shapes[i].size(); ++j) {
+              if (j > 0) ss << ", ";
+              ss << base_shapes[i][j];
+            }
+            ss << "]";
+            LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE]   '" << ordered_names[i] << "' base_shape: " << ss.str();
+          }
+          
+          // All non-batch dimensions are concrete - precompile all power-of-two batch models
+          auto power_of_two_batch_sizes = generate_power_of_two_batch_sizes(max_dynamic_batch_);
+          
+          std::ostringstream batch_ss;
+          batch_ss << "[";
+          for (std::size_t i = 0; i < power_of_two_batch_sizes.size(); ++i) {
+            if (i > 0) batch_ss << ", ";
+            batch_ss << power_of_two_batch_sizes[i];
+          }
+          batch_ss << "]";
+          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Power-of-two batch sizes to compile: " << batch_ss.str();
+          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] >>> STARTING DYNAMIC BATCH PRECOMPILATION <<<";
+          
+          precompile_all_dynamic_batch_models(
+              power_of_two_batch_sizes,
+              ordered_names,
+              base_shapes,
+              onnx_string_buffer,
+              options,
+              t_,
+              fp16_enable_,
+              bf16_enable_,
+              int8_enable_,
+              fp8_enable_,
+              int8_calibration_cache_available_,
+              dynamic_range_map_,
+              exhaustive_tune_,
+              model_path_,
+              model_cache_path_,
+              mxr_filename_prefix,
+              cached_programs_[fused_node.Name()]);
+          
+          // Precompilation complete - disable deferred compilation
+          map_defer_compilation_[fused_node.Name()] = false;
+          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✓✓✓ Dynamic batch precompilation COMPLETE for node '" 
+                                << fused_node.Name() << "'";
+          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to FALSE";
+          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] cached_programs size: " << cached_programs_[fused_node.Name()].size();
+        } else {
+          // Non-batch dimensions contain symbolic values - cannot precompile
+          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✗ CANNOT PRECOMPILE: Non-batch dimensions contain symbolic values";
+          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Deferring compilation to runtime for node '" << fused_node.Name() << "'";
+          map_defer_compilation_[fused_node.Name()] = true;
+          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to TRUE";
+        }
+      } else {
+        // Model has multiple dynamic dimensions (not just batch) - defer to runtime
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✗ CANNOT PRECOMPILE: Model has non-batch dynamic dimensions";
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Deferring compilation to runtime for node '" << fused_node.Name() << "'";
+        map_defer_compilation_[fused_node.Name()] = true;
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to TRUE";
+      }
+    } else {
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Mode: STATIC (max_dynamic_batch=0)";
+      
+      // Static model (max_dynamic_batch == 0) - only precompile if ALL dimensions are concrete
+      // Check if any dimension is symbolic
+      bool has_symbolic_dims = false;
+      std::string symbolic_info;
+      for (std::size_t i = 0; i < input_names.size(); ++i) {
+        if (initializers.count(input_names[i]) > 0) continue;  // Skip initializers
+        if (i < input_tensor.size()) {
+          auto tensor_shape = input_tensor[i]->Shape();
+          if (tensor_shape != nullptr) {
+            for (int j = 0; j < tensor_shape->dim_size(); ++j) {
+              if (!tensor_shape->dim(j).has_dim_value()) {
+                has_symbolic_dims = true;
+                symbolic_info = "Input '" + input_names[i] + "' dim " + std::to_string(j);
+                LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Found symbolic dimension: " << symbolic_info;
+                break;
+              }
+            }
+          }
+        }
+        if (has_symbolic_dims) break;
+      }
+      
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] has_symbolic_dims = " << (has_symbolic_dims ? "true" : "false");
+      
+      if (!has_symbolic_dims) {
+        // All dimensions are concrete - precompile static model
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] All dimensions are concrete - precompiling static model";
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] >>> STARTING STATIC MODEL PRECOMPILATION <<<";
+        
+        precompile_static_model(
+            input_names,
+            input_tensor,
+            initializers,
+            input_name_index,
+            onnx_string_buffer,
+            options,
+            t_,
+            fp16_enable_,
+            bf16_enable_,
+            int8_enable_,
+            fp8_enable_,
+            int8_calibration_cache_available_,
+            dynamic_range_map_,
+            exhaustive_tune_,
+            model_path_,
+            model_cache_path_,
+            mxr_filename_prefix,
+            cached_programs_[fused_node.Name()]);
+        
+        // Precompilation complete - disable deferred compilation
+        map_defer_compilation_[fused_node.Name()] = false;
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✓✓✓ Static model precompilation COMPLETE for node '" 
+                              << fused_node.Name() << "'";
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to FALSE";
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] cached_programs size: " << cached_programs_[fused_node.Name()].size();
+      } else {
+        // Has symbolic dimensions and max_dynamic_batch == 0 - defer to runtime
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✗ CANNOT PRECOMPILE: Has symbolic dimensions but max_dynamic_batch=0";
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Symbolic dimension found: " << symbolic_info;
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Deferring compilation to runtime for node '" << fused_node.Name() << "'";
+        map_defer_compilation_[fused_node.Name()] = true;
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to TRUE";
+      }
+    }
+    
+    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ════════════════════════════════════════════════════";
 
-    // by parsing the model_proto, create a program corresponding to
-    // the input fused_node
+    // Create program object (may be empty if precompiled programs are in cache)
     migraphx::program prog;
-
-    // compile the program
     map_progs_[fused_node.Name()] = prog;
 
     map_onnx_string_[fused_node.Name()] = onnx_string_buffer;
     map_input_index_[fused_node.Name()] = input_name_index;
 
-    // Initialize the cached_programs map for this node if not already done
-    if (cached_programs_.find(fused_node.Name()) == cached_programs_.end()) {
-      cached_programs_[fused_node.Name()] = std::unordered_map<std::string, migraphx::program>();
-    }
+    // NOTE: cached_programs_ was initialized earlier before precompilation
 
     NodeComputeInfo compute_info;
     compute_info.create_state_func = [=](ComputeContext* context, FunctionState* state) {
@@ -3312,9 +3931,13 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       if (max_dynamic_batch_ > 0) {
         p->has_dynamic_batch = true;
         p->power_of_two_batch_sizes = generate_power_of_two_batch_sizes(max_dynamic_batch_);
-        LOGS_DEFAULT(INFO) << "[Compile] Dynamic batch enabled for node '" << context->node_name 
-                           << "' with max_dynamic_batch=" << max_dynamic_batch_
-                           << ", generated " << p->power_of_two_batch_sizes.size() << " power-of-two batch sizes";
+        LOGS_DEFAULT(VERBOSE) << "[Compile][CREATE_STATE] Dynamic batch enabled for node '" << context->node_name 
+                              << "' with max_dynamic_batch=" << max_dynamic_batch_
+                              << ", generated " << p->power_of_two_batch_sizes.size() << " power-of-two batch sizes";
+        LOGS_DEFAULT(VERBOSE) << "[Compile][CREATE_STATE] defer_compilation=" << p->defer_compilation;
+      } else {
+        LOGS_DEFAULT(VERBOSE) << "[Compile][CREATE_STATE] Static model mode for node '" << context->node_name << "'";
+        LOGS_DEFAULT(VERBOSE) << "[Compile][CREATE_STATE] defer_compilation=" << p->defer_compilation;
       }
       
       *state = p.release();

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1157,40 +1157,6 @@ MIGraphXExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_v
   return result;
 }
 
-// Check if any inputs have dynamic/symbolic dimensions that require deferred compilation
-static bool inputs_have_dynamic_dims(const GraphViewer& graph) {
-  const auto& input_args = graph.GetInputs();
-
-  for (const auto& arg : input_args) {
-    if (arg == nullptr) {
-      return true;
-    }
-
-    auto sptr = arg->Shape();
-    if (sptr == nullptr || sptr->dim_size() == 0) {
-      LOGS_DEFAULT(VERBOSE) << "[inputs_have_dynamic_dims] Input '" << arg->Name()
-                            << "' has no shape info, treating as dynamic";
-      return true;
-    }
-
-    for (int i = 0; i < sptr->dim_size(); i++) {
-      if (sptr->dim(i).has_dim_param()) {
-        std::string dim_param = sptr->dim(i).dim_param();
-        if (i == 0) {
-          LOGS_DEFAULT(VERBOSE) << "[inputs_have_dynamic_dims] Input '" << arg->Name()
-                                << "' has dynamic batch dimension: " << dim_param;
-        } else {
-          LOGS_DEFAULT(VERBOSE) << "[inputs_have_dynamic_dims] Input '" << arg->Name()
-                                << "' dimension " << i << " is symbolic: " << dim_param;
-        }
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
-
 // Get input and output names from the graph
 static std::pair<std::vector<std::string>, std::vector<std::string>> get_io_names(const GraphViewer& graph) {
   const auto& input_args = graph.GetInputs();
@@ -1212,95 +1178,6 @@ static std::pair<std::vector<std::string>, std::vector<std::string>> get_io_name
   }
 
   return {std::move(input_names), std::move(output_names)};
-}
-
-// Check input tensors for symbolic dimensions and build shape vector for cache key generation
-// Returns input shapes suitable for hash calculation and whether symbolic dims were found
-static std::vector<std::int64_t> check_for_symbolic_dims(
-    const std::vector<const NodeArg*>& input_tensor,
-    const std::set<std::string>& session_input_names,
-    int64_t default_batch_size = 1)
-{
-  std::vector<std::int64_t> input_shapes;
-  bool has_symbolic_dims = false;
-  // Track if ALL inputs have symbolic batch dimension (starts true, set false if any concrete batch found)
-  bool all_batch_dims_symbolic = !session_input_names.empty();
-
-  for (std::size_t i = 0; i < session_input_names.size(); ++i) {
-    auto tensor_shape = input_tensor[i]->Shape();
-
-    // Check for symbolic dimensions and handle them
-    if (tensor_shape == nullptr || tensor_shape->dim_size() == 0) {
-      LOGS_DEFAULT(WARNING) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                            << ") has no shape information";
-      has_symbolic_dims = true;
-      // No shape info implies batch is also unknown - keeps all_batch_dims_symbolic as true for this input
-      continue;
-    }
-
-    // Handle batch dimension (first dimension) specially
-    if (tensor_shape->dim_size() > 0) {
-      const auto& batch_dim = tensor_shape->dim(0);
-      int64_t batch_size_to_use = default_batch_size;
-
-      if (batch_dim.has_dim_value()) {
-        batch_size_to_use = batch_dim.dim_value();
-        // Found a concrete batch dimension - not all batch dims are symbolic
-        all_batch_dims_symbolic = false;
-        LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                              << ") batch size: " << batch_size_to_use;
-      } else if (batch_dim.has_dim_param()) {
-        // Symbolic batch dimension - default to 1
-        has_symbolic_dims = true;
-        LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                              << ") batch size is symbolic: " << batch_dim.dim_param()
-                              << ", defaulting to " << default_batch_size;
-      } else {
-        // Unknown batch dimension - default to 1
-        has_symbolic_dims = true;
-        LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                              << ") batch size is unknown, defaulting to " << default_batch_size;
-      }
-
-      // Add batch size to input shapes for hash calculation
-      input_shapes.push_back(batch_size_to_use);
-    }
-
-    // Process all dimensions (skip batch dimension at j=0, start at j=1)
-    for (int j = 1; j < tensor_shape->dim_size(); ++j) {
-      const auto& dim = tensor_shape->dim(j);
-
-      // Handle symbolic dimensions
-      if (dim.has_dim_param()) {
-        LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                              << ") dimension " << j << " is symbolic: " << dim.dim_param();
-        has_symbolic_dims = true;
-        // Use -1 as placeholder for symbolic dimensions in hash calculation
-        input_shapes.push_back(-1);
-      } else if (dim.has_dim_value()) {
-        auto dim_val = dim.dim_value();
-        input_shapes.push_back(dim_val);
-        LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                              << ") dimension " << j << " value: " << dim_val;
-      } else {
-        LOGS_DEFAULT(WARNING) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                              << ") dimension " << j << " has no value or param";
-        has_symbolic_dims = true;
-      }
-    }
-  }
-
-  if (has_symbolic_dims) {
-    LOGS_DEFAULT(WARNING) << "[Compile] Model has symbolic dimensions, "
-                          << "dynamic batch dimensions defaulted to " << default_batch_size
-                          << " (will be overridden at runtime if needed)";
-  }
-
-  if (all_batch_dims_symbolic) {
-    LOGS_DEFAULT(VERBOSE) << "[Compile] All inputs have symbolic batch dimension";
-  }
-
-  return {std::move(input_shapes)};
 }
 
 // Attempt to load a model and catch any exceptions on load fail.
@@ -1751,59 +1628,6 @@ static int compute_output_index(const std::string_view sv) {
   }
   const auto index_str = sv.substr(pos + out_name_prefix.length());
   return ToInteger(Trim(index_str, std::isdigit));
-}
-
-// Helper: Handle program inputs and outputs binding
-// This function binds input tensors and allocates output tensors for the MIGraphX program
-static
-std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program_input_outputs(
-    const migraphx::program_parameter_shapes& param_shapes,
-    const std::unordered_map<std::string, std::size_t>& map_input_name_index,
-    const Ort::KernelContext& ctx,
-    const migraphx::program& prog)
-{
-  migraphx::program_parameters m;
-  std::vector<std::size_t> prog_output_indices;
-  auto prog_output_shapes = prog.get_output_shapes();
-
-  if (param_shapes.size() > 0) {
-    for (const auto& name : param_shapes.names()) {
-      auto it = map_input_name_index.find(name);
-      if (it != map_input_name_index.end()) {
-        LOGS_DEFAULT(VERBOSE) << "Setting parameters for:" << name;
-        const auto& input_tensor = ctx.GetInput(it->second);
-        const auto& tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-        const auto& tensor_type = tensor_info.GetElementType();
-
-        migraphx_shape_datatype_t mgx_current_type;
-        getMIGraphXType(tensor_type, mgx_current_type);
-        const auto& mgx_s = param_shapes[name];
-
-        if (mgx_current_type != mgx_s.type()) {
-          LOGS_DEFAULT(FATAL) << "MIGraphX: param type mismatch for" << name;
-        }
-
-        LOGS_DEFAULT(VERBOSE) << "Writing Raw tensor data ";
-        m.add(name, migraphx::argument(mgx_s,
-                                       const_cast<void*>(input_tensor.GetTensorRawData())));
-      }
-      // It is an output argument
-      else {
-        const auto output_index = compute_output_index(name);
-        if (output_index != -1) {
-          prog_output_indices.push_back(static_cast<std::size_t>(output_index));
-          const auto& mgx_output_shape = prog_output_shapes[output_index];
-          const auto& lens = mgx_output_shape.lengths();
-          const std::vector<int64_t> ort_output_shape(lens.begin(), lens.end());
-          auto output_tensor = ctx.GetOutput(output_index, ort_output_shape.data(), ort_output_shape.size());
-          const void* output_data = output_tensor.GetTensorMutableRawData();
-          const auto& mgx_arg_shape = param_shapes[name];
-          m.add(name, migraphx::argument(mgx_arg_shape, const_cast<void*>(output_data)));
-        }
-      }
-    }
-  }
-  return {m, prog_output_indices};
 }
 
 // Overload: Handle program inputs and outputs binding with pre-cached output shapes

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1185,7 +1185,9 @@ static std::pair<std::vector<std::string>, std::vector<std::string>> get_io_name
 bool load_precompiled_model(migraphx::program& prog, const std::filesystem::path& path) try {
   if (!path.empty() && exists(path)) {
     LOGS_DEFAULT(VERBOSE) << "[load_precompiled_model] Attempting to load model from disk: " << path.string();
-    prog = migraphx::load(path.string().c_str());
+    migraphx::file_options fo;
+    fo.set_file_format("msgpack");
+    prog = migraphx::load(path.string().c_str(), fo);
     LOGS_DEFAULT(VERBOSE) << "[load_precompiled_model] ✓ Successfully loaded model from disk";
     return true;
   }
@@ -1195,7 +1197,7 @@ bool load_precompiled_model(migraphx::program& prog, const std::filesystem::path
 } catch (const std::exception& e) {
   LOGS_DEFAULT(VERBOSE) << "[load_precompiled_model] ✗ Failed to load model from disk: " << e.what();
   return false;
-} catch (...) {
+  } catch (...) {
   LOGS_DEFAULT(VERBOSE) << "[load_precompiled_model] ✗ Failed to load model from disk (unknown exception)";
   return false;
 }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1735,8 +1735,29 @@ static void handle_input_shape_mismatch(
     mgx_state->cached_programs_ref.value().get()[cache_hash] = prog;
   }
 
+  // Invalidate ultra-fast path caches (will be repopulated on next run)
+  mgx_state->caches_valid = false;
+  mgx_state->cached_param_shapes = std::nullopt;
+  mgx_state->cached_output_shapes = std::nullopt;
+  mgx_state->cached_prog_params = std::nullopt;
+  mgx_state->cached_param_names.clear();
+  mgx_state->cached_prog_output_indices.clear();
+  mgx_state->last_input_shape_hash.clear();
+
   param_shapes = prog.get_parameter_shapes();
   mgx_state->defer_compilation = false;
+}
+
+// Helper: Extract output index from MIGraphX output parameter name
+// MIGraphX names outputs as "#output_0", "#output_1", etc.
+static int compute_output_index(const std::string_view sv) {
+  constexpr std::string_view out_name_prefix = "#output_";
+  const auto pos = sv.find(out_name_prefix);
+  if (pos == std::string_view::npos) {
+    return -1;
+  }
+  const auto index_str = sv.substr(pos + out_name_prefix.length());
+  return ToInteger(Trim(index_str, std::isdigit));
 }
 
 // Helper: Handle program inputs and outputs binding
@@ -1751,17 +1772,6 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
   migraphx::program_parameters m;
   std::vector<std::size_t> prog_output_indices;
   auto prog_output_shapes = prog.get_output_shapes();
-
-  auto compute_output_index = [](const std::string_view sv) -> int {
-    constexpr std::string_view out_name_prefix = "#output_";
-    const auto pos = sv.find(out_name_prefix);
-    if (pos == std::string_view::npos) {
-      return -1;
-    }
-
-    const auto index_str = sv.substr(pos + out_name_prefix.length());
-    return ToInteger(Trim(index_str, std::isdigit));
-  };
 
   if (param_shapes.size() > 0) {
     for (const auto& name : param_shapes.names()) {
@@ -1796,6 +1806,45 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
           const void* output_data = output_tensor.GetTensorMutableRawData();
           const auto& mgx_arg_shape = param_shapes[name];
           m.add(name, migraphx::argument(mgx_arg_shape, const_cast<void*>(output_data)));
+        }
+      }
+    }
+  }
+  return {m, prog_output_indices};
+}
+
+// Overload: Handle program inputs and outputs binding with pre-cached output shapes
+// This avoids calling prog.get_output_shapes() when shapes are already cached
+static
+std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program_input_outputs(
+    const migraphx::program_parameter_shapes& param_shapes,
+    const migraphx::shapes& output_shapes,
+    const std::unordered_map<std::string, std::size_t>& map_input_name_index,
+    const Ort::KernelContext& ctx)
+{
+  migraphx::program_parameters m;
+  std::vector<std::size_t> prog_output_indices;
+  prog_output_indices.reserve(output_shapes.size());
+
+  if (param_shapes.size() > 0) {
+    for (const auto& name : param_shapes.names()) {
+      auto it = map_input_name_index.find(name);
+      if (it != map_input_name_index.end()) {
+        // Input parameter
+        const auto& input_tensor = ctx.GetInput(it->second);
+        const auto& mgx_s = param_shapes[name];
+        m.add(name, migraphx::argument(mgx_s,
+                                       const_cast<void*>(input_tensor.GetTensorRawData())));
+      } else {
+        // Output parameter
+        const auto output_index = compute_output_index(name);
+        if (output_index != -1) {
+          prog_output_indices.push_back(static_cast<std::size_t>(output_index));
+          const auto& lens = output_shapes[output_index].lengths();
+          const std::vector<int64_t> ort_output_shape(lens.begin(), lens.end());
+          auto output_tensor = ctx.GetOutput(output_index, ort_output_shape.data(), ort_output_shape.size());
+          const auto& mgx_arg_shape = param_shapes[name];
+          m.add(name, migraphx::argument(mgx_arg_shape, output_tensor.GetTensorMutableRawData()));
         }
       }
     }
@@ -2045,47 +2094,103 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       Ort::KernelContext ctx(context);
       MIGraphXFuncState* mgx_state = reinterpret_cast<MIGraphXFuncState*>(state);
 
-      std::unordered_map<std::string, std::size_t>& map_input_name_index = mgx_state->input_name_indexes;
-      migraphx::program& prog = mgx_state->prog;
-      migraphx::onnx_options& cmp_options = mgx_state->options;
+      auto& map_input_name_index = mgx_state->input_name_indexes;
+      auto& prog = mgx_state->prog;
+      auto& cmp_options = mgx_state->options;
 
-      // Fast path: If compilation is not deferred and we have cached programs, check for a match
-      if (!mgx_state->defer_compilation && mgx_state->cached_programs_ref.has_value()) {
-        // Build cache key from all inputs in map_input_name_index (already filtered to model inputs only)
-        std::vector<std::int64_t> all_input_shapes;
-        for (const auto& it : map_input_name_index) {
-          auto input_tensor = ctx.GetInput(it.second);
-          auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-          const auto tensor_shape = tensor_info.GetShape();
-          all_input_shapes.insert(all_input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
+      // ═══════════════════════════════════════════════════════════════════════
+      // Build input shape hash ONCE - used for all cache lookups
+      // ═══════════════════════════════════════════════════════════════════════
+      std::vector<std::int64_t> all_input_shapes;
+      all_input_shapes.reserve(map_input_name_index.size() * 4);  // Pre-allocate
+      for (const auto& [name, index] : map_input_name_index) {
+        const auto& shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
+        all_input_shapes.insert(all_input_shapes.end(), shape.begin(), shape.end());
+      }
+      const auto current_hash = make_hash(all_input_shapes);
+
+      // ═══════════════════════════════════════════════════════════════════════
+      // ULTRA-FAST PATH: Same shapes as last run - just rebind pointers and run
+      // ═══════════════════════════════════════════════════════════════════════
+      if (mgx_state->caches_valid && current_hash == mgx_state->last_input_shape_hash) {
+        // Rebind input/output pointers only (shapes unchanged)
+        auto& m = mgx_state->cached_prog_params.value();
+        const auto& param_names = mgx_state->cached_param_names;
+
+        for (const auto& name : param_names) {
+          auto it = map_input_name_index.find(name);
+          if (it != map_input_name_index.end()) {
+            // Input: update pointer
+            const auto& input_tensor = ctx.GetInput(it->second);
+            m.add(name.c_str(), migraphx::argument(mgx_state->cached_param_shapes.value()[name.c_str()],
+                                           const_cast<void*>(input_tensor.GetTensorRawData())));
+          } else {
+            // Output: update pointer
+            const int output_index = compute_output_index(name);
+            if (output_index != -1) {
+              const auto& lens = mgx_state->cached_output_shapes.value()[output_index].lengths();
+              std::vector<int64_t> ort_shape(lens.begin(), lens.end());
+              auto output_tensor = ctx.GetOutput(output_index, ort_shape.data(), ort_shape.size());
+              m.add(name.c_str(), migraphx::argument(mgx_state->cached_param_shapes.value()[name.c_str()],
+                                             output_tensor.GetTensorMutableRawData()));
+            }
+          }
         }
 
-        auto cache_hash = make_hash(all_input_shapes);
+        // Run directly - minimal overhead path
+        run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m,
+                             mgx_state->cached_prog_output_indices);
+        return Status::OK();
+      }
+
+      // ═══════════════════════════════════════════════════════════════════════
+      // FAST PATH: Check cached programs for this shape hash
+      // ═══════════════════════════════════════════════════════════════════════
+      if (!mgx_state->defer_compilation && mgx_state->cached_programs_ref.has_value()) {
         auto& cached_programs = mgx_state->cached_programs_ref.value().get();
+        auto prog_it = cached_programs.find(current_hash);
+        if (prog_it != cached_programs.end()) {
+          // Found cached program - use it and populate caches
+          prog = prog_it->second;
 
-        auto it = cached_programs.find(cache_hash);
-        if (it != cached_programs.end()) {
-          // Use the cached program directly
-          migraphx::program& cached_prog = it->second;
-          auto param_shapes = cached_prog.get_parameter_shapes();
+          // Populate caches for ultra-fast path on next call
+          mgx_state->cached_param_shapes = prog.get_parameter_shapes();
+          mgx_state->cached_output_shapes = prog.get_output_shapes();
 
-          // Bind inputs and allocate outputs for the cached program
-          auto [m, prog_output_indices] = handle_program_input_outputs(param_shapes, map_input_name_index, ctx, cached_prog);
+          // Cache param names (once per program)
+          mgx_state->cached_param_names.clear();
+          for (const auto& name : mgx_state->cached_param_shapes->names()) {
+            mgx_state->cached_param_names.push_back(name);
+          }
 
-          // Run the cached program
-          run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, cached_prog, m, prog_output_indices);
+          // Bind inputs/outputs using cached shapes (avoids another get_output_shapes() call)
+          auto [m, prog_output_indices] = handle_program_input_outputs(
+              mgx_state->cached_param_shapes.value(),
+              mgx_state->cached_output_shapes.value(),
+              map_input_name_index, ctx);
 
+          mgx_state->cached_prog_params = std::move(m);
+          mgx_state->cached_prog_output_indices = std::move(prog_output_indices);
+          mgx_state->last_input_shape_hash = current_hash;
+          mgx_state->caches_valid = true;
+
+          run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog,
+                               mgx_state->cached_prog_params.value(),
+                               mgx_state->cached_prog_output_indices);
           return Status::OK();
         }
       }
 
-      // Standard path: Process input shapes and determine if recompilation is needed
+      // ═══════════════════════════════════════════════════════════════════════
+      // STANDARD PATH: Shape checking and potential recompilation
+      // ═══════════════════════════════════════════════════════════════════════
       auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
           mgx_state->defer_compilation, map_input_name_index, ctx, cmp_options, prog);
 
-      // input shapes are different, needs to re-parse onnx and
-      // re-compile the program
       if (!input_shape_match) {
+        // Invalidate caches before recompilation
+        mgx_state->caches_valid = false;
+
         handle_input_shape_mismatch(
             mgx_state,
             model_cache_path_,
@@ -2094,12 +2199,33 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             ctx,
             param_shapes,
             input_shapes);
+
+        // Re-fetch param_shapes after recompilation
+        param_shapes = prog.get_parameter_shapes();
       }
 
-      // Bind inputs and allocate outputs for the MIGraphX program
-      auto [m, prog_output_indices] = handle_program_input_outputs(param_shapes, map_input_name_index, ctx, prog);
+      // Fetch and cache shapes ONCE (avoid duplicate API calls)
+      mgx_state->cached_param_shapes = param_shapes;
+      mgx_state->cached_output_shapes = prog.get_output_shapes();
 
-      // Run the MIGraphX program and handle outputs
+      // Cache param names
+      mgx_state->cached_param_names.clear();
+      for (const auto& name : mgx_state->cached_param_shapes->names()) {
+        mgx_state->cached_param_names.push_back(name);
+      }
+
+      // Bind inputs and allocate outputs using cached shapes
+      auto [m, prog_output_indices] = handle_program_input_outputs(
+          mgx_state->cached_param_shapes.value(),
+          mgx_state->cached_output_shapes.value(),
+          map_input_name_index, ctx);
+
+      // Complete cache population
+      mgx_state->cached_prog_params = m;
+      mgx_state->cached_prog_output_indices = prog_output_indices;
+      mgx_state->last_input_shape_hash = current_hash;
+      mgx_state->caches_valid = true;
+
       run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, prog_output_indices);
 
       return Status::OK();

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1157,62 +1157,51 @@ MIGraphXExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_v
   return result;
 }
 
-// Result structure for get_input_output_names containing detailed symbolic dimension info
-struct InputOutputNamesResult {
-  bool defer_compilation;        // True if any input has unknown/symbolic dimensions
-  bool prog_has_dynamic_batch;   // True if batch dimension (dim 0) is symbolic for any input
-  SymbolicDimsMap symbolic_dims; // Fine-grained tracking of which dimensions are symbolic per input
-};
-
-InputOutputNamesResult get_input_output_names(const GraphViewer& graph,
-                                              std::vector<std::string>& input_names,
-                                              std::vector<std::string>& output_names) {
-  input_names.clear();
-  output_names.clear();
-  SymbolicDimsMap symbolic_dims;
-  bool defer_compilation = false;
-  bool prog_has_dynamic_batch = false;
-
+// Check if any inputs have dynamic/symbolic dimensions that require deferred compilation
+static bool inputs_have_dynamic_dims(const GraphViewer& graph) {
   const auto& input_args = graph.GetInputs();
 
   for (const auto& arg : input_args) {
     if (arg == nullptr) {
-      defer_compilation = true;
-      continue;
+      return true;
     }
 
-    input_names.push_back(arg->Name());
     auto sptr = arg->Shape();
-
     if (sptr == nullptr || sptr->dim_size() == 0) {
-      defer_compilation = true;
-      // Mark all dimensions as unknown for this input
-      LOGS_DEFAULT(VERBOSE) << "[get_input_output_names] Input '" << arg->Name()
-                            << "' has no shape info, treating as fully dynamic";
-      continue;
+      LOGS_DEFAULT(VERBOSE) << "[inputs_have_dynamic_dims] Input '" << arg->Name()
+                            << "' has no shape info, treating as dynamic";
+      return true;
     }
 
-    std::vector<SymbolicDimInfo> input_symbolic_dims;
     for (int i = 0; i < sptr->dim_size(); i++) {
       if (sptr->dim(i).has_dim_param()) {
-        defer_compilation = true;
         std::string dim_param = sptr->dim(i).dim_param();
-        input_symbolic_dims.push_back({i, dim_param});
-
-        // Check if this is the batch dimension (dim 0)
         if (i == 0) {
-          prog_has_dynamic_batch = true;
-          LOGS_DEFAULT(VERBOSE) << "[get_input_output_names] Input '" << arg->Name()
+          LOGS_DEFAULT(VERBOSE) << "[inputs_have_dynamic_dims] Input '" << arg->Name()
                                 << "' has dynamic batch dimension: " << dim_param;
         } else {
-          LOGS_DEFAULT(VERBOSE) << "[get_input_output_names] Input '" << arg->Name()
+          LOGS_DEFAULT(VERBOSE) << "[inputs_have_dynamic_dims] Input '" << arg->Name()
                                 << "' dimension " << i << " is symbolic: " << dim_param;
         }
+        return true;
       }
     }
+  }
 
-    if (!input_symbolic_dims.empty()) {
-      symbolic_dims[arg->Name()] = std::move(input_symbolic_dims);
+  return false;
+}
+
+// Get input and output names from the graph
+static void get_io_names(const GraphViewer& graph,
+                         std::vector<std::string>& input_names,
+                         std::vector<std::string>& output_names) {
+  input_names.clear();
+  output_names.clear();
+
+  const auto& input_args = graph.GetInputs();
+  for (const auto& arg : input_args) {
+    if (arg != nullptr) {
+      input_names.push_back(arg->Name());
     }
   }
 
@@ -1228,28 +1217,11 @@ InputOutputNamesResult get_input_output_names(const GraphViewer& graph,
       tmp_out_names.end(),
       std::back_inserter(output_names),
       [&](const auto& name) { return !name.empty(); });
-
-  if (prog_has_dynamic_batch) {
-    LOGS_DEFAULT(VERBOSE) << "[get_input_output_names] Model has dynamic batch dimension";
-  }
-  if (!symbolic_dims.empty()) {
-    LOGS_DEFAULT(VERBOSE) << "[get_input_output_names] Found " << symbolic_dims.size()
-                          << " inputs with symbolic dimensions";
-  }
-
-  return {defer_compilation, prog_has_dynamic_batch, std::move(symbolic_dims)};
 }
-
-// Result structure for check_for_symbolic_dims
-struct SymbolicDimsCheckResult {
-  std::vector<std::int64_t> input_shapes;  // Shapes for cache key hash calculation
-  bool has_symbolic_dims;                   // True if any symbolic dimensions found
-  bool symbolic_batch_dim;                  // True if batch dimension (dim 0) is symbolic for any input
-};
 
 // Check input tensors for symbolic dimensions and build shape vector for cache key generation
 // Returns input shapes suitable for hash calculation and whether symbolic dims were found
-static SymbolicDimsCheckResult check_for_symbolic_dims(
+static std::vector<std::int64_t> check_for_symbolic_dims(
     const std::vector<const NodeArg*>& input_tensor,
     const std::set<std::string>& session_input_names,
     int64_t default_batch_size = 1)
@@ -1333,7 +1305,7 @@ static SymbolicDimsCheckResult check_for_symbolic_dims(
     LOGS_DEFAULT(VERBOSE) << "[Compile] All inputs have symbolic batch dimension";
   }
 
-  return {std::move(input_shapes), has_symbolic_dims, all_batch_dims_symbolic};
+  return {std::move(input_shapes)};
 }
 
 // Attempt to load a model and catch any exceptions on load fail.
@@ -1686,54 +1658,28 @@ static void handle_input_shape_mismatch(
   auto& cmp_options = mgx_state->options;
   const auto& map_input_name_index = mgx_state->input_name_indexes;
 
-  // Determine batch size ONLY from inputs that have symbolic/dynamic dimensions
-  // We must NOT use weight/embedding tensors which have large fixed first dimensions
-  const auto& symbolic_dims = mgx_state->symbolic_dims;
-  std::size_t current_batch_size = 0;
-
-  // First, try to find batch size from inputs with symbolic batch dimension
+  // Build cache key from ALL inputs (not just symbolic ones)
+  std::vector<std::int64_t> all_input_shapes;
   for (const auto& it : map_input_name_index) {
-    const auto& name = it.first;
-
-    // Check if this input has a symbolic batch dimension (dim 0)
-    auto sym_it = symbolic_dims.find(name);
-    if (sym_it != symbolic_dims.end()) {
-      bool has_dynamic_batch = false;
-      for (const auto& sym_dim : sym_it->second) {
-        if (sym_dim.dim_index == 0) {
-          has_dynamic_batch = true;
-          break;
-        }
-      }
-
-      if (has_dynamic_batch) {
-        auto input_tensor = ctx.GetInput(it.second);
-        auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-        const auto tensor_shape = tensor_info.GetShape();
-        if (!tensor_shape.empty()) {
-          current_batch_size = static_cast<std::size_t>(tensor_shape[0]);
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Found dynamic batch input '" << name
-                                << "' with batch=" << current_batch_size;
-          break;  // Use first dynamic batch input found
-        }
-      }
-    }
+    auto input_tensor = ctx.GetInput(it.second);
+    auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+    const auto tensor_shape = tensor_info.GetShape();
+    all_input_shapes.insert(all_input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
   }
+  auto cache_hash = make_hash(all_input_shapes);
 
-  LOGS_DEFAULT(VERBOSE) << "[Compute] Using batch size: " << current_batch_size;
-
-  // Check in-memory batched_programs cache first (before disk cache)
-  if (mgx_state->batched_programs_ref.has_value() && current_batch_size > 0) {
-    auto& batched_progs = mgx_state->batched_programs_ref.value().get();
-    auto it = batched_progs.find(current_batch_size);
-    if (it != batched_progs.end()) {
-      LOGS_DEFAULT(VERBOSE) << "[Compute] Found batch size " << current_batch_size
-                         << " in in-memory batched_programs cache - using cached program";
+  // Check in-memory cached_programs first (before disk cache)
+  if (mgx_state->cached_programs_ref.has_value()) {
+    auto& cached_progs = mgx_state->cached_programs_ref.value().get();
+    auto it = cached_progs.find(cache_hash);
+    if (it != cached_progs.end()) {
+      LOGS_DEFAULT(VERBOSE) << "[Compute] Found hash " << cache_hash
+                         << " in in-memory cached_programs - using cached program";
       prog = it->second;
-        param_shapes = prog.get_parameter_shapes();
+      param_shapes = prog.get_parameter_shapes();
       return;  // Early exit - no need to load from disk or compile
     } else {
-      LOGS_DEFAULT(VERBOSE) << "[Compute] Batch size " << current_batch_size
+      LOGS_DEFAULT(VERBOSE) << "[Compute] Hash " << cache_hash
                          << " not in in-memory cache, checking disk cache";
     }
   }
@@ -1741,31 +1687,6 @@ static void handle_input_shape_mismatch(
   std::filesystem::path model_cache_file;
   // empty cache path means the MXR caching is disabled - always compile
   if (!model_cache_path.empty()) {
-    // Build cache key from ONLY inputs with symbolic/dynamic dimensions
-    // This ensures different batch sizes get different cache files
-    std::vector<std::int64_t> dynamic_input_shapes;
-
-    for (const auto& it : map_input_name_index) {
-      const auto& name = it.first;
-
-      // Check if this input has any symbolic dimensions
-      auto sym_it = symbolic_dims.find(name);
-      if (sym_it != symbolic_dims.end() && !sym_it->second.empty()) {
-        auto input_tensor = ctx.GetInput(it.second);
-        auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-        const auto tensor_shape = tensor_info.GetShape();
-
-        // Include ALL dimensions of dynamic inputs in cache key
-        dynamic_input_shapes.insert(dynamic_input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
-      }
-    }
-
-    // If no dynamic inputs found, fall back to using batch size directly
-    if (dynamic_input_shapes.empty()) {
-      dynamic_input_shapes.push_back(static_cast<std::int64_t>(current_batch_size));
-    }
-
-    auto cache_hash = make_hash(dynamic_input_shapes);
     model_cache_file = mgx_state->model_cache_dir / (mxr_filename_prefix + cache_hash + ".mxr");
   }
 
@@ -1821,11 +1742,11 @@ static void handle_input_shape_mismatch(
     LOGS_DEFAULT(VERBOSE) << "[Compute] Cache hit - loaded precompiled model";
   }
 
-  // Store the compiled/loaded program in the in-memory batched_programs cache
-  if (mgx_state->batched_programs_ref.has_value() && current_batch_size > 0) {
-    mgx_state->batched_programs_ref.value().get()[current_batch_size] = prog;
-    LOGS_DEFAULT(VERBOSE) << "[Compute] Stored program for batch size " << current_batch_size
-                          << " in in-memory batched_programs cache";
+  // Store the compiled/loaded program in the in-memory cached_programs cache
+  if (mgx_state->cached_programs_ref.has_value()) {
+    mgx_state->cached_programs_ref.value().get()[cache_hash] = prog;
+    LOGS_DEFAULT(VERBOSE) << "[Compute] Stored program for hash " << cache_hash
+                          << " in in-memory cached_programs cache";
   }
 
   param_shapes = prog.get_parameter_shapes();
@@ -1922,11 +1843,9 @@ struct InputShapeResult {
 
 // Helper: Handle input shape processing for both dynamic and static cases
 // This function processes runtime input shapes and determines if recompilation is needed
-// Now uses fine-grained symbolic dimension tracking for more precise shape matching
+// Compares all input dimensions of the compiled program against runtime input dimensions
 static InputShapeResult handle_input_shape(
     bool defer_compilation,
-    const SymbolicDimsMap& symbolic_dims,
-    bool prog_has_dynamic_batch,
     const std::unordered_map<std::string, std::size_t>& map_input_name_index,
     Ort::KernelContext& ctx,
     migraphx::onnx_options& cmp_options,
@@ -1943,9 +1862,6 @@ static InputShapeResult handle_input_shape(
     LOGS_DEFAULT(VERBOSE) << "[Compute] Setting shapes for " << map_input_name_index.size()
                           << " runtime input parameters (excluding constants)";
 
-    if (prog_has_dynamic_batch) {
-      LOGS_DEFAULT(VERBOSE) << "[Compute] Program has dynamic batch dimension - using runtime batch sizes";
-    }
 
     for (const auto& it : map_input_name_index) {
       const auto& name = it.first;
@@ -1960,22 +1876,16 @@ static InputShapeResult handle_input_shape(
       cmp_options.set_input_parameter_shape(name, ort_lens);
       input_shape_match = false;
 
-      // Only include inputs with symbolic dimensions in cache key (for correct hashing)
-      // This ensures different batch sizes result in different cache files
-      auto sym_it = symbolic_dims.find(name);
-      if (sym_it != symbolic_dims.end() && !sym_it->second.empty()) {
-        input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
-        LOGS_DEFAULT(VERBOSE) << "[Compute] Including dynamic input '" << name << "' in cache key";
-      }
+      // Include ALL inputs in cache key for hash calculation
+      input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
     }
     LOGS_DEFAULT(VERBOSE) << "[Compute] All runtime input shapes set as static parameters in MIGraphX options";
     LOGS_DEFAULT(VERBOSE) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
   } else {
-    LOGS_DEFAULT(VERBOSE) << "Assigning inputs, and parameters from compiled model";
+    LOGS_DEFAULT(VERBOSE) << "[Compute] Checking if compiled program shapes match runtime inputs";
     param_shapes = prog.get_parameter_shapes();
-    auto prog_output_shapes = prog.get_output_shapes();
 
-    // check whether input shapes match with shapes of program inputs
+    // Check if all input shapes match the compiled program's shapes
     if (param_shapes.size() > 0) {
       for (auto&& name : param_shapes.names()) {
         if (map_input_name_index.count(name) > 0) {
@@ -1994,84 +1904,16 @@ static InputShapeResult handle_input_shape(
             mgx_lens.clear();
           }
 
-          // Check if shapes match - with fine-grained symbolic dimension tracking
-          bool shape_mismatch = (mgx_lens != ort_lens);
-
-          if (shape_mismatch) {
-            // Check if mismatch is only in symbolic dimensions (expected and handled)
-            auto sym_it = symbolic_dims.find(name);
-            bool is_symbolic_dim_change = false;
-
-            if (sym_it != symbolic_dims.end() && mgx_lens.size() == ort_lens.size()) {
-              // Check if only symbolic dimensions changed
-              is_symbolic_dim_change = true;
-              for (size_t i = 0; i < mgx_lens.size(); ++i) {
-                if (mgx_lens[i] != ort_lens[i]) {
-                  // Check if this dimension is symbolic
-                  bool is_symbolic = false;
-                  for (const auto& sym_dim : sym_it->second) {
-                    if (sym_dim.dim_index == static_cast<int>(i)) {
-                      is_symbolic = true;
-                      LOGS_DEFAULT(VERBOSE) << "[Compute] Symbolic dimension '" << sym_dim.dim_param
-                                            << "' (dim " << i << ") changed from " << mgx_lens[i]
-                                            << " to " << ort_lens[i] << " for input '" << name << "'";
-                      break;
-                    }
-                  }
-                  if (!is_symbolic) {
-                    is_symbolic_dim_change = false;
-                    LOGS_DEFAULT(WARNING) << "[Compute] Non-symbolic dimension " << i
-                                          << " changed from " << mgx_lens[i] << " to " << ort_lens[i]
-                                          << " for input '" << name << "' - unexpected shape change";
-                    break;
-                  }
-                }
-              }
-            }
-
-            if (is_symbolic_dim_change) {
-              LOGS_DEFAULT(VERBOSE) << "[Compute] Shape change in symbolic dimensions only for input '" << name << "'";
-            } else {
-              LOGS_DEFAULT(VERBOSE) << "[Compute] Shape mismatch for input '" << name
-                                    << "': MIGraphX expects [" << mgx_lens.size() << " dims], "
-                                    << "got [" << ort_lens.size() << " dims]";
-            }
-
-            // Check if it's specifically a batch size change (common case)
-            if (mgx_lens.size() == ort_lens.size() && mgx_lens.size() > 0 && mgx_lens[0] != ort_lens[0]) {
-              if (prog_has_dynamic_batch) {
-                LOGS_DEFAULT(VERBOSE) << "[Compute] Dynamic batch size changed from " << mgx_lens[0]
-                                      << " to " << ort_lens[0] << " for input '" << name << "'";
-              } else {
-                LOGS_DEFAULT(VERBOSE) << "[Compute] Batch size changed from " << mgx_lens[0]
-                                      << " to " << ort_lens[0] << " for input '" << name << "'";
-              }
-            }
-
+          // Check if shapes match
+          if (mgx_lens != ort_lens) {
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Shape mismatch for input '" << name << "': "
+                                  << "compiled shape vs runtime shape differ";
             cmp_options.set_input_parameter_shape(name, ort_lens);
             input_shape_match = false;
           }
 
-          // Only include inputs with symbolic dimensions in cache key (for correct hashing)
-          auto sym_it = symbolic_dims.find(name);
-          if (sym_it != symbolic_dims.end() && !sym_it->second.empty()) {
-            input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
-          }
-
-          // Log batch size and full shape for tracking
-          if (!tensor_shape.empty()) {
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' batch size: " << tensor_shape[0];
-
-            // Log full shape for debugging symbolic dimensions
-            std::ostringstream shape_str;
-            shape_str << "[";
-            for (size_t i = 0; i < tensor_shape.size(); ++i) {
-              if (i > 0) shape_str << ", ";
-              shape_str << tensor_shape[i];
-            }
-            shape_str << "]";
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' full shape: " << shape_str.str();
-          }
+          // Include ALL inputs in cache key for hash calculation
+          input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
         }
       }
     }
@@ -2106,18 +1948,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     }
 
     constexpr std::size_t default_batch_size = 1;
-    // empty cache path means the MXR caching is disabled - always compile
-    if (!model_cache_path_.empty() or first_start_) {
-      auto [input_shapes, has_symbolic_dims, symbolic_batch_dim] = check_for_symbolic_dims(input_tensor, session_input_names, default_batch_size);
 
-      if (!input_shapes.empty()) {
-        model_cache_file = model_cache_path_ / (mxr_filename_prefix + make_hash(input_shapes) + ".mxr");
-      } else {
-        LOGS_DEFAULT(WARNING) << "[Compile] Input shapes are empty, skipping model cache file hash generation";
-      }
-
-      first_start_ = false;
-    }
 
     // map parameter input name to index
     std::unordered_map<std::string, std::size_t> input_name_index;
@@ -2137,101 +1968,64 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     dump_model_as_onnx(onnx_string_buffer, std::string{fused_node.Name() + ".onnx"});
 
     std::vector<std::string> input_names, output_names;
-    auto names_result = get_input_output_names(graph_body_viewer, input_names, output_names);
-    defer_compilation = defer_compilation || names_result.defer_compilation;
-    bool prog_has_dynamic_batch = names_result.prog_has_dynamic_batch;
-    SymbolicDimsMap symbolic_dims = std::move(names_result.symbolic_dims);
+    get_io_names(graph_body_viewer, input_names, output_names);
 
-    // Set default batch size for symbolic dimensions in onnx_options
-    // NOTE: Only set shapes for actual model inputs, NOT for constants or initializers
-    // MIGraphX will automatically infer shapes for constants and intermediate tensors
-    if (defer_compilation) {
-      LOGS_DEFAULT(VERBOSE) << "[Compile] Setting default batch size of " << default_batch_size
-                            << " for model input parameters (excluding constants)";
+    // Get initializers to filter them out
+    const auto& initializers = graph_body_viewer.GetAllInitializedTensors();
 
-      // Get initializers to filter them out
-      const auto& initializers = graph_body_viewer.GetAllInitializedTensors();
+    for (std::size_t i = 0; i < input_names.size(); ++i) {
+      // Skip if this is an initializer/constant - let MIGraphX infer its shape
+      if (initializers.count(input_names[i]) > 0) {
+        LOGS_DEFAULT(VERBOSE) << "[Compile] Skipping '" << input_names[i] << "' (initializer/constant)";
+        continue;
+      }
 
-      for (std::size_t i = 0; i < input_names.size(); ++i) {
-        // Skip if this is an initializer/constant - let MIGraphX infer its shape
-        if (initializers.count(input_names[i]) > 0) {
-          LOGS_DEFAULT(VERBOSE) << "[Compile] Skipping '" << input_names[i] << "' (initializer/constant)";
-          continue;
-        }
+      if (i < input_tensor.size()) {
+        auto tensor_shape = input_tensor[i]->Shape();
+        if (tensor_shape != nullptr && tensor_shape->dim_size() > 0) {
+          std::vector<std::size_t> default_shape;
+          bool has_symbolic = false;
 
-        if (i < input_tensor.size()) {
-          auto tensor_shape = input_tensor[i]->Shape();
-          if (tensor_shape != nullptr && tensor_shape->dim_size() > 0) {
-            std::vector<std::size_t> default_shape;
-            bool has_symbolic = false;
-
-            for (int j = 0; j < tensor_shape->dim_size(); ++j) {
-              const auto& dim = tensor_shape->dim(j);
-              if (dim.has_dim_value()) {
-                default_shape.push_back(static_cast<std::size_t>(dim.dim_value()));
-              } else if (dim.has_dim_param() || !dim.has_dim_value()) {
-                // Symbolic or unknown dimension - use default batch size for dim 0, 1 for others
-                has_symbolic = true;
-                default_shape.push_back(j == 0 ? default_batch_size : 1);
-                LOGS_DEFAULT(VERBOSE) << "[Compile] Input parameter '" << input_names[i]
-                                      << "' dimension " << j << " is symbolic, using default";
-              }
+          for (int j = 0; j < tensor_shape->dim_size(); ++j) {
+            const auto& dim = tensor_shape->dim(j);
+            if (dim.has_dim_value()) {
+              default_shape.push_back(static_cast<std::size_t>(dim.dim_value()));
+            } else if (dim.has_dim_param() || !dim.has_dim_value()) {
+              // Symbolic or unknown dimension - use default batch size for dim 0, 1 for others
+              has_symbolic = true;
+              default_shape.push_back(j == 0 ? default_batch_size : 1);
+              LOGS_DEFAULT(VERBOSE) << "[Compile] Input parameter '" << input_names[i]
+                                    << "' dimension " << j << " is symbolic, using default";
             }
+          }
 
-            if (has_symbolic && !default_shape.empty()) {
-              options.set_input_parameter_shape(input_names[i], default_shape);
-              LOGS_DEFAULT(VERBOSE) << "[Compile] Set default shape for input parameter '" << input_names[i] << "'";
-            }
+          if (has_symbolic && !default_shape.empty()) {
+            options.set_input_parameter_shape(input_names[i], default_shape);
+            LOGS_DEFAULT(VERBOSE) << "[Compile] Set default shape for input parameter '" << input_names[i] << "'";
           }
         }
       }
-      LOGS_DEFAULT(VERBOSE) << "[Compile] Constants and initializers will have shapes inferred by MIGraphX";
     }
+    LOGS_DEFAULT(VERBOSE) << "[Compile] Constants and initializers will have shapes inferred by MIGraphX";
+
+    // always defer compilation to compute for first inference
+    // This is done as if the modic has static input shapes but batch changes we'll need to do an update anyway
+    // In the case of dynamic shapes, like with dynamic batch or sequence length we wont know input shapes until runtime
+    map_defer_compilation_[fused_node.Name()] = true;
 
     // by parsing the model_proto, create a program corresponding to
     // the input fused_node
     migraphx::program prog;
-
-    if (!defer_compilation) {
-      prog = load_or_compile_model(model_cache_file, onnx_string_buffer, options, t_,
-                                   fp16_enable_, bf16_enable_, int8_enable_, fp8_enable_,
-                                   int8_calibration_cache_available_, dynamic_range_map_, exhaustive_tune_, model_path_);
-
-      // NOTE: DO NOT set output shapes as input parameters!
-      // Outputs are dynamically inferred by MIGraphX based on input shapes
-      // Store the compiled/loaded program in batched_programs_ indexed by batch size
-      auto param_shapes = prog.get_parameter_shapes();
-      if (param_shapes.size() > 0) {
-        // Extract batch size from first input parameter
-        for (auto&& name : param_shapes.names()) {
-          auto shape = param_shapes[name];
-          auto lens = shape.lengths();
-          if (!lens.empty()) {
-            std::size_t batch_size = lens[0];
-            batched_programs_[fused_node.Name()][batch_size] = prog;
-            LOGS_DEFAULT(VERBOSE) << "[Compile] Stored program for batch size " << batch_size
-                                  << " in batched_programs cache";
-            break;  // Only need batch size from first input
-          }
-        }
-      }
-    } else {
-      LOGS_DEFAULT(VERBOSE) << "[Compile] Deferring compilation until runtime (no static input shapes available)";
-      LOGS_DEFAULT(VERBOSE) << "[Compile] Will use default batch size of 1, then recompile with actual batch at runtime";
-    }
 
     // compile the program
     map_progs_[fused_node.Name()] = prog;
 
     map_onnx_string_[fused_node.Name()] = onnx_string_buffer;
     map_input_index_[fused_node.Name()] = input_name_index;
-    map_defer_compilation_[fused_node.Name()] = defer_compilation;
-    map_symbolic_dims_[fused_node.Name()] = symbolic_dims;
-    map_prog_has_dynamic_batch_[fused_node.Name()] = prog_has_dynamic_batch;
 
-    // Initialize the batched_programs map for this node if not already done
-    if (batched_programs_.find(fused_node.Name()) == batched_programs_.end()) {
-      batched_programs_[fused_node.Name()] = std::unordered_map<std::size_t, migraphx::program>();
+    // Initialize the cached_programs map for this node if not already done
+    if (cached_programs_.find(fused_node.Name()) == cached_programs_.end()) {
+      cached_programs_[fused_node.Name()] = std::unordered_map<std::string, migraphx::program>();
     }
 
     NodeComputeInfo compute_info;
@@ -2242,9 +2036,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             map_defer_compilation_[context->node_name], fp16_enable_, bf16_enable_, fp8_enable_, int8_enable_,
             int8_calibration_cache_available_, dynamic_range_map_,
             model_cache_path_.string(), dump_model_ops_, exhaustive_tune_, max_dynamic_batch_,
-            std::ref(batched_programs_[context->node_name]),
-            map_symbolic_dims_[context->node_name],
-            map_prog_has_dynamic_batch_[context->node_name]};
+            std::ref(cached_programs_[context->node_name])};
       *state = p.release();
       return 0;
     };
@@ -2261,71 +2053,45 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       std::unordered_map<std::string, std::size_t>& map_input_name_index = mgx_state->input_name_indexes;
       migraphx::program& prog = mgx_state->prog;
       migraphx::onnx_options& cmp_options = mgx_state->options;
-      bool& defer_compilation = mgx_state->defer_compilation;
-      const SymbolicDimsMap& symbolic_dims = mgx_state->symbolic_dims;
-      bool prog_has_dynamic_batch = mgx_state->prog_has_dynamic_batch;
 
-      // Fast path: If program has dynamic batch and we have a cached program for the current batch size,
-      // use it directly without going through shape comparison and recompilation
-      if (prog_has_dynamic_batch && mgx_state->batched_programs_ref.has_value()) {
-        // Get current batch size from an input with symbolic batch dimension (dim 0)
-        // This ensures we use the actual dynamic batch input, not weight tensors
-        std::size_t current_batch_size = 0;
+      // Fast path: If compilation is not deferred and we have cached programs, check for a match
+      if (!migx_state->defer_compilation && mgx_state->cached_programs_ref.has_value()) {
+        // Build cache key from ALL inputs
+        std::vector<std::int64_t> all_input_shapes;
         for (const auto& it : map_input_name_index) {
-          const auto& name = it.first;
-
-          // Check if this input has a symbolic batch dimension (dim 0)
-          auto sym_it = symbolic_dims.find(name);
-          if (sym_it != symbolic_dims.end()) {
-            bool has_dynamic_batch = false;
-            for (const auto& sym_dim : sym_it->second) {
-              if (sym_dim.dim_index == 0) {
-                has_dynamic_batch = true;
-                break;
-              }
-            }
-
-            if (has_dynamic_batch) {
-              auto input_tensor = ctx.GetInput(it.second);
-              auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-              const auto tensor_shape = tensor_info.GetShape();
-              if (!tensor_shape.empty()) {
-                current_batch_size = static_cast<std::size_t>(tensor_shape[0]);
-                break;  // Use first dynamic batch input found
-              }
-            }
-          }
+          auto input_tensor = ctx.GetInput(it.second);
+          auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+          const auto tensor_shape = tensor_info.GetShape();
+          all_input_shapes.insert(all_input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
         }
 
-        // Check if we have a cached program for this batch size
-        if (current_batch_size > 0) {
-          auto& batched_programs = mgx_state->batched_programs_ref.value().get();
-          auto it = batched_programs.find(current_batch_size);
-          if (it != batched_programs.end()) {
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Fast path: Found cached program for batch size " << current_batch_size;
+        auto cache_hash = make_hash(all_input_shapes);
+        auto& cached_programs = mgx_state->cached_programs_ref.value().get();
+        auto it = cached_programs.find(cache_hash);
+        if (it != cached_programs.end()) {
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Fast path: Found cached program for hash " << cache_hash;
 
-            // Use the cached program directly
-            migraphx::program& cached_prog = it->second;
-            auto param_shapes = cached_prog.get_parameter_shapes();
+          // Use the cached program directly
+          migraphx::program& cached_prog = it->second;
+          auto param_shapes = cached_prog.get_parameter_shapes();
 
-            // Bind inputs and allocate outputs for the cached program
-            auto [m, prog_output_indices] = handle_program_input_outputs(param_shapes, map_input_name_index, ctx, cached_prog);
+          // Bind inputs and allocate outputs for the cached program
+          auto [m, prog_output_indices] = handle_program_input_outputs(param_shapes, map_input_name_index, ctx, cached_prog);
 
-            // Run the cached program
-            run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, cached_prog, m, prog_output_indices);
+          // Run the cached program
+          run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, cached_prog, m, prog_output_indices);
 
-            return Status::OK();
-          } else {
-            LOGS_DEFAULT(VERBOSE) << "[Compute] No cached program for batch size " << current_batch_size
-                                  << ", falling back to standard path";
-          }
+          return Status::OK();
+        } else {
+          LOGS_DEFAULT(VERBOSE) << "[Compute] No cached program for hash " << cache_hash
+                                << ", falling back to standard path";
         }
       }
 
       // Standard path: Process input shapes and determine if recompilation is needed
       // Using fine-grained symbolic dimension tracking for more precise shape matching
       auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
-          defer_compilation, symbolic_dims, prog_has_dynamic_batch, map_input_name_index, ctx, cmp_options, prog);
+          defer_compilation, map_input_name_index, ctx, cmp_options, prog);
 
       // input shapes are different, needs to re-parse onnx and
       // re-compile the program

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -7,9 +7,11 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <future>
 #include <iterator>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -3466,6 +3468,7 @@ static inline std::string precompile_model_for_batch(
 
 // Precompile all power-of-two batch models during Compile() phase
 // This moves compilation from compute_func() to initialization time
+// Uses parallel loading to speed up cache loading when multiple batch sizes are needed
 static inline void precompile_all_dynamic_batch_models(
     const std::vector<std::size_t>& power_of_two_batch_sizes,
     const std::vector<std::string>& input_names,
@@ -3486,27 +3489,82 @@ static inline void precompile_all_dynamic_batch_models(
     std::unordered_map<std::string, migraphx::program>& cached_programs)
 {
   LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] Precompiling " 
-                     << power_of_two_batch_sizes.size() << " power-of-two batch models...";
+                     << power_of_two_batch_sizes.size() << " power-of-two batch models in parallel...";
+  
+  // Mutex to protect shared cached_programs map
+  std::mutex cache_mutex;
+  
+  // Launch async tasks for each batch size
+  std::vector<std::future<void>> futures;
   
   for (const auto& batch_size : power_of_two_batch_sizes) {
-    precompile_model_for_batch(
-        batch_size,
-        input_names,
-        all_input_base_shapes,
-        onnx_string,
-        options,
-        t,
-        fp16_enable,
-        bf16_enable,
-        int8_enable,
-        fp8_enable,
-        int8_calibration_cache_available,
-        dynamic_range_map,
-        exhaustive_tune,
-        model_path,
-        model_cache_path,
-        mxr_filename_prefix,
-        cached_programs);
+    futures.push_back(std::async(std::launch::async, 
+      [&, batch_size]() {
+        // Build cache key for this batch size
+        std::vector<std::int64_t> batch_shape_key;
+        for (std::size_t i = 0; i < input_names.size(); ++i) {
+          batch_shape_key.push_back(static_cast<std::int64_t>(batch_size));
+          batch_shape_key.insert(batch_shape_key.end(), 
+                                all_input_base_shapes[i].begin(), 
+                                all_input_base_shapes[i].end());
+        }
+        auto cache_hash = make_hash(batch_shape_key);
+        
+        LOGS_DEFAULT(VERBOSE) << "[precompile_model_for_batch] Batch " << batch_size << " -> hash: " << cache_hash;
+        
+        // Check if already cached in memory (thread-safe check)
+        {
+          std::lock_guard<std::mutex> lock(cache_mutex);
+          if (cached_programs.find(cache_hash) != cached_programs.end()) {
+            LOGS_DEFAULT(VERBOSE) << "[precompile_model_for_batch] ✓ Batch " << batch_size << " already cached";
+            return;
+          }
+        }
+        
+        // Build disk cache file path
+        std::filesystem::path batch_cache_file;
+        if (!model_cache_path.empty()) {
+          batch_cache_file = model_cache_path / (mxr_filename_prefix + cache_hash + ".mxr");
+        }
+        
+        LOGS_DEFAULT(VERBOSE) << "[precompile_model_for_batch] Compiling/loading batch " << batch_size << "...";
+        
+        // Create thread-local copy of options to avoid race conditions
+        migraphx::onnx_options local_options = options;
+        
+        // Load or compile the model (most time-consuming part)
+        migraphx::program batch_prog = load_or_compile_model(
+            batch_cache_file,
+            onnx_string,
+            local_options,  // Use thread-local copy
+            t,
+            fp16_enable,
+            bf16_enable,
+            int8_enable,
+            fp8_enable,
+            int8_calibration_cache_available,
+            dynamic_range_map,  // Read-only access
+            exhaustive_tune,
+            model_path,
+            nullptr,  // ctx not needed for precompilation
+            nullptr,  // map_input_name_index not needed
+            input_names,
+            all_input_base_shapes,
+            batch_size);
+        
+        // Store in memory cache (thread-safe insertion)
+        {
+          std::lock_guard<std::mutex> lock(cache_mutex);
+          cached_programs[cache_hash] = std::move(batch_prog);
+          LOGS_DEFAULT(VERBOSE) << "[precompile_model_for_batch] ✓ Stored batch " << batch_size << " in cache";
+        }
+      }
+    ));
+  }
+  
+  // Wait for all tasks to complete
+  for (auto& future : futures) {
+    future.get();
   }
   
   LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] ✓ Precompiled " 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1969,6 +1969,18 @@ static migraphx::onnx_options get_program_parameter_options(
   return options;
 }
 
+// Build a map from input parameter name to index
+template <typename Container>
+static std::unordered_map<std::string, std::size_t> get_input_name_map(const Container& input_defs) {
+  std::unordered_map<std::string, std::size_t> input_name_index;
+  input_name_index.reserve(input_defs.size());
+  std::size_t i = 0;
+  for (const auto& def : input_defs) {
+    input_name_index[def->Name()] = i++;
+  }
+  return input_name_index;
+}
+
 constexpr std::uint64_t MIGraphX_Version =
     ((MIGRAPHX_VERSION_MAJOR << 16) | (MIGRAPHX_VERSION_MINOR << 8) | MIGRAPHX_VERSION_PATCH);
 
@@ -1993,13 +2005,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     }
 
 
-    // map parameter input name to index
-    std::unordered_map<std::string, std::size_t> input_name_index;
-    const auto& input_defs = fused_node.InputDefs();
-    input_name_index.reserve(input_defs.size());
-    for (std::size_t i = 0; i < input_defs.size(); ++i) {
-      input_name_index[input_defs[i]->Name()] = i;
-    }
+    auto input_name_index = get_input_name_map(fused_node.InputDefs());
 
     auto model = graph_body_viewer.CreateModel(*GetLogger());
     auto model_proto = model->ToProto();

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1317,6 +1317,7 @@ migraphx::program CompileProgramWithBatch(
   const std::string& onnx_string,
   const std::vector<std::string>& input_names,
   const std::vector<std::vector<std::int64_t>>& all_input_base_shapes,
+  //const std::unordered_map<std::string, std::size_t>& map_input_name_index,
   size_t batch_size,
   migraphx::onnx_options options,
   const migraphx::target& t,
@@ -1362,7 +1363,7 @@ migraphx::program CompileProgramWithBatch(
   migraphx::program prog = migraphx::parse_onnx_buffer(onnx_string, options);
   migraphx::program_parameters quant_params;
 
-  if ((int8_enable ^ fp8_enable) && int8_calibration_cache_available) {
+  /* if ((int8_enable ^ fp8_enable) && int8_calibration_cache_available) {
     auto local_param_shapes = prog.get_parameter_shapes();
     // Add input parameter data and the values they're set to
     for (auto&& name : local_param_shapes.names()) {
@@ -1382,7 +1383,7 @@ migraphx::program CompileProgramWithBatch(
         quant_params.add(name, migraphx::argument(local_param_shapes[name], const_cast<void*>(input_tensor.GetTensorRawData())));
       }
     }
-  }
+  } */
 
   calibrate_and_quantize(prog, t, quant_params, fp16_enable, bf16_enable, int8_enable,
                         fp8_enable, int8_calibration_cache_available, dynamic_range_map);

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1582,10 +1582,10 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       std::vector<std::int64_t> input_shapes;
 
       if (no_input_shape) {
-        LOGS_DEFAULT(VERBOSE) << "[Compute] No static input shapes available, setting from runtime inputs";
+        LOGS_DEFAULT(INFO) << "[Compute] No static input shapes available, setting from runtime inputs";
         // NOTE: map_input_name_index only contains actual runtime inputs, not constants/initializers
         // Constants and initializers are embedded in the graph and MIGraphX infers their shapes
-        LOGS_DEFAULT(VERBOSE) << "[Compute] Setting shapes for " << map_input_name_index.size()
+        LOGS_DEFAULT(INFO) << "[Compute] Setting shapes for " << map_input_name_index.size()
                               << " runtime input parameters (excluding constants)";
 
         for (auto& it : map_input_name_index) {
@@ -1606,7 +1606,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
           // Log batch size and full shape for tracking dynamic shapes
           if (!tensor_shape.empty()) {
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Input parameter '" << name
+            LOGS_DEFAULT(INFO) << "[Compute] Input parameter '" << name
                                   << "' batch size (runtime override): " << tensor_shape[0];
 
             std::ostringstream shape_str;
@@ -1616,11 +1616,11 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
               shape_str << tensor_shape[i];
             }
             shape_str << "]";
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Input parameter '" << name << "' set as static shape: " << shape_str.str();
+            LOGS_DEFAULT(INFO) << "[Compute] Input parameter '" << name << "' set as static shape: " << shape_str.str();
           }
         }
-        LOGS_DEFAULT(VERBOSE) << "[Compute] All runtime input shapes set as static parameters in MIGraphX options";
-        LOGS_DEFAULT(VERBOSE) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
+        LOGS_DEFAULT(INFO) << "[Compute] All runtime input shapes set as static parameters in MIGraphX options";
+        LOGS_DEFAULT(INFO) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
       } else {
         LOGS_DEFAULT(VERBOSE) << "Assigning inputs, and parameters from compiled model";
         param_shapes = prog.get_parameter_shapes();
@@ -1648,13 +1648,13 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
               // Check if shapes match
               if (mgx_lens != ort_lens) {
-                LOGS_DEFAULT(VERBOSE) << "[Compute] Shape mismatch for input '" << name
+                LOGS_DEFAULT(INFO) << "[Compute] Shape mismatch for input '" << name
                                       << "': MIGraphX expects [" << mgx_lens.size() << " dims], "
                                       << "got [" << ort_lens.size() << " dims]";
 
                 // Check if it's specifically a batch size change
                 if (mgx_lens.size() == ort_lens.size() && mgx_lens.size() > 0 && mgx_lens[0] != ort_lens[0]) {
-                  LOGS_DEFAULT(VERBOSE) << "[Compute] Batch size changed from " << mgx_lens[0]
+                  LOGS_DEFAULT(INFO) << "[Compute] Batch size changed from " << mgx_lens[0]
                                         << " to " << ort_lens[0] << " for input '" << name << "'";
                 }
 
@@ -1665,7 +1665,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
               // Log batch size and full shape for tracking
               if (!tensor_shape.empty()) {
-                LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' batch size: " << tensor_shape[0];
+                LOGS_DEFAULT(INFO) << "[Compute] Input '" << name << "' batch size: " << tensor_shape[0];
 
                 // Log full shape for debugging symbolic dimensions
                 std::ostringstream shape_str;
@@ -1675,7 +1675,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
                   shape_str << tensor_shape[i];
                 }
                 shape_str << "]";
-                LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' full shape: " << shape_str.str();
+                LOGS_DEFAULT(INFO) << "[Compute] Input '" << name << "' full shape: " << shape_str.str();
               }
             }
           }
@@ -1685,7 +1685,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       // input shapes are different, needs to re-parse onnx and
       // re-compile the program
       if (!input_shape_match) {
-        LOGS_DEFAULT(VERBOSE) << "[Compute] Input shape mismatch detected, initiating recompilation";
+        LOGS_DEFAULT(INFO) << "[Compute] Input shape mismatch detected, initiating recompilation";
 
         std::filesystem::path model_cache_file;
         // empty cache path means the MXR caching is disabled - always compile
@@ -1711,21 +1711,21 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             shapes_str << input_shapes[i];
           }
           shapes_str << "]";
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Cache key input shapes (including updated batch): " << shapes_str.str();
+          LOGS_DEFAULT(INFO) << "[Compute] Cache key input shapes (including updated batch): " << shapes_str.str();
 
           auto cache_hash = make_hash(input_shapes);
           model_cache_file = mgx_state->model_cache_dir / (mxr_filename_prefix + cache_hash + ".mxr");
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Cache file with batch-aware hash: " << model_cache_file.string();
+          LOGS_DEFAULT(INFO) << "[Compute] Cache file with batch-aware hash: " << model_cache_file.string();
         }
 
         if (!load_precompiled_model(prog, model_cache_file)) {
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Cache miss. Compiling model with updated batch size";
+          LOGS_DEFAULT(INFO) << "[Compute] Cache miss. Compiling model with updated batch size";
 
           // CRITICAL: Ensure ALL input parameter shapes are explicitly set as static shapes in cmp_options
           // This must be done BEFORE parsing to treat dynamic shapes as static for compilation
           // NOTE: Only set shapes for actual runtime input parameters, NOT for constants/initializers
           // MIGraphX will automatically infer shapes for constants and intermediate tensors
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Setting " << map_input_name_index.size()
+          LOGS_DEFAULT(INFO) << "[Compute] Setting " << map_input_name_index.size()
                                 << " input parameter shapes as static in MIGraphX options (excluding constants)";
 
           for (auto& it : map_input_name_index) {
@@ -1740,7 +1740,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             // Only for actual input parameters - constants/initializers are handled by MIGraphX
             cmp_options.set_input_parameter_shape(name, ort_lens);
 
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Set static shape for input parameter '" << name << "': ["
+            LOGS_DEFAULT(INFO) << "[Compute] Set static shape for input parameter '" << name << "': ["
                                   << [&]() {
                                       std::ostringstream ss;
                                       for (size_t i = 0; i < ort_lens.size(); ++i) {
@@ -1750,21 +1750,21 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
                                       return ss.str();
                                     }() << "]";
           }
-          LOGS_DEFAULT(VERBOSE) << "[Compute] All input parameter shapes set as static";
-          LOGS_DEFAULT(VERBOSE) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
+          LOGS_DEFAULT(INFO) << "[Compute] All input parameter shapes set as static";
+          LOGS_DEFAULT(INFO) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
 
 #ifndef ENABLE_TRAINING_CORE
 #ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
           cmp_options.set_external_data_path(model_path_.parent_path().string());
 #endif
 #endif
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Parsing ONNX buffer with static input shapes";
+          LOGS_DEFAULT(INFO) << "[Compute] Parsing ONNX buffer with static input shapes";
           prog = migraphx::parse_onnx_buffer(onnx_string, cmp_options);
-          LOGS_DEFAULT(VERBOSE) << "[Compute] ONNX parsing complete";
+          LOGS_DEFAULT(INFO) << "[Compute] ONNX parsing complete";
 
           // Verify that MIGraphX parsed with correct shapes for input parameters
           auto parsed_param_shapes = prog.get_parameter_shapes();
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Verifying parsed parameter shapes ("
+          LOGS_DEFAULT(INFO) << "[Compute] Verifying parsed parameter shapes ("
                                 << parsed_param_shapes.size() << " total parameters):";
           for (auto&& param_name : parsed_param_shapes.names()) {
             auto shape = parsed_param_shapes[param_name];
@@ -1779,7 +1779,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
             // Distinguish between input parameters we set and constants MIGraphX inferred
             bool is_input_param = (map_input_name_index.count(param_name) > 0);
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Parameter '" << param_name << "' parsed shape: " << ss.str()
+            LOGS_DEFAULT(INFO) << "[Compute] Parameter '" << param_name << "' parsed shape: " << ss.str()
                                   << (is_input_param ? " (input parameter)" : " (constant/internal)");
           }
 
@@ -1811,11 +1811,11 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           compile_program(prog, t, exhaustive_tune_);
 
           // Save compiled model with batch-aware filename
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Saving compiled model with updated batch size to: "
+          LOGS_DEFAULT(INFO) << "[Compute] Saving compiled model with updated batch size to: "
                                 << model_cache_file.string();
           save_compiled_model(prog, model_cache_file);
         } else {
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Cache hit! Loaded precompiled model with matching batch size";
+          LOGS_DEFAULT(INFO) << "[Compute] Cache hit! Loaded precompiled model with matching batch size";
         }
 
         mgx_state->prog = prog;
@@ -1828,7 +1828,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       std::vector<std::size_t> prog_output_indices;
 
       // Log the output shapes from the compiled program to verify they match input batch
-      LOGS_DEFAULT(VERBOSE) << "[Compute] Program has " << prog_output_shapes.size() << " outputs:";
+      LOGS_DEFAULT(INFO) << "[Compute] Program has " << prog_output_shapes.size() << " outputs:";
       for (std::size_t i = 0; i < prog_output_shapes.size(); ++i) {
         auto out_lens = prog_output_shapes[i].lengths();
         std::ostringstream ss;
@@ -1838,7 +1838,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           ss << out_lens[j];
         }
         ss << "]";
-        LOGS_DEFAULT(VERBOSE) << "[Compute] Program output " << i << " shape: " << ss.str();
+        LOGS_DEFAULT(INFO) << "[Compute] Program output " << i << " shape: " << ss.str();
       }
 
       if (param_shapes.size() > 0) {
@@ -1886,7 +1886,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
               // Log output batch size for tracking
               if (!ort_output_shape.empty()) {
-                LOGS_DEFAULT(VERBOSE) << "[Compute] Output " << output_index << " ('" << name
+                LOGS_DEFAULT(INFO) << "[Compute] Output " << output_index << " ('" << name
                                       << "') allocated with shape: ["
                                       << [&]() {
                                           std::ostringstream ss;
@@ -1896,7 +1896,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
                                           }
                                           return ss.str();
                                         }() << "]";
-                LOGS_DEFAULT(VERBOSE) << "[Compute] Output " << output_index << " batch size: " << ort_output_shape[0];
+                LOGS_DEFAULT(INFO) << "[Compute] Output " << output_index << " batch size: " << ort_output_shape[0];
               }
 
               // argument shape
@@ -1913,9 +1913,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
         void* rocm_stream;
         Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &rocm_stream));
-        LOGS_DEFAULT(VERBOSE) << "[Compute] Executing MIGraphX program...";
+        LOGS_DEFAULT(INFO) << "[Compute] Executing MIGraphX program...";
         auto prog_outputs = prog.run_async(m, static_cast<hipStream_t>(rocm_stream));
-        LOGS_DEFAULT(VERBOSE) << "[Compute] Execution complete, got " << prog_outputs.size() << " outputs";
+        LOGS_DEFAULT(INFO) << "[Compute] Execution complete, got " << prog_outputs.size() << " outputs";
 
         // Verify actual output shapes match expectations
         for (std::size_t i = 0; i < prog_outputs.size(); ++i) {
@@ -1928,7 +1928,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             ss << actual_lens[j];
           }
           ss << "]";
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Actual output " << i << " shape after execution: " << ss.str()
+          LOGS_DEFAULT(INFO) << "[Compute] Actual output " << i << " shape after execution: " << ss.str()
                                 << (actual_lens.size() > 0 ? " (batch=" + std::to_string(actual_lens[0]) + ")" : "");
         }
 
@@ -1947,7 +1947,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
             // Log output batch size for tracking
             if (!ort_shape.empty()) {
-              LOGS_DEFAULT(VERBOSE) << "[Compute] Output " << i << " batch size: " << ort_shape[0];
+              LOGS_DEFAULT(INFO) << "[Compute] Output " << i << " batch size: " << ort_shape[0];
             }
 
             HIP_CALL_THROW(hipMemcpyWithStream(output_data,

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -165,7 +165,7 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
 
   // Overwrite initialized values with values from environment variables.
 
-  LOGS_DEFAULT(WARNING) << "[MIGraphX EP] MIGraphX ENV Override Variables Set:";
+  LOGS_DEFAULT(INFO) << "[MIGraphX EP] MIGraphX ENV Override Variables Set:";
   GET_ENV_BOOL(migraphx_env_vars::kFP16Enable, fp16_enable_);
 #if HIP_VERSION_MAJOR > 6 || (HIP_VERSION_MAJOR == 6 && (HIP_VERSION_MINOR > 4 || (HIP_VERSION_MINOR == 4 && HIP_VERSION_PATCH >= 2)))
   GET_ENV_BOOL(migraphx_env_vars::kBF16Enable, bf16_enable_);

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1764,55 +1764,38 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
   };
 
   if (param_shapes.size() > 0) {
-    for (auto&& name : param_shapes.names()) {
-      if (map_input_name_index.count(name) > 0) {
+    for (const auto& name : param_shapes.names()) {
+      auto it = map_input_name_index.find(name);
+      if (it != map_input_name_index.end()) {
         LOGS_DEFAULT(VERBOSE) << "Setting parameters for:" << name;
-        auto input_tensor = ctx.GetInput(map_input_name_index.at(name));
-        auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-        const auto tensor_shape = tensor_info.GetShape();
-        const auto tensor_type = tensor_info.GetElementType();
+        const auto& input_tensor = ctx.GetInput(it->second);
+        const auto& tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+        const auto& tensor_type = tensor_info.GetElementType();
 
-        migraphx_shape_datatype_t mgx_type;
-        getMIGraphXType(tensor_type, mgx_type);
-        auto mgx_s = param_shapes[name];
+        migraphx_shape_datatype_t mgx_current_type;
+        getMIGraphXType(tensor_type, mgx_current_type);
+        const auto& mgx_s = param_shapes[name];
 
-        if (mgx_type != mgx_s.type()) {
-          LOGS_DEFAULT(FATAL) << "MIGraphX: param type mismatch";
+        if (mgx_current_type != mgx_s.type()) {
+          LOGS_DEFAULT(FATAL) << "MIGraphX: param type mismatch for" << name;
         }
 
         LOGS_DEFAULT(VERBOSE) << "Writing Raw tensor data ";
-        m.add(name, migraphx::argument(param_shapes[name],
+        m.add(name, migraphx::argument(mgx_s,
                                        const_cast<void*>(input_tensor.GetTensorRawData())));
       }
       // It is an output argument
       else {
-        int output_index = compute_output_index(name);
+        const auto output_index = compute_output_index(name);
         if (output_index != -1) {
           prog_output_indices.push_back(static_cast<std::size_t>(output_index));
-          auto mgx_output_shape = prog_output_shapes[output_index];
-          auto lens = mgx_output_shape.lengths();
-          std::vector<int64_t> ort_output_shape(lens.begin(), lens.end());
+          const auto& mgx_output_shape = prog_output_shapes[output_index];
+          const auto& lens = mgx_output_shape.lengths();
+          const std::vector<int64_t> ort_output_shape(lens.begin(), lens.end());
           auto output_tensor = ctx.GetOutput(output_index, ort_output_shape.data(), ort_output_shape.size());
-          void* output_data = output_tensor.GetTensorMutableRawData();
-
-          // Log output batch size for tracking
-          if (!ort_output_shape.empty()) {
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Output " << output_index << " ('" << name
-                                  << "') allocated with shape: ["
-                                  << [&]() {
-                                      std::ostringstream ss;
-                                      for (size_t j = 0; j < ort_output_shape.size(); ++j) {
-                                        if (j > 0) ss << ", ";
-                                        ss << ort_output_shape[j];
-                                      }
-                                      return ss.str();
-                                    }() << "]";
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Output " << output_index << " batch size: " << ort_output_shape[0];
-          }
-
-          // argument shape
-          auto mgx_arg_shape = param_shapes[name];
-          m.add(name, migraphx::argument(mgx_arg_shape, output_data));
+          const void* output_data = output_tensor.GetTensorMutableRawData();
+          const auto& mgx_arg_shape = param_shapes[name];
+          m.add(name, migraphx::argument(mgx_arg_shape, const_cast<void*>(output_data)));
         }
       }
     }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -2185,31 +2185,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     migraphx::program prog;
 
     if (!defer_compilation) {
-      if (!load_precompiled_model(prog, model_cache_file)) {
-        LOGS_DEFAULT(VERBOSE) << "[Compile] Cache miss. Compiling model with batch size included in shapes";
-        LOGS_DEFAULT(VERBOSE) << "[Compile] Model cache file will be: " << model_cache_file.string();
-
-        // Compile using the helper function (shapes already set in options)
-        // No runtime context available during initial compile - pass nullptr
-        prog = CompileProgramWithBatch(
-            onnx_string_buffer,
-            options,
-            t_,
-            fp16_enable_,
-            bf16_enable_,
-            int8_enable_,
-            fp8_enable_,
-            int8_calibration_cache_available_,
-            dynamic_range_map_,
-            exhaustive_tune_,
-            model_path_);
-
-        LOGS_DEFAULT(VERBOSE) << "[Compile] Saving compiled model to cache: " << model_cache_file.string();
-        save_compiled_model(prog, model_cache_file);
-        LOGS_DEFAULT(VERBOSE) << "[Compile] Model saved successfully with batch-aware filename";
-      } else {
-        LOGS_DEFAULT(VERBOSE) << "[Compile] Cache hit! Loaded precompiled model from: " << model_cache_file.string();
-      }
+      prog = load_or_compile_model(model_cache_file, onnx_string_buffer, options, t_,
+                                   fp16_enable_, bf16_enable_, int8_enable_, fp8_enable_,
+                                   int8_calibration_cache_available_, dynamic_range_map_, exhaustive_tune_, model_path_);
 
       // NOTE: DO NOT set output shapes as input parameters!
       // Outputs are dynamically inferred by MIGraphX based on input shapes

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1184,23 +1184,29 @@ static std::pair<std::vector<std::string>, std::vector<std::string>> get_io_name
 // Useful to default to EP to trigger the compile if file doesn't exist or loading fails.
 bool load_precompiled_model(migraphx::program& prog, const std::filesystem::path& path) try {
   if (!path.empty() && exists(path)) {
-    LOGS_DEFAULT(VERBOSE) << "Attempting to load model at:" << path.string();
+    LOGS_DEFAULT(WARNING) << "[load_precompiled_model] Attempting to load model from disk: " << path.string();
     prog = migraphx::load(path.string().c_str());
-    LOGS_DEFAULT(VERBOSE) << "load model : Success";
+    LOGS_DEFAULT(WARNING) << "[load_precompiled_model] ✓ Successfully loaded model from disk";
     return true;
   }
+  LOGS_DEFAULT(WARNING) << "[load_precompiled_model] Cache file does not exist: " 
+                        << (path.empty() ? "(no path specified)" : path.string());
+  return false;
+} catch (const std::exception& e) {
+  LOGS_DEFAULT(WARNING) << "[load_precompiled_model] ✗ Failed to load model from disk: " << e.what();
   return false;
 } catch (...) {
+  LOGS_DEFAULT(WARNING) << "[load_precompiled_model] ✗ Failed to load model from disk (unknown exception)";
   return false;
 }
 
 void save_compiled_model(const migraphx::program& prog, const std::filesystem::path& path) {
   if (!path.empty()) {
-    LOGS_DEFAULT(VERBOSE) << "Model Save at " << path.string() << ": Begin";
+    LOGS_DEFAULT(WARNING) << "[save_compiled_model] Saving compiled model to disk: " << path.string();
     migraphx::file_options fo;
     fo.set_file_format("msgpack");
     save(prog, path.string().c_str(), fo);
-    LOGS_DEFAULT(VERBOSE) << "Model Save: Complete";
+    LOGS_DEFAULT(WARNING) << "[save_compiled_model] ✓ Model saved successfully";
   }
 }
 
@@ -1593,12 +1599,18 @@ static migraphx::program load_or_compile_model(
 {
   migraphx::program prog;
 
+  LOGS_DEFAULT(WARNING) << "[load_or_compile_model] ==== ENTERING ====";
+  LOGS_DEFAULT(WARNING) << "[load_or_compile_model] Cache file: " << (cache_file.empty() ? "(none)" : cache_file.string());
+  LOGS_DEFAULT(WARNING) << "[load_or_compile_model] Batch size: " << (batch_size > 0 ? std::to_string(batch_size) : "(default)");
+
   if (!load_precompiled_model(prog, cache_file)) {
+    // Cache miss - need to compile
     if (batch_size > 0) {
-      LOGS_DEFAULT(VERBOSE) << "[LoadOrCompile] Cache miss for batch size " << batch_size << ", compiling...";
+      LOGS_DEFAULT(WARNING) << "[load_or_compile_model] ✗ CACHE MISS for batch size " << batch_size << " - COMPILING...";
     } else {
-      LOGS_DEFAULT(VERBOSE) << "[LoadOrCompile] Cache miss, compiling...";
+      LOGS_DEFAULT(WARNING) << "[load_or_compile_model] ✗ CACHE MISS - COMPILING...";
     }
+    LOGS_DEFAULT(WARNING) << "[load_or_compile_model] Compilation started (this may take a while)...";
 
     prog = CompileProgramWithBatch(
         onnx_string,
@@ -1618,18 +1630,23 @@ static migraphx::program load_or_compile_model(
         all_input_base_shapes,
         batch_size);
 
+    LOGS_DEFAULT(WARNING) << "[load_or_compile_model] Compilation finished";
+    
     save_compiled_model(prog, cache_file);
     if (!cache_file.empty()) {
-      LOGS_DEFAULT(VERBOSE) << "[LoadOrCompile] Saved compiled model to: " << cache_file.string();
+      LOGS_DEFAULT(WARNING) << "[load_or_compile_model] Saved compiled model to disk: " << cache_file.string();
     }
   } else {
+    // Cache hit - loaded from disk
     if (batch_size > 0) {
-      LOGS_DEFAULT(VERBOSE) << "[LoadOrCompile] Cache hit for batch size " << batch_size;
+      LOGS_DEFAULT(WARNING) << "[load_or_compile_model] ✓ CACHE HIT - LOADING FROM DISK for batch size " << batch_size;
     } else {
-      LOGS_DEFAULT(VERBOSE) << "[LoadOrCompile] Cache hit! Loaded from: " << cache_file.string();
+      LOGS_DEFAULT(WARNING) << "[load_or_compile_model] ✓ CACHE HIT - LOADING FROM DISK";
     }
+    LOGS_DEFAULT(WARNING) << "[load_or_compile_model] Loaded precompiled model from: " << cache_file.string();
   }
 
+  LOGS_DEFAULT(WARNING) << "[load_or_compile_model] ==== EXITING ====";
   return prog;
 }
 
@@ -1660,19 +1677,139 @@ static void run_migraphx_program(
   bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 && 
                         original_batch_size < padded_batch_size);
 
+  LOGS_DEFAULT(WARNING) << "[run_migraphx_program] ==== ENTERING ====";
   LOGS_DEFAULT(WARNING) << "[run_migraphx_program] original_batch_size=" << original_batch_size 
                         << ", padded_batch_size=" << padded_batch_size 
                         << ", needs_slicing=" << needs_slicing;
+  LOGS_DEFAULT(WARNING) << "[run_migraphx_program] prog_output_indices.size()=" << prog_output_indices.size();
+  if (!prog_output_indices.empty()) {
+    std::ostringstream ss;
+    ss << "[";
+    for (size_t i = 0; i < prog_output_indices.size(); ++i) {
+      if (i > 0) ss << ", ";
+      ss << prog_output_indices[i];
+    }
+    ss << "]";
+    LOGS_DEFAULT(WARNING) << "[run_migraphx_program] prog_output_indices=" << ss.str();
+  }
 
-  // In case of input parameters are reused as output parameter call hipMemcpy
+  // Process ALL outputs for proper slicing when needed
   auto output_num = prog_outputs->size();
-  LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Number of outputs: " << output_num;
+  LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Number of MIGraphX outputs: " << output_num;
   
-  if (prog_output_indices.size() < output_num) {
-    std::unordered_set<std::size_t> prog_output_indices_set(prog_output_indices.begin(), prog_output_indices.end());
+  std::unordered_set<std::size_t> prog_output_indices_set(prog_output_indices.begin(), prog_output_indices.end());
+  std::vector<std::size_t> outputs_to_copy;  // Outputs that need memcpy (not pre-allocated)
+  
+  for (std::size_t i = 0; i < output_num; ++i) {
+    if (prog_output_indices_set.count(i) == 0) {
+      outputs_to_copy.push_back(i);
+    }
+  }
+  
+  LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Pre-allocated outputs (in prog_output_indices): " 
+                        << prog_output_indices_set.size();
+  LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Outputs to copy (not pre-allocated): " 
+                        << outputs_to_copy.size();
+  
+  // First, handle pre-allocated outputs (need slicing but were already bound)
+  // NOTE: This is a problematic state! Pre-allocated outputs should NOT exist when slicing is needed.
+  // The proper solution is to use temp buffers in handle_program_input_outputs when needs_slicing=true.
+  // This code handles the case defensively by copying sliced data to newly allocated ORT outputs.
+  if (needs_slicing && !prog_output_indices_set.empty()) {
+    LOGS_DEFAULT(WARNING) << "[run_migraphx_program] ⚠️  WARNING: Handling " << prog_output_indices_set.size() 
+                         << " pre-allocated outputs with slicing";
+    LOGS_DEFAULT(WARNING) << "[run_migraphx_program] ⚠️  This indicates handle_program_input_outputs did NOT use temp buffers!";
+    LOGS_DEFAULT(WARNING) << "[run_migraphx_program] ⚠️  Pre-allocated outputs should be empty when slicing is needed.";
+    
     for (std::size_t i = 0; i < output_num; ++i) {
-      if (prog_output_indices_set.count(i) > 0)
-        continue;
+      if (prog_output_indices_set.count(i) > 0) {
+        // This output was pre-allocated with padded shape - need to copy sliced data
+        auto gpu_res = (*prog_outputs)[i];
+        migraphx::shape res_shape = gpu_res.get_shape();
+        auto res_lens = res_shape.lengths();
+        
+        LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Pre-allocated output " << i 
+                             << " MIGraphX shape: [" << [&]() {
+          std::ostringstream ss;
+          for (size_t j = 0; j < res_lens.size(); ++j) {
+            if (j > 0) ss << ", ";
+            ss << res_lens[j];
+          }
+          return ss.str();
+        }() << "]";
+        
+        // Create sliced shape for ORT output
+        std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
+        if (!ort_shape.empty() && static_cast<std::size_t>(ort_shape[0]) != original_batch_size) {
+          ort_shape[0] = static_cast<int64_t>(original_batch_size);
+          
+          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Slicing pre-allocated output " << i 
+                               << " from batch size " << padded_batch_size << " to " << original_batch_size;
+          
+          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Output " << i << " ORT shape (after slicing): [" << [&]() {
+            std::ostringstream ss;
+            for (size_t j = 0; j < ort_shape.size(); ++j) {
+              if (j > 0) ss << ", ";
+              ss << ort_shape[j];
+            }
+            return ss.str();
+          }() << "]";
+          
+          // Calculate bytes to copy (sliced portion only)
+          std::size_t bytes_per_batch = res_shape.bytes() / padded_batch_size;
+          std::size_t bytes_to_copy = bytes_per_batch * original_batch_size;
+          
+          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Bytes per batch: " << bytes_per_batch
+                               << ", total bytes to copy: " << bytes_to_copy;
+          
+          // Allocate temp buffer for sliced data on GPU
+          void* temp_sliced_buffer = nullptr;
+          auto hip_status = hipMalloc(&temp_sliced_buffer, bytes_to_copy);
+          if (hip_status != hipSuccess) {
+            LOGS_DEFAULT(ERROR) << "[run_migraphx_program] hipMalloc failed for sliced output buffer!";
+            ORT_THROW("hipMalloc failed for sliced output buffer");
+          }
+          
+          // Copy sliced data from MIGraphX output to temp buffer
+          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Copying sliced data to temp buffer...";
+          HIP_CALL_THROW(hipMemcpyWithStream(temp_sliced_buffer,
+                                             gpu_res.data(),
+                                             bytes_to_copy,
+                                             hipMemcpyDeviceToDevice,
+                                             static_cast<hipStream_t>(rocm_stream)));
+          
+          // Synchronize to ensure copy is complete before allocating ORT output
+          HIP_CALL_THROW(hipStreamSynchronize(static_cast<hipStream_t>(rocm_stream)));
+          
+          // Now allocate the ORT output tensor with the SLICED shape
+          // This should work because we're allocating fresh (not re-using the padded buffer)
+          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Allocating ORT output with sliced shape...";
+          auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
+          void* output_data = output_tensor.GetTensorMutableRawData();
+          
+          // Copy from temp buffer to ORT output
+          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Copying from temp buffer to ORT output...";
+          HIP_CALL_THROW(hipMemcpyWithStream(output_data,
+                                             temp_sliced_buffer,
+                                             bytes_to_copy,
+                                             hipMemcpyDeviceToDevice,
+                                             static_cast<hipStream_t>(rocm_stream)));
+          
+          // Free temporary buffer
+          hipFree(temp_sliced_buffer);
+          
+          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] ✓ Successfully sliced pre-allocated output " << i;
+        } else {
+          // No slicing needed for this output (batch dimension matches)
+          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Output " << i << " batch dim already matches, no slicing needed";
+        }
+      }
+    }
+  }
+  
+  // Now handle outputs that need memcpy (not pre-allocated)
+  if (prog_output_indices.size() < output_num) {
+    for (std::size_t i : outputs_to_copy) {
       auto gpu_res = (*prog_outputs)[i];
       migraphx::shape res_shape = gpu_res.get_shape();
       auto res_lens = res_shape.lengths();
@@ -1850,22 +1987,36 @@ static int compute_output_index(const std::string_view sv) {
 
 // Overload: Handle program inputs and outputs binding with pre-cached output shapes
 // This avoids calling prog.get_output_shapes() when shapes are already cached
+// When needs_slicing is true, allocates temporary GPU buffers for outputs instead of binding directly
 static
 std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program_input_outputs(
     const migraphx::program_parameter_shapes& param_shapes,
     const migraphx::shapes& output_shapes,
     const std::unordered_map<std::string, std::size_t>& map_input_name_index,
-    const Ort::KernelContext& ctx)
+    const Ort::KernelContext& ctx,
+    bool needs_slicing = false,
+    std::vector<void*>* temp_output_buffers = nullptr)
 {
+  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] ==== ENTERING ====";
+  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] needs_slicing=" << needs_slicing 
+                        << ", temp_output_buffers=" << (temp_output_buffers != nullptr ? "valid" : "nullptr");
+  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] param_shapes.size()=" << param_shapes.size()
+                        << ", output_shapes.size()=" << output_shapes.size();
+  
   migraphx::program_parameters m;
   std::vector<std::size_t> prog_output_indices;
   prog_output_indices.reserve(output_shapes.size());
+
+  std::size_t input_count = 0;
+  std::size_t output_count = 0;
+  std::size_t temp_buffer_count = 0;
 
   if (param_shapes.size() > 0) {
     for (const auto& name : param_shapes.names()) {
       auto it = map_input_name_index.find(name);
       if (it != map_input_name_index.end()) {
         // Input parameter
+        input_count++;
         const auto& input_tensor = ctx.GetInput(it->second);
         const auto& mgx_s = param_shapes[name];
         m.add(name, migraphx::argument(mgx_s,
@@ -1874,27 +2025,69 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
         // Output parameter
         const auto output_index = compute_output_index(name);
         if (output_index != -1) {
-          prog_output_indices.push_back(static_cast<std::size_t>(output_index));
-          const auto& lens = output_shapes[output_index].lengths();
-          const std::vector<int64_t> ort_output_shape(lens.begin(), lens.end());
-          auto output_tensor = ctx.GetOutput(output_index, ort_output_shape.data(), ort_output_shape.size());
+          output_count++;
           const auto& mgx_arg_shape = param_shapes[name];
-          m.add(name, migraphx::argument(mgx_arg_shape, output_tensor.GetTensorMutableRawData()));
+          
+          LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] Processing output '" << name 
+                                << "' (index=" << output_index << ")"
+                                << ", needs_slicing=" << needs_slicing 
+                                << ", temp_output_buffers=" << (temp_output_buffers != nullptr ? "valid" : "nullptr");
+          
+          if (needs_slicing && temp_output_buffers != nullptr) {
+            // When slicing, allocate temporary GPU buffer for padded output
+            // Don't add to prog_output_indices since these aren't pre-allocated ORT outputs
+            std::size_t output_size_bytes = mgx_arg_shape.bytes();
+            void* temp_buffer = nullptr;
+            auto hip_status = hipMalloc(&temp_buffer, output_size_bytes);
+            if (hip_status != hipSuccess) {
+              ORT_THROW("hipMalloc failed for temporary output buffer");
+            }
+            temp_output_buffers->push_back(temp_buffer);
+            temp_buffer_count++;
+            m.add(name, migraphx::argument(mgx_arg_shape, temp_buffer));
+            LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] ✓ Allocated TEMP BUFFER for output " 
+                                  << output_index << " '" << name << "' (" << output_size_bytes << " bytes)"
+                                  << " - NOT adding to prog_output_indices";
+          } else {
+            // Normal path: bind directly to ORT output tensor
+            LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] Using NORMAL PATH for output " 
+                                  << output_index << " '" << name << "'"
+                                  << " - adding to prog_output_indices";
+            prog_output_indices.push_back(static_cast<std::size_t>(output_index));
+            const auto& lens = output_shapes[output_index].lengths();
+            const std::vector<int64_t> ort_output_shape(lens.begin(), lens.end());
+            auto output_tensor = ctx.GetOutput(output_index, ort_output_shape.data(), ort_output_shape.size());
+            m.add(name, migraphx::argument(mgx_arg_shape, output_tensor.GetTensorMutableRawData()));
+          }
         }
       }
     }
   }
+  
+  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] ==== SUMMARY ====";
+  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] Processed " << input_count << " inputs, " 
+                        << output_count << " outputs";
+  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] Temp buffers allocated: " << temp_buffer_count;
+  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] prog_output_indices.size()=" << prog_output_indices.size();
+  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] ==== EXITING ====";
+  
   return {m, prog_output_indices};
 }
 
 // Helper: Populate optimized caches for ultra-fast path
 // This separates inputs from outputs, pre-computes indices, and pre-allocates output shapes
+// When slicing is needed, stores sliced output shapes instead of padded shapes
 static void populate_ultra_fast_caches(
     MIGraphXFuncState* mgx_state,
     const migraphx::program_parameter_shapes& param_shapes,
     const migraphx::shapes& output_shapes,
-    const std::unordered_map<std::string, std::size_t>& map_input_name_index)
+    const std::unordered_map<std::string, std::size_t>& map_input_name_index,
+    std::size_t original_batch_size = 0,
+    std::size_t padded_batch_size = 0)
 {
+  bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 && 
+                        original_batch_size < padded_batch_size);
+  
   // Clear existing caches
   mgx_state->cached_inputs.clear();
   mgx_state->cached_outputs.clear();
@@ -1919,19 +2112,69 @@ static void populate_ultra_fast_caches(
         // This is an output parameter
         const int output_index = compute_output_index(name);
         if (output_index != -1) {
-          MIGraphXFuncState::CachedOutputParam out;
-          out.name = name;
-          out.output_index = output_index;
-          out.mgx_shape = param_shapes[name];
-          mgx_state->cached_outputs.push_back(std::move(out));
+          // When slicing, don't cache outputs (ultra-fast path won't be used)
+          if (!needs_slicing) {
+            MIGraphXFuncState::CachedOutputParam out;
+            out.name = name;
+            out.output_index = output_index;
+            out.mgx_shape = param_shapes[name];
+            mgx_state->cached_outputs.push_back(std::move(out));
 
-          // Pre-allocate ORT-format output shape vector
-          const auto& lens = output_shapes[output_index].lengths();
-          mgx_state->cached_output_ort_shapes.emplace_back(lens.begin(), lens.end());
+            // Pre-allocate ORT-format output shape vector
+            const auto& lens = output_shapes[output_index].lengths();
+            mgx_state->cached_output_ort_shapes.emplace_back(lens.begin(), lens.end());
+          }
         }
       }
     }
   }
+}
+
+// Helper: Build input shapes vector in cached_inputs order (MIGraphX parameter order)
+// This ensures consistency between how shapes are stored and how they're compared in ultra-fast path
+static std::vector<std::int64_t> build_input_shapes_in_cached_order(
+    MIGraphXFuncState* mgx_state,
+    Ort::KernelContext& ctx,
+    std::size_t padded_batch_size = 0)
+{
+  std::vector<std::int64_t> shapes;
+  shapes.reserve(mgx_state->cached_inputs.size() * 4);  // Estimate average 4 dims per input
+  
+  LOGS_DEFAULT(WARNING) << "[build_input_shapes_in_cached_order] Building shapes in cached_inputs order";
+  LOGS_DEFAULT(WARNING) << "[build_input_shapes_in_cached_order] cached_inputs.size()=" << mgx_state->cached_inputs.size()
+                        << ", padded_batch_size=" << padded_batch_size;
+  
+  // Log first few input names to verify ordering
+  if (mgx_state->cached_inputs.size() > 0) {
+    std::ostringstream input_order_ss;
+    input_order_ss << "[build_input_shapes_in_cached_order] Input order (first 5): ";
+    for (size_t i = 0; i < std::min(mgx_state->cached_inputs.size(), static_cast<size_t>(5)); ++i) {
+      if (i > 0) input_order_ss << ", ";
+      input_order_ss << mgx_state->cached_inputs[i].name;
+    }
+    if (mgx_state->cached_inputs.size() > 5) input_order_ss << ", ...";
+    LOGS_DEFAULT(WARNING) << input_order_ss.str();
+  }
+  
+  for (const auto& cached_inp : mgx_state->cached_inputs) {
+    auto input_tensor = ctx.GetInput(cached_inp.ort_index);
+    auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+    const auto tensor_shape = tensor_info.GetShape();
+    
+    if (!tensor_shape.empty()) {
+      if (padded_batch_size > 0) {
+        // Use padded batch size for first dimension
+        shapes.push_back(static_cast<std::int64_t>(padded_batch_size));
+        shapes.insert(shapes.end(), tensor_shape.begin() + 1, tensor_shape.end());
+      } else {
+        // Use original shape
+        shapes.insert(shapes.end(), tensor_shape.begin(), tensor_shape.end());
+      }
+    }
+  }
+  
+  LOGS_DEFAULT(WARNING) << "[build_input_shapes_in_cached_order] Built " << shapes.size() << " shape dimensions";
+  return shapes;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1950,15 +2193,36 @@ static bool execute_ultra_fast_path(
   LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] caches_valid = " << mgx_state->caches_valid;
   LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] last_input_shapes_raw.size() = " 
                         << mgx_state->last_input_shapes_raw.size();
+  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] cached_outputs.size() = " 
+                        << mgx_state->cached_outputs.size();
   
   if (!mgx_state->caches_valid || mgx_state->last_input_shapes_raw.empty()) {
     LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Caches not valid or empty - skipping";
+    return false;
+  }
+  
+  // Ultra-fast path not supported when outputs need dynamic slicing
+  if (mgx_state->cached_outputs.empty()) {
+    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] No cached outputs (slicing mode) - skipping";
     return false;
   }
 
   // Quick shape comparison
   LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Performing shape comparison";
   LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Number of cached inputs: " << mgx_state->cached_inputs.size();
+  
+  // Log first few input names to verify ordering consistency
+  if (mgx_state->cached_inputs.size() > 0) {
+    std::ostringstream input_order_ss;
+    input_order_ss << "[ULTRA_FAST_PATH] Input order (first 5): ";
+    for (size_t i = 0; i < std::min(mgx_state->cached_inputs.size(), static_cast<size_t>(5)); ++i) {
+      if (i > 0) input_order_ss << ", ";
+      input_order_ss << mgx_state->cached_inputs[i].name;
+    }
+    if (mgx_state->cached_inputs.size() > 5) input_order_ss << ", ...";
+    LOGS_DEFAULT(WARNING) << input_order_ss.str();
+  }
+  
   bool shapes_match = true;
   std::size_t offset = 0;
   const auto& last_shapes = mgx_state->last_input_shapes_raw;
@@ -2265,18 +2529,12 @@ static bool execute_fast_path(
   auto param_shapes = prog.get_parameter_shapes();
   auto output_shapes = prog.get_output_shapes();
 
-  // Populate optimized caches for ultra-fast path
-  populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
-
-  // Bind inputs/outputs
-  auto [m, prog_output_indices] = handle_program_input_outputs(
-      param_shapes, output_shapes, map_input_name_index, ctx);
-
-  mgx_state->cached_prog_params = std::move(m);
-  mgx_state->cached_prog_output_indices = std::move(prog_output_indices);
-  mgx_state->last_input_shapes_raw = std::move(all_input_shapes);
-  mgx_state->last_input_shape_hash = current_hash;
-  mgx_state->caches_valid = true;
+  bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 && 
+                        original_batch_size < padded_batch_size);
+  
+  // Populate optimized caches for ultra-fast path (disabled when slicing)
+  populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index,
+                            original_batch_size, padded_batch_size);
 
   // Allocate and pad inputs if needed for dynamic batching
   bool using_padded_inputs = false;
@@ -2286,16 +2544,42 @@ static bool execute_fast_path(
     auto rocm_stream = static_cast<hipStream_t>(rocm_stream_ptr);
     using_padded_inputs = allocate_and_pad_inputs(mgx_state, ctx, original_batch_size, 
                                                   padded_batch_size, rocm_stream);
-    
-    // Rebind padded inputs to program parameters
-    if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
-      LOGS_DEFAULT(WARNING) << "[FAST_PATH] Rebinding padded input buffers";
-      auto& prog_params = mgx_state->cached_prog_params.value();
-      for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
-        const auto& inp = mgx_state->cached_inputs[i];
-        const auto& padded_buf = mgx_state->padded_input_buffers[i];
-        prog_params.add(inp.name.c_str(), migraphx::argument(padded_buf.mgx_shape, padded_buf.data));
-      }
+  }
+
+  // Bind inputs/outputs (use temp buffers for outputs when slicing)
+  LOGS_DEFAULT(WARNING) << "[FAST_PATH] Calling handle_program_input_outputs with needs_slicing=" << needs_slicing;
+  std::vector<void*> temp_output_buffers;
+  auto [m, prog_output_indices] = handle_program_input_outputs(
+      param_shapes, output_shapes, map_input_name_index, ctx, needs_slicing, &temp_output_buffers);
+
+  LOGS_DEFAULT(WARNING) << "[FAST_PATH] handle_program_input_outputs returned:";
+  LOGS_DEFAULT(WARNING) << "[FAST_PATH]   prog_output_indices.size()=" << prog_output_indices.size();
+  LOGS_DEFAULT(WARNING) << "[FAST_PATH]   temp_output_buffers.size()=" << temp_output_buffers.size();
+  if (needs_slicing && !prog_output_indices.empty()) {
+    LOGS_DEFAULT(WARNING) << "[FAST_PATH]   ⚠️  WARNING: prog_output_indices is NOT empty with slicing enabled!";
+  }
+
+  mgx_state->cached_prog_params = std::move(m);
+  mgx_state->cached_prog_output_indices = std::move(prog_output_indices);
+  
+  // IMPORTANT: Build last_input_shapes_raw in cached_inputs order (MIGraphX parameter order)
+  // This ensures ultra-fast path shape comparison uses consistent ordering
+  mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(
+      mgx_state, ctx, using_padded_inputs ? padded_batch_size : 0);
+  LOGS_DEFAULT(WARNING) << "[FAST_PATH] Built last_input_shapes_raw in cached_inputs order, size=" 
+                        << mgx_state->last_input_shapes_raw.size();
+  
+  mgx_state->last_input_shape_hash = current_hash;
+  mgx_state->caches_valid = true;
+
+  // Rebind padded inputs to program parameters
+  if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
+    LOGS_DEFAULT(WARNING) << "[FAST_PATH] Rebinding padded input buffers";
+    auto& prog_params = mgx_state->cached_prog_params.value();
+    for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
+      const auto& inp = mgx_state->cached_inputs[i];
+      const auto& padded_buf = mgx_state->padded_input_buffers[i];
+      prog_params.add(inp.name.c_str(), migraphx::argument(padded_buf.mgx_shape, padded_buf.data));
     }
   }
 
@@ -2305,6 +2589,13 @@ static bool execute_fast_path(
                        mgx_state->cached_prog_params.value(),
                        mgx_state->cached_prog_output_indices,
                        original_batch_size, padded_batch_size);
+  
+  // Free temporary output buffers
+  for (void* buf : temp_output_buffers) {
+    if (buf != nullptr) {
+      hipFree(buf);
+    }
+  }
   
   // Free padded buffers after execution
   if (using_padded_inputs) {
@@ -2619,8 +2910,14 @@ static void execute_standard_path(
       }
     }
     
-    if (needs_padding && padded_batch_size > 0) {
-      LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Building padded shape key for cache lookup";
+    // We need to fetch from cache whether padding is needed or not
+    // Even when batch size matches exactly, we still use cached compiled programs
+    if (padded_batch_size > 0) {
+      if (needs_padding) {
+        LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Building padded shape key for cache lookup (needs padding)";
+      } else {
+        LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Building shape key for cache lookup (exact match, no padding)";
+      }
       // Update the shape hash and all_input_shapes to use the padded batch size
       std::vector<std::int64_t> padded_shapes;
       padded_shapes.reserve(all_input_shapes.size());
@@ -2648,74 +2945,135 @@ static void execute_standard_path(
                           << cached_progs.size() << ")";
         auto prog_it = cached_progs.find(padded_hash);
         if (prog_it != cached_progs.end()) {
-          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] ✓✓✓ CACHE HIT for padded batch size " 
-                             << padded_batch_size;
+          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] ✓✓✓ CACHE HIT for batch size " 
+                             << padded_batch_size << (needs_padding ? " (will pad)" : " (exact match, no padding)");
           prog = prog_it->second;
           
-          // Get shapes for the padded program
+          // Get shapes for the cached program
           auto param_shapes = prog.get_parameter_shapes();
           auto output_shapes = prog.get_output_shapes();
           
-          // Populate caches
-          populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
+          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Cached program param_shapes.size()=" 
+                               << param_shapes.size() << ", output_shapes.size()=" << output_shapes.size();
           
-          // Rebuild padded_shapes in cached_inputs order (MIGraphX parameter order)
-          // This ensures consistency with ultra-fast path shape comparison
-          padded_shapes.clear();
-          padded_shapes.reserve(mgx_state->cached_inputs.size() * 2);
-          for (const auto& cached_inp : mgx_state->cached_inputs) {
-            auto input_tensor = ctx.GetInput(cached_inp.ort_index);
-            auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-            const auto tensor_shape = tensor_info.GetShape();
+          if (needs_padding) {
+            // ============ PADDING PATH: Batch size needs to be padded ============
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Taking PADDING path";
             
-            if (!tensor_shape.empty()) {
-              padded_shapes.push_back(static_cast<std::int64_t>(padded_batch_size));
-              padded_shapes.insert(padded_shapes.end(), tensor_shape.begin() + 1, tensor_shape.end());
+            // Populate caches (with slicing info so ultra-fast path is disabled)
+            populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index,
+                                      original_batch_size, padded_batch_size);
+            
+            // Rebuild padded_shapes in cached_inputs order (MIGraphX parameter order)
+            // This ensures consistency with ultra-fast path shape comparison
+            padded_shapes.clear();
+            padded_shapes.reserve(mgx_state->cached_inputs.size() * 2);
+            for (const auto& cached_inp : mgx_state->cached_inputs) {
+              auto input_tensor = ctx.GetInput(cached_inp.ort_index);
+              auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+              const auto tensor_shape = tensor_info.GetShape();
+              
+              if (!tensor_shape.empty()) {
+                padded_shapes.push_back(static_cast<std::int64_t>(padded_batch_size));
+                padded_shapes.insert(padded_shapes.end(), tensor_shape.begin() + 1, tensor_shape.end());
+              }
             }
-          }
-          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Rebuilt padded_shapes in cached_inputs order";
-          
-          // Bind inputs and outputs
-          auto [m, prog_output_indices] = handle_program_input_outputs(
-              param_shapes, output_shapes, map_input_name_index, ctx);
-          
-          mgx_state->cached_prog_params = m;
-          mgx_state->cached_prog_output_indices = prog_output_indices;
-          mgx_state->last_input_shapes_raw = std::move(padded_shapes);
-          mgx_state->last_input_shape_hash = padded_hash;
-          mgx_state->caches_valid = true;
-          
-          // Allocate and pad inputs for dynamic batching
-          void* rocm_stream_ptr;
-          Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &rocm_stream_ptr));
-          auto rocm_stream = static_cast<hipStream_t>(rocm_stream_ptr);
-          bool using_padded_inputs = allocate_and_pad_inputs(mgx_state, ctx, original_batch_size, 
-                                                             padded_batch_size, rocm_stream);
-          
-          // Rebind padded inputs to program parameters
-          if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Rebinding padded input buffers";
-            for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
-              const auto& inp = mgx_state->cached_inputs[i];
-              const auto& padded_buf = mgx_state->padded_input_buffers[i];
-              m.add(inp.name.c_str(), migraphx::argument(padded_buf.mgx_shape, padded_buf.data));
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Rebuilt padded_shapes in cached_inputs order";
+            
+            // Allocate and pad inputs for dynamic batching
+            void* rocm_stream_ptr;
+            Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &rocm_stream_ptr));
+            auto rocm_stream = static_cast<hipStream_t>(rocm_stream_ptr);
+            bool using_padded_inputs = allocate_and_pad_inputs(mgx_state, ctx, original_batch_size, 
+                                                               padded_batch_size, rocm_stream);
+            
+            // Bind inputs and outputs with temporary output buffers (for slicing)
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Calling handle_program_input_outputs with needs_slicing=true";
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] param_shapes.size()=" << param_shapes.size()
+                                 << ", output_shapes.size()=" << output_shapes.size();
+            std::vector<void*> temp_output_buffers;
+            auto [m, prog_output_indices] = handle_program_input_outputs(
+                param_shapes, output_shapes, map_input_name_index, ctx, true, &temp_output_buffers);
+            
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] handle_program_input_outputs returned:";
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch]   prog_output_indices.size()=" << prog_output_indices.size();
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch]   temp_output_buffers.size()=" << temp_output_buffers.size();
+            if (!prog_output_indices.empty()) {
+              LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch]   ⚠️  WARNING: prog_output_indices is NOT empty!";
+              LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch]   ⚠️  This means outputs were pre-allocated instead of using temp buffers!";
             }
+            
+            mgx_state->cached_prog_params = m;
+            mgx_state->cached_prog_output_indices = prog_output_indices;
+            mgx_state->last_input_shapes_raw = std::move(padded_shapes);
+            mgx_state->last_input_shape_hash = padded_hash;
+            mgx_state->caches_valid = true;
+            
+            // Rebind padded inputs to program parameters
+            if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
+              LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Rebinding padded input buffers";
+              for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
+                const auto& inp = mgx_state->cached_inputs[i];
+                const auto& padded_buf = mgx_state->padded_input_buffers[i];
+                m.add(inp.name.c_str(), migraphx::argument(padded_buf.mgx_shape, padded_buf.data));
+              }
+            }
+            
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Running with output slicing enabled";
+            // Run with slicing enabled
+            run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, 
+                                prog_output_indices, original_batch_size, padded_batch_size);
+            
+            // Free temporary output buffers
+            for (void* buf : temp_output_buffers) {
+              if (buf != nullptr) {
+                hipFree(buf);
+              }
+            }
+            
+            // Free padded buffers after execution
+            if (using_padded_inputs) {
+              free_padded_inputs(mgx_state);
+            }
+            
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] ==== EXITING execute_standard_path (padded path) ====";
+            return;
+          } else {
+            // ============ EXACT MATCH PATH: Batch size matches exactly, no padding needed ============
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Taking EXACT MATCH path (no padding/slicing)";
+            
+            // Populate caches for ultra-fast path (no slicing needed)
+            populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
+            
+            // Bind inputs and allocate outputs (no slicing)
+            auto [m, prog_output_indices] = handle_program_input_outputs(
+                param_shapes, output_shapes, map_input_name_index, ctx);
+            
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] handle_program_input_outputs returned:";
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch]   prog_output_indices.size()=" << prog_output_indices.size();
+            
+            // Complete cache population
+            mgx_state->cached_prog_params = m;
+            mgx_state->cached_prog_output_indices = prog_output_indices;
+            
+            // IMPORTANT: Build last_input_shapes_raw in cached_inputs order (MIGraphX parameter order)
+            // This ensures ultra-fast path shape comparison uses consistent ordering
+            mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(mgx_state, ctx, 0);
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Built last_input_shapes_raw in cached_inputs order, size=" 
+                                  << mgx_state->last_input_shapes_raw.size();
+            
+            mgx_state->last_input_shape_hash = current_hash;
+            mgx_state->caches_valid = true;
+            
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Running program (exact batch match, no padding/slicing)";
+            run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, prog_output_indices, 
+                                0, 0);  // Pass 0,0 for batch sizes to indicate no slicing needed
+            
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] ==== EXITING execute_standard_path (exact match path) ====";
+            return;
           }
-          
-          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Running with output slicing enabled";
-          // Run with slicing enabled
-          run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, 
-                              prog_output_indices, original_batch_size, padded_batch_size);
-          
-          // Free padded buffers after execution
-          if (using_padded_inputs) {
-            free_padded_inputs(mgx_state);
-          }
-          
-          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] ==== EXITING execute_standard_path (padded path) ====";
-          return;
         } else {
-          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] ✗✗✗ CACHE MISS for padded hash " 
+          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] ✗✗✗ CACHE MISS for hash " 
                                 << padded_hash;
           LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] This shouldn't happen - expected batch "
                                 << padded_batch_size << " to be pre-compiled";
@@ -2761,7 +3119,13 @@ static void execute_standard_path(
   // Complete cache population
   mgx_state->cached_prog_params = m;
   mgx_state->cached_prog_output_indices = prog_output_indices;
-  mgx_state->last_input_shapes_raw = std::move(all_input_shapes);
+  
+  // IMPORTANT: Build last_input_shapes_raw in cached_inputs order (MIGraphX parameter order)
+  // This ensures ultra-fast path shape comparison uses consistent ordering
+  mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(mgx_state, ctx, 0);
+  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] Built last_input_shapes_raw in cached_inputs order, size=" 
+                        << mgx_state->last_input_shapes_raw.size();
+  
   mgx_state->last_input_shape_hash = current_hash;
   mgx_state->caches_valid = true;
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -2131,24 +2131,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         LOGS_DEFAULT(VERBOSE) << "[Compile] Cache hit! Loaded precompiled model from: " << model_cache_file.string();
       }
 
-      // Log output shapes to verify they match the input batch size
-      auto prog_output_shapes = prog.get_output_shapes();
-      LOGS_DEFAULT(VERBOSE) << "[Compile] Compiled model has " << prog_output_shapes.size() << " outputs:";
-      for (std::size_t i = 0; i < prog_output_shapes.size(); ++i) {
-        auto out_lens = prog_output_shapes[i].lengths();
-        std::ostringstream ss;
-        ss << "[";
-        for (size_t j = 0; j < out_lens.size(); ++j) {
-          if (j > 0) ss << ", ";
-          ss << out_lens[j];
-        }
-        ss << "]";
-        LOGS_DEFAULT(VERBOSE) << "[Compile] Output " << i << " shape: " << ss.str()
-                              << (out_lens.size() > 0 ? " (batch=" + std::to_string(out_lens[0]) + ")" : "");
-      }
       // NOTE: DO NOT set output shapes as input parameters!
       // Outputs are dynamically inferred by MIGraphX based on input shapes
-
       // Store the compiled/loaded program in batched_programs_ indexed by batch size
       auto param_shapes = prog.get_parameter_shapes();
       if (param_shapes.size() > 0) {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1700,6 +1700,129 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
   return {m, prog_output_indices};
 }
 
+// Result structure for handle_input_shape function
+struct InputShapeResult {
+  bool input_shape_match;
+  migraphx::program_parameter_shapes param_shapes;
+  std::vector<std::int64_t> input_shapes;
+};
+
+// Helper: Handle input shape processing for both dynamic and static cases
+// This function processes runtime input shapes and determines if recompilation is needed
+static InputShapeResult handle_input_shape(
+    bool no_input_shape,
+    const std::unordered_map<std::string, std::size_t>& map_input_name_index,
+    Ort::KernelContext& ctx,
+    migraphx::onnx_options& cmp_options,
+    const migraphx::program& prog)
+{
+  bool input_shape_match = true;
+  migraphx::program_parameter_shapes param_shapes;
+  std::vector<std::int64_t> input_shapes;
+
+  if (no_input_shape) {
+    LOGS_DEFAULT(INFO) << "[Compute] No static input shapes available, setting from runtime inputs";
+    // NOTE: map_input_name_index only contains actual runtime inputs, not constants/initializers
+    // Constants and initializers are embedded in the graph and MIGraphX infers their shapes
+    LOGS_DEFAULT(INFO) << "[Compute] Setting shapes for " << map_input_name_index.size()
+                          << " runtime input parameters (excluding constants)";
+
+    for (const auto& it : map_input_name_index) {
+      const auto& name = it.first;
+      const auto& index = it.second;
+      auto input_tensor = ctx.GetInput(index);
+      auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+      const auto tensor_shape = tensor_info.GetShape();
+      std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
+
+      // Override default batch size with incoming batch size and treat as static
+      // Only for actual input parameters - constants are handled by MIGraphX
+      cmp_options.set_input_parameter_shape(name, ort_lens);
+      input_shape_match = false;
+
+      // Collect all shape dimensions including updated batch size for cache key
+      input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
+
+      // Log batch size and full shape for tracking dynamic shapes
+      if (!tensor_shape.empty()) {
+        LOGS_DEFAULT(INFO) << "[Compute] Input parameter '" << name
+                              << "' batch size (runtime override): " << tensor_shape[0];
+
+        std::ostringstream shape_str;
+        shape_str << "[";
+        for (size_t i = 0; i < tensor_shape.size(); ++i) {
+          if (i > 0) shape_str << ", ";
+          shape_str << tensor_shape[i];
+        }
+        shape_str << "]";
+        LOGS_DEFAULT(INFO) << "[Compute] Input parameter '" << name << "' set as static shape: " << shape_str.str();
+      }
+    }
+    LOGS_DEFAULT(INFO) << "[Compute] All runtime input shapes set as static parameters in MIGraphX options";
+    LOGS_DEFAULT(INFO) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
+  } else {
+    LOGS_DEFAULT(VERBOSE) << "Assigning inputs, and parameters from compiled model";
+    param_shapes = prog.get_parameter_shapes();
+    auto prog_output_shapes = prog.get_output_shapes();
+
+    // check whether input shapes match with shapes of program inputs
+    if (param_shapes.size() > 0) {
+      for (auto&& name : param_shapes.names()) {
+        if (map_input_name_index.count(name) > 0) {
+          auto input_tensor = ctx.GetInput(map_input_name_index.at(name));
+          auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+          const auto tensor_shape = tensor_info.GetShape();
+          std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
+
+          auto mgx_s = param_shapes[name];
+          auto mgx_lens = mgx_s.lengths();
+          auto mgx_strides = mgx_s.strides();
+
+          // Handle scalar tensors (rank-0 tensors)
+          if (mgx_lens.size() == 1 && mgx_lens[0] == 1 &&
+              mgx_strides.size() == 1 && mgx_strides[0] == 0) {
+            mgx_lens.clear();
+          }
+
+          // Check if shapes match
+          if (mgx_lens != ort_lens) {
+            LOGS_DEFAULT(INFO) << "[Compute] Shape mismatch for input '" << name
+                                  << "': MIGraphX expects [" << mgx_lens.size() << " dims], "
+                                  << "got [" << ort_lens.size() << " dims]";
+
+            // Check if it's specifically a batch size change
+            if (mgx_lens.size() == ort_lens.size() && mgx_lens.size() > 0 && mgx_lens[0] != ort_lens[0]) {
+              LOGS_DEFAULT(INFO) << "[Compute] Batch size changed from " << mgx_lens[0]
+                                    << " to " << ort_lens[0] << " for input '" << name << "'";
+            }
+
+            cmp_options.set_input_parameter_shape(name, ort_lens);
+            input_shape_match = false;
+          }
+          input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
+
+          // Log batch size and full shape for tracking
+          if (!tensor_shape.empty()) {
+            LOGS_DEFAULT(INFO) << "[Compute] Input '" << name << "' batch size: " << tensor_shape[0];
+
+            // Log full shape for debugging symbolic dimensions
+            std::ostringstream shape_str;
+            shape_str << "[";
+            for (size_t i = 0; i < tensor_shape.size(); ++i) {
+              if (i > 0) shape_str << ", ";
+              shape_str << tensor_shape[i];
+            }
+            shape_str << "]";
+            LOGS_DEFAULT(INFO) << "[Compute] Input '" << name << "' full shape: " << shape_str.str();
+          }
+        }
+      }
+    }
+  }
+
+  return {input_shape_match, param_shapes, input_shapes};
+}
+
 constexpr std::uint64_t MIGraphX_Version =
     ((MIGRAPHX_VERSION_MAJOR << 16) | (MIGRAPHX_VERSION_MINOR << 8) | MIGRAPHX_VERSION_PATCH);
 
@@ -1963,112 +2086,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       bool int8_enable = mgx_state->int8_enable;
       bool int8_calibration_cache_available = mgx_state->int8_calibration_cache_available;
 
-      // mean no program at all, so need to get the input shape info
-      // from input data
-      bool input_shape_match = true;
-      migraphx::program_parameter_shapes param_shapes;
-      std::vector<std::int64_t> input_shapes;
-
-      if (no_input_shape) {
-        LOGS_DEFAULT(INFO) << "[Compute] No static input shapes available, setting from runtime inputs";
-        // NOTE: map_input_name_index only contains actual runtime inputs, not constants/initializers
-        // Constants and initializers are embedded in the graph and MIGraphX infers their shapes
-        LOGS_DEFAULT(INFO) << "[Compute] Setting shapes for " << map_input_name_index.size()
-                              << " runtime input parameters (excluding constants)";
-
-        for (auto& it : map_input_name_index) {
-          auto& name = it.first;
-          auto& index = it.second;
-          auto input_tensor = ctx.GetInput(index);
-          auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-          const auto tensor_shape = tensor_info.GetShape();
-          std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
-
-          // Override default batch size with incoming batch size and treat as static
-          // Only for actual input parameters - constants are handled by MIGraphX
-          cmp_options.set_input_parameter_shape(name, ort_lens);
-          input_shape_match = false;
-
-          // Collect all shape dimensions including updated batch size for cache key
-          input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
-
-          // Log batch size and full shape for tracking dynamic shapes
-          if (!tensor_shape.empty()) {
-            LOGS_DEFAULT(INFO) << "[Compute] Input parameter '" << name
-                                  << "' batch size (runtime override): " << tensor_shape[0];
-
-            std::ostringstream shape_str;
-            shape_str << "[";
-            for (size_t i = 0; i < tensor_shape.size(); ++i) {
-              if (i > 0) shape_str << ", ";
-              shape_str << tensor_shape[i];
-            }
-            shape_str << "]";
-            LOGS_DEFAULT(INFO) << "[Compute] Input parameter '" << name << "' set as static shape: " << shape_str.str();
-          }
-        }
-        LOGS_DEFAULT(INFO) << "[Compute] All runtime input shapes set as static parameters in MIGraphX options";
-        LOGS_DEFAULT(INFO) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
-      } else {
-        LOGS_DEFAULT(VERBOSE) << "Assigning inputs, and parameters from compiled model";
-        param_shapes = prog.get_parameter_shapes();
-        auto prog_output_shapes = prog.get_output_shapes();
-
-        // check whether input shapes match with shapes of program inputs
-        // migraphx::onnx_options cmp_options;
-        if (param_shapes.size() > 0) {
-          for (auto&& name : param_shapes.names()) {
-            if (map_input_name_index.count(name) > 0) {
-              auto input_tensor = ctx.GetInput(map_input_name_index[name]);
-              auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-              const auto tensor_shape = tensor_info.GetShape();
-              std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
-
-              auto mgx_s = param_shapes[name];
-              auto mgx_lens = mgx_s.lengths();
-              auto mgx_strides = mgx_s.strides();
-
-              // Handle scalar tensors (rank-0 tensors)
-              if (mgx_lens.size() == 1 && mgx_lens[0] == 1 &&
-                  mgx_strides.size() == 1 && mgx_strides[0] == 0) {
-                mgx_lens.clear();
-              }
-
-              // Check if shapes match
-              if (mgx_lens != ort_lens) {
-                LOGS_DEFAULT(INFO) << "[Compute] Shape mismatch for input '" << name
-                                      << "': MIGraphX expects [" << mgx_lens.size() << " dims], "
-                                      << "got [" << ort_lens.size() << " dims]";
-
-                // Check if it's specifically a batch size change
-                if (mgx_lens.size() == ort_lens.size() && mgx_lens.size() > 0 && mgx_lens[0] != ort_lens[0]) {
-                  LOGS_DEFAULT(INFO) << "[Compute] Batch size changed from " << mgx_lens[0]
-                                        << " to " << ort_lens[0] << " for input '" << name << "'";
-                }
-
-                cmp_options.set_input_parameter_shape(name, ort_lens);
-                input_shape_match = false;
-              }
-              input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
-
-              // Log batch size and full shape for tracking
-              if (!tensor_shape.empty()) {
-                LOGS_DEFAULT(INFO) << "[Compute] Input '" << name << "' batch size: " << tensor_shape[0];
-
-                // Log full shape for debugging symbolic dimensions
-                std::ostringstream shape_str;
-                shape_str << "[";
-                for (size_t i = 0; i < tensor_shape.size(); ++i) {
-                  if (i > 0) shape_str << ", ";
-                  shape_str << tensor_shape[i];
-                }
-                shape_str << "]";
-                LOGS_DEFAULT(INFO) << "[Compute] Input '" << name << "' full shape: " << shape_str.str();
-              }
-            }
-          }
-        }
-      }
+      // Process input shapes and determine if recompilation is needed
+      auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
+          no_input_shape, map_input_name_index, ctx, cmp_options, prog);
 
       // input shapes are different, needs to re-parse onnx and
       // re-compile the program

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1737,10 +1737,10 @@ static void handle_input_shape_mismatch(
 
   // Invalidate ultra-fast path caches (will be repopulated on next run)
   mgx_state->caches_valid = false;
-  mgx_state->cached_param_shapes = std::nullopt;
-  mgx_state->cached_output_shapes = std::nullopt;
+  mgx_state->cached_inputs.clear();
+  mgx_state->cached_outputs.clear();
+  mgx_state->cached_output_ort_shapes.clear();
   mgx_state->cached_prog_params = std::nullopt;
-  mgx_state->cached_param_names.clear();
   mgx_state->cached_prog_output_indices.clear();
   mgx_state->last_input_shape_hash.clear();
 
@@ -1850,6 +1850,53 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
     }
   }
   return {m, prog_output_indices};
+}
+
+// Helper: Populate optimized caches for ultra-fast path
+// This separates inputs from outputs, pre-computes indices, and pre-allocates output shapes
+static void populate_ultra_fast_caches(
+    MIGraphXFuncState* mgx_state,
+    const migraphx::program_parameter_shapes& param_shapes,
+    const migraphx::shapes& output_shapes,
+    const std::unordered_map<std::string, std::size_t>& map_input_name_index)
+{
+  // Clear existing caches
+  mgx_state->cached_inputs.clear();
+  mgx_state->cached_outputs.clear();
+  mgx_state->cached_output_ort_shapes.clear();
+
+  // Reserve space for outputs
+  mgx_state->cached_outputs.reserve(output_shapes.size());
+  mgx_state->cached_output_ort_shapes.reserve(output_shapes.size());
+
+  // Separate inputs from outputs
+  if (param_shapes.size() > 0) {
+    for (const auto& name : param_shapes.names()) {
+      auto it = map_input_name_index.find(name);
+      if (it != map_input_name_index.end()) {
+        // This is an input parameter
+        MIGraphXFuncState::CachedInputParam inp;
+        inp.name = name;
+        inp.ort_index = it->second;
+        inp.mgx_shape = param_shapes[name];
+        mgx_state->cached_inputs.push_back(std::move(inp));
+      } else {
+        // This is an output parameter
+        const int output_index = compute_output_index(name);
+        if (output_index != -1) {
+          MIGraphXFuncState::CachedOutputParam out;
+          out.name = name;
+          out.output_index = output_index;
+          out.mgx_shape = param_shapes[name];
+          mgx_state->cached_outputs.push_back(std::move(out));
+
+          // Pre-allocate ORT-format output shape vector
+          const auto& lens = output_shapes[output_index].lengths();
+          mgx_state->cached_output_ort_shapes.emplace_back(lens.begin(), lens.end());
+        }
+      }
+    }
+  }
 }
 
 // Result structure for handle_input_shape function
@@ -2111,30 +2158,25 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
       // ═══════════════════════════════════════════════════════════════════════
       // ULTRA-FAST PATH: Same shapes as last run - just rebind pointers and run
+      // No map lookups, no string parsing, no vector allocations
       // ═══════════════════════════════════════════════════════════════════════
       if (mgx_state->caches_valid && current_hash == mgx_state->last_input_shape_hash) {
-        // Rebind input/output pointers only (shapes unchanged)
         auto& m = mgx_state->cached_prog_params.value();
-        const auto& param_names = mgx_state->cached_param_names;
 
-        for (const auto& name : param_names) {
-          auto it = map_input_name_index.find(name);
-          if (it != map_input_name_index.end()) {
-            // Input: update pointer
-            const auto& input_tensor = ctx.GetInput(it->second);
-            m.add(name.c_str(), migraphx::argument(mgx_state->cached_param_shapes.value()[name.c_str()],
-                                           const_cast<void*>(input_tensor.GetTensorRawData())));
-          } else {
-            // Output: update pointer
-            const int output_index = compute_output_index(name);
-            if (output_index != -1) {
-              const auto& lens = mgx_state->cached_output_shapes.value()[output_index].lengths();
-              std::vector<int64_t> ort_shape(lens.begin(), lens.end());
-              auto output_tensor = ctx.GetOutput(output_index, ort_shape.data(), ort_shape.size());
-              m.add(name.c_str(), migraphx::argument(mgx_state->cached_param_shapes.value()[name.c_str()],
+        // Rebind inputs - direct iteration, no map lookups
+        for (const auto& inp : mgx_state->cached_inputs) {
+          const auto& input_tensor = ctx.GetInput(inp.ort_index);
+          m.add(inp.name.c_str(), migraphx::argument(inp.mgx_shape,
+                                             const_cast<void*>(input_tensor.GetTensorRawData())));
+        }
+
+        // Rebind outputs - direct iteration, uses pre-allocated shape vectors
+        for (std::size_t i = 0; i < mgx_state->cached_outputs.size(); ++i) {
+          const auto& out = mgx_state->cached_outputs[i];
+          const auto& ort_shape = mgx_state->cached_output_ort_shapes[i];
+          auto output_tensor = ctx.GetOutput(out.output_index, ort_shape.data(), ort_shape.size());
+          m.add(out.name.c_str(), migraphx::argument(out.mgx_shape,
                                              output_tensor.GetTensorMutableRawData()));
-            }
-          }
         }
 
         // Run directly - minimal overhead path
@@ -2153,21 +2195,16 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           // Found cached program - use it and populate caches
           prog = prog_it->second;
 
-          // Populate caches for ultra-fast path on next call
-          mgx_state->cached_param_shapes = prog.get_parameter_shapes();
-          mgx_state->cached_output_shapes = prog.get_output_shapes();
+          // Get shapes once
+          auto param_shapes = prog.get_parameter_shapes();
+          auto output_shapes = prog.get_output_shapes();
 
-          // Cache param names (once per program)
-          mgx_state->cached_param_names.clear();
-          for (const auto& name : mgx_state->cached_param_shapes->names()) {
-            mgx_state->cached_param_names.push_back(name);
-          }
+          // Populate optimized caches for ultra-fast path
+          populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
 
-          // Bind inputs/outputs using cached shapes (avoids another get_output_shapes() call)
+          // Bind inputs/outputs
           auto [m, prog_output_indices] = handle_program_input_outputs(
-              mgx_state->cached_param_shapes.value(),
-              mgx_state->cached_output_shapes.value(),
-              map_input_name_index, ctx);
+              param_shapes, output_shapes, map_input_name_index, ctx);
 
           mgx_state->cached_prog_params = std::move(m);
           mgx_state->cached_prog_output_indices = std::move(prog_output_indices);
@@ -2204,21 +2241,15 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         param_shapes = prog.get_parameter_shapes();
       }
 
-      // Fetch and cache shapes ONCE (avoid duplicate API calls)
-      mgx_state->cached_param_shapes = param_shapes;
-      mgx_state->cached_output_shapes = prog.get_output_shapes();
+      // Fetch output shapes once
+      auto output_shapes = prog.get_output_shapes();
 
-      // Cache param names
-      mgx_state->cached_param_names.clear();
-      for (const auto& name : mgx_state->cached_param_shapes->names()) {
-        mgx_state->cached_param_names.push_back(name);
-      }
+      // Populate optimized caches for ultra-fast path
+      populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
 
-      // Bind inputs and allocate outputs using cached shapes
+      // Bind inputs and allocate outputs
       auto [m, prog_output_indices] = handle_program_input_outputs(
-          mgx_state->cached_param_shapes.value(),
-          mgx_state->cached_output_shapes.value(),
-          map_input_name_index, ctx);
+          param_shapes, output_shapes, map_input_name_index, ctx);
 
       // Complete cache population
       mgx_state->cached_prog_params = m;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1487,6 +1487,34 @@ static void handle_input_shape_mismatch(
   auto& cmp_options = mgx_state->options;
   const auto& map_input_name_index = mgx_state->input_name_indexes;
 
+  // Determine batch size from the first input tensor
+  std::size_t current_batch_size = 0;
+  if (!map_input_name_index.empty()) {
+    auto first_it = map_input_name_index.begin();
+    auto input_tensor = ctx.GetInput(first_it->second);
+          auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+          const auto tensor_shape = tensor_info.GetShape();
+    if (!tensor_shape.empty()) {
+      current_batch_size = static_cast<std::size_t>(tensor_shape[0]);
+    }
+  }
+
+  // Check in-memory batched_programs cache first (before disk cache)
+  if (mgx_state->batched_programs_ref.has_value() && current_batch_size > 0) {
+    auto& batched_progs = mgx_state->batched_programs_ref.value().get();
+    auto it = batched_progs.find(current_batch_size);
+    if (it != batched_progs.end()) {
+      LOGS_DEFAULT(INFO) << "[Compute] Found batch size " << current_batch_size
+                         << " in in-memory batched_programs cache - using cached program";
+      prog = it->second;
+        param_shapes = prog.get_parameter_shapes();
+      return;  // Early exit - no need to load from disk or compile
+    } else {
+      LOGS_DEFAULT(INFO) << "[Compute] Batch size " << current_batch_size
+                         << " not in in-memory cache, checking disk cache";
+    }
+  }
+
   std::filesystem::path model_cache_file;
   // empty cache path means the MXR caching is disabled - always compile
   if (!model_cache_path.empty()) {
@@ -1568,6 +1596,13 @@ static void handle_input_shape_mismatch(
     save_compiled_model(prog, model_cache_file);
   } else {
     LOGS_DEFAULT(INFO) << "[Compute] Cache hit! Loaded precompiled model with matching batch size";
+  }
+
+  // Store the compiled/loaded program in the in-memory batched_programs cache
+  if (mgx_state->batched_programs_ref.has_value() && current_batch_size > 0) {
+    mgx_state->batched_programs_ref.value().get()[current_batch_size] = prog;
+    LOGS_DEFAULT(INFO) << "[Compute] Stored program for batch size " << current_batch_size
+                       << " in in-memory batched_programs cache";
   }
 
   param_shapes = prog.get_parameter_shapes();
@@ -2000,6 +2035,23 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       }
       // NOTE: DO NOT set output shapes as input parameters!
       // Outputs are dynamically inferred by MIGraphX based on input shapes
+
+      // Store the compiled/loaded program in batched_programs_ indexed by batch size
+      auto param_shapes = prog.get_parameter_shapes();
+      if (param_shapes.size() > 0) {
+        // Extract batch size from first input parameter
+        for (auto&& name : param_shapes.names()) {
+          auto shape = param_shapes[name];
+          auto lens = shape.lengths();
+          if (!lens.empty()) {
+            std::size_t batch_size = lens[0];
+            batched_programs_[fused_node.Name()][batch_size] = prog;
+            LOGS_DEFAULT(VERBOSE) << "[Compile] Stored program for batch size " << batch_size
+                                  << " in batched_programs cache";
+            break;  // Only need batch size from first input
+          }
+        }
+      }
     } else {
       LOGS_DEFAULT(VERBOSE) << "[Compile] Deferring compilation until runtime (no static input shapes available)";
       LOGS_DEFAULT(VERBOSE) << "[Compile] Will use default batch size of 1, then recompile with actual batch at runtime";
@@ -2011,6 +2063,12 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     map_onnx_string_[fused_node.Name()] = onnx_string_buffer;
     map_input_index_[fused_node.Name()] = input_name_index;
     map_no_input_shape_[fused_node.Name()] = no_input_shape;
+
+    // Initialize the batched_programs map for this node if not already done
+    if (batched_programs_.find(fused_node.Name()) == batched_programs_.end()) {
+      batched_programs_[fused_node.Name()] = std::unordered_map<std::size_t, migraphx::program>();
+    }
+
     NodeComputeInfo compute_info;
     compute_info.create_state_func = [=](ComputeContext* context, FunctionState* state) {
       std::unique_ptr<MIGraphXFuncState> p = std::make_unique<MIGraphXFuncState>();
@@ -2018,7 +2076,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             map_onnx_string_[context->node_name], options, t_, map_input_index_[context->node_name], &mgx_mu_,
             map_no_input_shape_[context->node_name], fp16_enable_, bf16_enable_, fp8_enable_, int8_enable_,
             int8_calibration_cache_available_, dynamic_range_map_,
-            model_cache_path_.string(), dump_model_ops_};
+            model_cache_path_.string(), dump_model_ops_, exhaustive_tune_, max_dynamic_batch_,
+            std::ref(batched_programs_[context->node_name])};
       *state = p.release();
       return 0;
     };

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -3475,7 +3475,8 @@ static inline std::string precompile_model_for_batch(
 
 // Precompile all power-of-two batch models during Compile() phase
 // This moves compilation from compute_func() to initialization time
-// Uses parallel loading to speed up cache loading when multiple batch sizes are needed
+// Uses parallel loading to speed up cache loading, but serializes compilation
+// to avoid thread-safety issues in MIGraphX compile()
 static inline void precompile_all_dynamic_batch_models(
     const std::vector<std::size_t>& power_of_two_batch_sizes,
     const std::vector<std::string>& input_names,
@@ -3495,87 +3496,157 @@ static inline void precompile_all_dynamic_batch_models(
     const std::string& mxr_filename_prefix,
     std::unordered_map<std::string, migraphx::program>& cached_programs)
 {
-  LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] Precompiling " 
-                     << power_of_two_batch_sizes.size() << " power-of-two batch models in parallel...";
+  LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] Processing " 
+                     << power_of_two_batch_sizes.size() << " power-of-two batch models...";
   
-  // Mutex to protect shared cached_programs map
+  // Structure to hold batch info for loading/compiling
+  struct BatchInfo {
+    std::size_t batch_size;
+    std::string cache_hash;
+    std::filesystem::path cache_file;
+  };
+  
+  // Build batch info for all batch sizes
+  std::vector<BatchInfo> batch_infos;
+  for (const auto& batch_size : power_of_two_batch_sizes) {
+    BatchInfo info;
+    info.batch_size = batch_size;
+    
+    // Build cache key for this batch size
+    std::vector<std::int64_t> batch_shape_key;
+    for (std::size_t i = 0; i < input_names.size(); ++i) {
+      batch_shape_key.push_back(static_cast<std::int64_t>(batch_size));
+      batch_shape_key.insert(batch_shape_key.end(), 
+                            all_input_base_shapes[i].begin(), 
+                            all_input_base_shapes[i].end());
+    }
+    info.cache_hash = make_hash(batch_shape_key);
+    
+    // Build disk cache file path
+    if (!model_cache_path.empty()) {
+      info.cache_file = model_cache_path / (mxr_filename_prefix + info.cache_hash + ".mxr");
+    }
+    
+    // Skip if already in memory cache
+    if (cached_programs.find(info.cache_hash) != cached_programs.end()) {
+      LOGS_DEFAULT(VERBOSE) << "[precompile_all_dynamic_batch_models] Batch " << batch_size 
+                            << " already in memory cache, skipping";
+      continue;
+    }
+    
+    batch_infos.push_back(info);
+  }
+  
+  if (batch_infos.empty()) {
+    LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] All models already cached in memory";
+    return;
+  }
+  
+  // ============================================================================
+  // PHASE 1: Parallel loading from disk cache
+  // ============================================================================
+  LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] Phase 1: Attempting parallel load from disk cache...";
+  
+  // Mutex to protect shared state
   std::mutex cache_mutex;
   
-  // Launch async tasks for each batch size
-  std::vector<std::future<void>> futures;
+  // Track which batch sizes need compilation (cache misses)
+  std::vector<BatchInfo> needs_compilation;
+  std::mutex compile_list_mutex;
   
-  for (const auto& batch_size : power_of_two_batch_sizes) {
-    futures.push_back(std::async(std::launch::async, 
-      [&, batch_size]() {
-        // Build cache key for this batch size
-        std::vector<std::int64_t> batch_shape_key;
-        for (std::size_t i = 0; i < input_names.size(); ++i) {
-          batch_shape_key.push_back(static_cast<std::int64_t>(batch_size));
-          batch_shape_key.insert(batch_shape_key.end(), 
-                                all_input_base_shapes[i].begin(), 
-                                all_input_base_shapes[i].end());
-        }
-        auto cache_hash = make_hash(batch_shape_key);
+  // Launch async tasks for parallel loading
+  std::vector<std::future<void>> load_futures;
+  
+  for (const auto& info : batch_infos) {
+    load_futures.push_back(std::async(std::launch::async, 
+      [&, info]() {
+        LOGS_DEFAULT(VERBOSE) << "[precompile_all_dynamic_batch_models] Trying to load batch " 
+                              << info.batch_size << " from disk...";
         
-        LOGS_DEFAULT(VERBOSE) << "[precompile_model_for_batch] Batch " << batch_size << " -> hash: " << cache_hash;
+        migraphx::program prog;
+        bool loaded = load_precompiled_model(prog, info.cache_file);
         
-        // Check if already cached in memory (thread-safe check)
-        {
+        if (loaded) {
+          // Cache hit - store in memory cache
           std::lock_guard<std::mutex> lock(cache_mutex);
-          if (cached_programs.find(cache_hash) != cached_programs.end()) {
-            LOGS_DEFAULT(VERBOSE) << "[precompile_model_for_batch] ✓ Batch " << batch_size << " already cached";
-            return;
-          }
-        }
-        
-        // Build disk cache file path
-        std::filesystem::path batch_cache_file;
-        if (!model_cache_path.empty()) {
-          batch_cache_file = model_cache_path / (mxr_filename_prefix + cache_hash + ".mxr");
-        }
-        
-        LOGS_DEFAULT(VERBOSE) << "[precompile_model_for_batch] Compiling/loading batch " << batch_size << "...";
-        
-        // Create thread-local copy of options to avoid race conditions
-        migraphx::onnx_options local_options = options;
-        
-        // Load or compile the model (most time-consuming part)
-        migraphx::program batch_prog = load_or_compile_model(
-            batch_cache_file,
-            onnx_string,
-            local_options,  // Use thread-local copy
-            t,
-            fp16_enable,
-            bf16_enable,
-            int8_enable,
-            fp8_enable,
-            int8_calibration_cache_available,
-            dynamic_range_map,  // Read-only access
-            exhaustive_tune,
-            model_path,
-            nullptr,  // ctx not needed for precompilation
-            nullptr,  // map_input_name_index not needed
-            input_names,
-            all_input_base_shapes,
-            batch_size);
-        
-        // Store in memory cache (thread-safe insertion)
-        {
-          std::lock_guard<std::mutex> lock(cache_mutex);
-          cached_programs[cache_hash] = std::move(batch_prog);
-          LOGS_DEFAULT(VERBOSE) << "[precompile_model_for_batch] ✓ Stored batch " << batch_size << " in cache";
+          cached_programs[info.cache_hash] = std::move(prog);
+          LOGS_DEFAULT(VERBOSE) << "[precompile_all_dynamic_batch_models] ✓ Loaded batch " 
+                                << info.batch_size << " from disk cache";
+        } else {
+          // Cache miss - add to compilation list
+          std::lock_guard<std::mutex> lock(compile_list_mutex);
+          needs_compilation.push_back(info);
+          LOGS_DEFAULT(VERBOSE) << "[precompile_all_dynamic_batch_models] ✗ Batch " 
+                                << info.batch_size << " not in disk cache, needs compilation";
         }
       }
     ));
   }
   
-  // Wait for all tasks to complete
-  for (auto& future : futures) {
+  // Wait for all loading tasks to complete
+  for (auto& future : load_futures) {
     future.get();
   }
   
-  LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] ✓ Precompiled " 
-                     << cached_programs.size() << " models";
+  std::size_t loaded_count = batch_infos.size() - needs_compilation.size();
+  LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] Phase 1 complete: " 
+                     << loaded_count << " loaded from cache, " 
+                     << needs_compilation.size() << " need compilation";
+  
+  // ============================================================================
+  // PHASE 2: Sequential compilation for cache misses
+  // ============================================================================
+  if (!needs_compilation.empty()) {
+    LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] Phase 2: Compiling " 
+                       << needs_compilation.size() << " models sequentially...";
+    
+    // Sort by batch size for consistent ordering
+    std::sort(needs_compilation.begin(), needs_compilation.end(),
+              [](const BatchInfo& a, const BatchInfo& b) { return a.batch_size < b.batch_size; });
+    
+    for (const auto& info : needs_compilation) {
+      LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] Compiling batch size " 
+                         << info.batch_size << "...";
+      
+      // Compile the model (this is the thread-unsafe part that must be serialized)
+      migraphx::program batch_prog = CompileProgramWithBatch(
+          onnx_string,
+          options,
+          t,
+          fp16_enable,
+          bf16_enable,
+          int8_enable,
+          fp8_enable,
+          int8_calibration_cache_available,
+          dynamic_range_map,
+          exhaustive_tune,
+          model_path,
+          nullptr,  // ctx not needed for precompilation
+          nullptr,  // map_input_name_index not needed
+          input_names,
+          all_input_base_shapes,
+          info.batch_size);
+      
+      LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] ✓ Compiled batch size " 
+                         << info.batch_size;
+      
+      // Save to disk cache
+      save_compiled_model(batch_prog, info.cache_file);
+      if (!info.cache_file.empty()) {
+        LOGS_DEFAULT(VERBOSE) << "[precompile_all_dynamic_batch_models] Saved to disk: " 
+                              << info.cache_file.string();
+      }
+      
+      // Store in memory cache
+      cached_programs[info.cache_hash] = std::move(batch_prog);
+    }
+    
+    LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] Phase 2 complete: " 
+                       << needs_compilation.size() << " models compiled";
+  }
+  
+  LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] ✓ All " 
+                     << cached_programs.size() << " models ready";
 }
 
 // Precompile static model (no dynamic batching) during Compile() phase

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1338,7 +1338,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     }
 
     // empty cache path means the MXR caching is disabled - always compile
-    if (!model_cache_path_.empty()) {
+    if (!model_cache_path_.empty() or first_start_) {
       std::vector<std::int64_t> input_shapes;
 
       // Use input_tensor directly, not session_input_names.size()
@@ -1365,9 +1365,10 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
       if(input_shapes.empty())
       {
-        LOGS_DEFAULT(WARNING) << "Input shapes are empty, skipping model caching";
+        LOGS_DEFAULT(ERROR) << "Input shapes are empty, skipping model caching";
       }
       model_cache_file = model_cache_path_ / (mxr_filename_prefix + make_hash(input_shapes) + ".mxr");
+      first_start_ = false;
     }
 
     // map parameter input name to index

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1461,28 +1461,23 @@ static void run_migraphx_program(
 // Helper: Handle input shape mismatch by recompiling the model with new input shapes
 // This function is called when runtime input shapes differ from compiled shapes
 static void handle_input_shape_mismatch(
+    MIGraphXFuncState* mgx_state,
     const std::filesystem::path& model_cache_path,
-    const std::filesystem::path& model_cache_dir,
-    const std::string& mxr_filename_prefix,
     const std::filesystem::path& model_path,
-    bool exhaustive_tune,
-    bool fp16_enable,
-    bool bf16_enable,
-    bool fp8_enable,
-    bool int8_enable,
-    bool int8_calibration_cache_available,
-    const migraphx::target& t,
+    const std::string& mxr_filename_prefix,
     Ort::KernelContext& ctx,
-    const std::unordered_map<std::string, std::size_t>& map_input_name_index,
-    std::unordered_map<std::string, float>& map_dynamic_range,
-    const std::string& onnx_string,
-    migraphx::onnx_options& cmp_options,
-    migraphx::program& prog,
     migraphx::program_parameter_shapes& param_shapes,
-    std::vector<std::int64_t>& input_shapes,
-    bool& no_input_shape)
+    std::vector<std::int64_t>& input_shapes)
 {
   LOGS_DEFAULT(INFO) << "[Compute] Input shape mismatch detected, initiating recompilation";
+
+  // Extract references from mgx_state for convenience
+  auto& prog = mgx_state->prog;
+  auto& cmp_options = mgx_state->options;
+  auto& onnx_string = mgx_state->onnx_string;
+  const auto& map_input_name_index = mgx_state->input_name_indexes;
+  auto& map_dynamic_range = mgx_state->dynamic_range_map;
+  const auto& t = mgx_state->t;
 
   std::filesystem::path model_cache_file;
   // empty cache path means the MXR caching is disabled - always compile
@@ -1511,7 +1506,7 @@ static void handle_input_shape_mismatch(
     LOGS_DEFAULT(INFO) << "[Compute] Cache key input shapes (including updated batch): " << shapes_str.str();
 
     auto cache_hash = make_hash(input_shapes);
-    model_cache_file = model_cache_dir / (mxr_filename_prefix + cache_hash + ".mxr");
+    model_cache_file = mgx_state->model_cache_dir / (mxr_filename_prefix + cache_hash + ".mxr");
     LOGS_DEFAULT(INFO) << "[Compute] Cache file with batch-aware hash: " << model_cache_file.string();
   }
 
@@ -1582,7 +1577,7 @@ static void handle_input_shape_mismatch(
 
     migraphx::program_parameters quant_params;
 
-    if ((int8_enable ^ fp8_enable) && int8_calibration_cache_available) {
+    if ((mgx_state->int8_enable ^ mgx_state->fp8_enable) && mgx_state->int8_calibration_cache_available) {
       auto local_param_shapes = prog.get_parameter_shapes();
       // Add input parameter data and the values they're set to
       for (auto&& name : local_param_shapes.names()) {
@@ -1603,9 +1598,10 @@ static void handle_input_shape_mismatch(
         }
       }
     }
-    calibrate_and_quantize(prog, t, quant_params, fp16_enable, bf16_enable, int8_enable,
-                           fp8_enable, int8_calibration_cache_available, map_dynamic_range);
-    compile_program(prog, t, exhaustive_tune);
+    calibrate_and_quantize(prog, t, quant_params, mgx_state->fp16_enable, mgx_state->bf16_enable,
+                           mgx_state->int8_enable, mgx_state->fp8_enable,
+                           mgx_state->int8_calibration_cache_available, map_dynamic_range);
+    compile_program(prog, t, mgx_state->exhaustive_tune);
 
     // Save compiled model with batch-aware filename
     LOGS_DEFAULT(INFO) << "[Compute] Saving compiled model with updated batch size to: "
@@ -1616,7 +1612,7 @@ static void handle_input_shape_mismatch(
   }
 
   param_shapes = prog.get_parameter_shapes();
-  no_input_shape = false;
+  mgx_state->no_input_shape = false;
 }
 
 // Helper: Handle program inputs and outputs binding
@@ -2074,17 +2070,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       MIGraphXFuncState* mgx_state = reinterpret_cast<MIGraphXFuncState*>(state);
 
       std::unordered_map<std::string, std::size_t>& map_input_name_index = mgx_state->input_name_indexes;
-      std::unordered_map<std::string, float>& map_dynamic_range = mgx_state->dynamic_range_map;
-      migraphx::target t = mgx_state->t;
       migraphx::program& prog = mgx_state->prog;
-      std::string& onnx_string = mgx_state->onnx_string;
       migraphx::onnx_options& cmp_options = mgx_state->options;
       bool& no_input_shape = mgx_state->no_input_shape;
-      bool fp16_enable = mgx_state->fp16_enable;
-      bool bf16_enable = mgx_state->bf16_enable;
-      bool fp8_enable = mgx_state->fp8_enable;
-      bool int8_enable = mgx_state->int8_enable;
-      bool int8_calibration_cache_available = mgx_state->int8_calibration_cache_available;
 
       // Process input shapes and determine if recompilation is needed
       auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
@@ -2094,26 +2082,13 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       // re-compile the program
       if (!input_shape_match) {
         handle_input_shape_mismatch(
+            mgx_state,
             model_cache_path_,
-            mgx_state->model_cache_dir,
-            mxr_filename_prefix,
             model_path_,
-            exhaustive_tune_,
-            fp16_enable,
-            bf16_enable,
-            fp8_enable,
-            int8_enable,
-            int8_calibration_cache_available,
-            t,
+            mxr_filename_prefix,
             ctx,
-            map_input_name_index,
-            map_dynamic_range,
-            onnx_string,
-            cmp_options,
-            prog,
             param_shapes,
-            input_shapes,
-            no_input_shape);
+            input_shapes);
       }
 
       // Bind inputs and allocate outputs for the MIGraphX program

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1428,8 +1428,9 @@ static void run_migraphx_program(
   // In case of input parameters are reused as output parameter call hipMemcpy
   auto output_num = prog_outputs->size();
   if (prog_output_indices.size() < output_num) {
+    std::unordered_set<std::size_t> prog_output_indices_set(prog_output_indices.begin(), prog_output_indices.end());
     for (std::size_t i = 0; i < output_num; ++i) {
-      if (std::find(prog_output_indices.begin(), prog_output_indices.end(), static_cast<int>(i)) != prog_output_indices.end())
+      if (prog_output_indices_set.count(i) > 0)
         continue;
       auto gpu_res = (*prog_outputs)[i];
       migraphx::shape res_shape = gpu_res.get_shape();

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1340,20 +1340,69 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     // empty cache path means the MXR caching is disabled - always compile
     if (!model_cache_path_.empty() or first_start_) {
       std::vector<std::int64_t> input_shapes;
+      bool has_symbolic_dims = false;
+
       for (std::size_t i = 0; i < session_input_names.size(); ++i) {
         auto tensor_shape = input_tensor[i]->Shape();
+
+        // Check for symbolic dimensions and handle them
+        if (tensor_shape == nullptr || tensor_shape->dim_size() == 0) {
+          LOGS_DEFAULT(WARNING) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                                << ") has no shape information";
+          has_symbolic_dims = true;
+          continue;
+        }
+
+        // Process all dimensions (skip batch dimension at j=0, start at j=1)
         for (int j = 1; j < tensor_shape->dim_size(); ++j) {
-          input_shapes.push_back(tensor_shape->dim(j).dim_value());
+          const auto& dim = tensor_shape->dim(j);
+
+          // Handle symbolic dimensions
+          if (dim.has_dim_param()) {
+            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                                  << ") dimension " << j << " is symbolic: " << dim.dim_param();
+            has_symbolic_dims = true;
+            // Use -1 as placeholder for symbolic dimensions in hash calculation
+            input_shapes.push_back(-1);
+          } else if (dim.has_dim_value()) {
+            auto dim_val = dim.dim_value();
+            input_shapes.push_back(dim_val);
+            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                                  << ") dimension " << j << " value: " << dim_val;
+          } else {
+            LOGS_DEFAULT(WARNING) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                                  << ") dimension " << j << " has no value or param";
+            has_symbolic_dims = true;
+          }
         }
 
         // Log batch size (first dimension) for tracking
-        if (tensor_shape->dim_size() > 0 && tensor_shape->dim(0).has_dim_value()) {
-          auto batch_size = tensor_shape->dim(0).dim_value();
-          LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                                << ") batch size: " << batch_size;
+        if (tensor_shape->dim_size() > 0) {
+          const auto& batch_dim = tensor_shape->dim(0);
+          if (batch_dim.has_dim_value()) {
+            auto batch_size = batch_dim.dim_value();
+            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                                  << ") batch size: " << batch_size;
+          } else if (batch_dim.has_dim_param()) {
+            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                                  << ") batch size is symbolic: " << batch_dim.dim_param();
+          } else {
+            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                                  << ") batch size is unknown";
+          }
         }
       }
-      model_cache_file = model_cache_path_ / (mxr_filename_prefix + make_hash(input_shapes) + ".mxr");
+
+      if (has_symbolic_dims) {
+        LOGS_DEFAULT(WARNING) << "[Compile] Model has symbolic dimensions, cache file may not be unique for all shapes";
+      }
+
+      if (!input_shapes.empty()) {
+        model_cache_file = model_cache_path_ / (mxr_filename_prefix + make_hash(input_shapes) + ".mxr");
+      } else {
+        LOGS_DEFAULT(WARNING) << "[Compile] Input shapes are empty, skipping model cache file hash generation";
+      }
+
       first_start_ = false;
     }
 
@@ -1463,9 +1512,18 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           cmp_options.set_input_parameter_shape(name, ort_lens);
           input_shape_match = false;
 
-          // Log batch size for tracking
+          // Log batch size and full shape for tracking dynamic shapes
           if (!tensor_shape.empty()) {
             LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' batch size: " << tensor_shape[0];
+
+            std::ostringstream shape_str;
+            shape_str << "[";
+            for (size_t i = 0; i < tensor_shape.size(); ++i) {
+              if (i > 0) shape_str << ", ";
+              shape_str << tensor_shape[i];
+            }
+            shape_str << "]";
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' shape (dynamic): " << shape_str.str();
           }
         }
       } else {
@@ -1486,20 +1544,36 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
               auto mgx_s = param_shapes[name];
               auto mgx_lens = mgx_s.lengths();
               auto mgx_strides = mgx_s.strides();
+
+              // Handle scalar tensors (rank-0 tensors)
               if (mgx_lens.size() == 1 && mgx_lens[0] == 1 &&
                   mgx_strides.size() == 1 && mgx_strides[0] == 0) {
                 mgx_lens.clear();
               }
 
+              // Check if shapes match
               if (mgx_lens != ort_lens) {
+                LOGS_DEFAULT(VERBOSE) << "[Compute] Shape mismatch for input '" << name
+                                      << "': MIGraphX expects [" << mgx_lens.size() << " dims], "
+                                      << "got [" << ort_lens.size() << " dims]";
                 cmp_options.set_input_parameter_shape(name, ort_lens);
                 input_shape_match = false;
               }
               input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
 
-              // Log batch size for tracking
+              // Log batch size and full shape for tracking
               if (!tensor_shape.empty()) {
                 LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' batch size: " << tensor_shape[0];
+
+                // Log full shape for debugging symbolic dimensions
+                std::ostringstream shape_str;
+                shape_str << "[";
+                for (size_t i = 0; i < tensor_shape.size(); ++i) {
+                  if (i > 0) shape_str << ", ";
+                  shape_str << tensor_shape[i];
+                }
+                shape_str << "]";
+                LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' full shape: " << shape_str.str();
               }
             }
           }
@@ -1509,11 +1583,25 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       // input shapes are different, needs to re-parse onnx and
       // re-compile the program
       if (!input_shape_match) {
+        LOGS_DEFAULT(VERBOSE) << "[Compute] Input shape mismatch detected, initiating recompilation";
+
         std::filesystem::path model_cache_file;
         // empty cache path means the MXR caching is disabled - always compile
         if (!model_cache_path_.empty()) {
+          // Log the shapes being used for cache key generation
+          std::ostringstream shapes_str;
+          shapes_str << "[";
+          for (size_t i = 0; i < input_shapes.size(); ++i) {
+            if (i > 0) shapes_str << ", ";
+            shapes_str << input_shapes[i];
+          }
+          shapes_str << "]";
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Cache key input shapes: " << shapes_str.str();
+
           model_cache_file = mgx_state->model_cache_dir / (mxr_filename_prefix + make_hash(input_shapes) + ".mxr");
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Looking for cached model at: " << model_cache_file.string();
         }
+
         if (!load_precompiled_model(prog, model_cache_file)) {
           LOGS_DEFAULT(VERBOSE) << "Input shape mismatch detected. Recompiling";
 #ifndef ENABLE_TRAINING_CORE

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1155,34 +1155,64 @@ MIGraphXExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_v
   return result;
 }
 
-bool get_input_output_names(const GraphViewer& graph,
-                            std::vector<std::string>& input_names,
-                            std::vector<std::string>& output_names) {
+// Result structure for get_input_output_names containing detailed symbolic dimension info
+struct InputOutputNamesResult {
+  bool defer_compilation;        // True if any input has unknown/symbolic dimensions
+  bool prog_has_dynamic_batch;   // True if batch dimension (dim 0) is symbolic for any input
+  SymbolicDimsMap symbolic_dims; // Fine-grained tracking of which dimensions are symbolic per input
+};
+
+InputOutputNamesResult get_input_output_names(const GraphViewer& graph,
+                                              std::vector<std::string>& input_names,
+                                              std::vector<std::string>& output_names) {
   input_names.clear();
   output_names.clear();
+  SymbolicDimsMap symbolic_dims;
+  bool defer_compilation = false;
+  bool prog_has_dynamic_batch = false;
+
   const auto& input_args = graph.GetInputs();
-  std::transform(input_args.begin(), input_args.end(), std::back_inserter(input_names), [](auto& arg) {
-    return arg->Name();
-  });
 
-  bool no_input_shape = std::any_of(input_args.begin(), input_args.end(), [&](auto arg) {
-    if (arg == nullptr)
-      return true;
-
-    auto sptr = arg->Shape();
-    if (sptr == nullptr)
-      return true;
-
-    if (sptr->dim_size() == 0)
-      return true;
-
-    for (int i = 0; i < sptr->dim_size(); i++) {
-      if (sptr->dim(i).has_dim_param())
-        return true;
+  for (const auto& arg : input_args) {
+    if (arg == nullptr) {
+      defer_compilation = true;
+      continue;
     }
 
-    return false;
-  });
+    input_names.push_back(arg->Name());
+    auto sptr = arg->Shape();
+
+    if (sptr == nullptr || sptr->dim_size() == 0) {
+      defer_compilation = true;
+      // Mark all dimensions as unknown for this input
+      LOGS_DEFAULT(VERBOSE) << "[get_input_output_names] Input '" << arg->Name()
+                            << "' has no shape info, treating as fully dynamic";
+      continue;
+    }
+
+    std::vector<SymbolicDimInfo> input_symbolic_dims;
+    for (int i = 0; i < sptr->dim_size(); i++) {
+      if (sptr->dim(i).has_dim_param()) {
+        defer_compilation = true;
+        std::string dim_param = sptr->dim(i).dim_param();
+        input_symbolic_dims.push_back({i, dim_param});
+
+        // Check if this is the batch dimension (dim 0)
+        if (i == 0) {
+          prog_has_dynamic_batch = true;
+          LOGS_DEFAULT(VERBOSE) << "[get_input_output_names] Input '" << arg->Name()
+                                << "' has dynamic batch dimension: " << dim_param;
+        } else {
+          LOGS_DEFAULT(VERBOSE) << "[get_input_output_names] Input '" << arg->Name()
+                                << "' dimension " << i << " is symbolic: " << dim_param;
+        }
+      }
+    }
+
+    if (!input_symbolic_dims.empty()) {
+      symbolic_dims[arg->Name()] = std::move(input_symbolic_dims);
+    }
+  }
 
   const auto& out_args = graph.GetOutputs();
   std::vector<std::string> tmp_out_names;
@@ -1197,7 +1227,15 @@ bool get_input_output_names(const GraphViewer& graph,
       std::back_inserter(output_names),
       [&](const auto& name) { return !name.empty(); });
 
-  return no_input_shape;
+  if (prog_has_dynamic_batch) {
+    LOGS_DEFAULT(VERBOSE) << "[get_input_output_names] Model has dynamic batch dimension";
+  }
+  if (!symbolic_dims.empty()) {
+    LOGS_DEFAULT(VERBOSE) << "[get_input_output_names] Found " << symbolic_dims.size()
+                          << " inputs with symbolic dimensions";
+  }
+
+  return {defer_compilation, prog_has_dynamic_batch, std::move(symbolic_dims)};
 }
 
 // Attempt to load a model and catch any exceptions on load fail.
@@ -1591,7 +1629,7 @@ static void handle_input_shape_mismatch(
   }
 
   param_shapes = prog.get_parameter_shapes();
-  mgx_state->no_input_shape = false;
+  mgx_state->defer_compilation = false;
 }
 
 // Helper: Handle program inputs and outputs binding
@@ -1684,8 +1722,11 @@ struct InputShapeResult {
 
 // Helper: Handle input shape processing for both dynamic and static cases
 // This function processes runtime input shapes and determines if recompilation is needed
+// Now uses fine-grained symbolic dimension tracking for more precise shape matching
 static InputShapeResult handle_input_shape(
-    bool no_input_shape,
+    bool defer_compilation,
+    const SymbolicDimsMap& symbolic_dims,
+    bool prog_has_dynamic_batch,
     const std::unordered_map<std::string, std::size_t>& map_input_name_index,
     Ort::KernelContext& ctx,
     migraphx::onnx_options& cmp_options,
@@ -1695,12 +1736,16 @@ static InputShapeResult handle_input_shape(
   migraphx::program_parameter_shapes param_shapes;
   std::vector<std::int64_t> input_shapes;
 
-  if (no_input_shape) {
+  if (defer_compilation) {
     LOGS_DEFAULT(VERBOSE) << "[Compute] No static input shapes available, setting from runtime inputs";
     // NOTE: map_input_name_index only contains actual runtime inputs, not constants/initializers
     // Constants and initializers are embedded in the graph and MIGraphX infers their shapes
     LOGS_DEFAULT(VERBOSE) << "[Compute] Setting shapes for " << map_input_name_index.size()
                           << " runtime input parameters (excluding constants)";
+
+    if (prog_has_dynamic_batch) {
+      LOGS_DEFAULT(VERBOSE) << "[Compute] Program has dynamic batch dimension - using runtime batch sizes";
+    }
 
     for (const auto& it : map_input_name_index) {
       const auto& name = it.first;
@@ -1722,6 +1767,17 @@ static InputShapeResult handle_input_shape(
       if (!tensor_shape.empty()) {
         LOGS_DEFAULT(VERBOSE) << "[Compute] Input parameter '" << name
                               << "' batch size (runtime override): " << tensor_shape[0];
+
+        // Log which dimensions are symbolic for this input
+        auto sym_it = symbolic_dims.find(name);
+        if (sym_it != symbolic_dims.end()) {
+          for (const auto& sym_dim : sym_it->second) {
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' dimension " << sym_dim.dim_index
+                                  << " ('" << sym_dim.dim_param << "') resolved to: "
+                                  << (sym_dim.dim_index < static_cast<int>(tensor_shape.size())
+                                      ? std::to_string(tensor_shape[sym_dim.dim_index]) : "N/A");
+          }
+        }
 
         std::ostringstream shape_str;
         shape_str << "[";
@@ -1759,16 +1815,58 @@ static InputShapeResult handle_input_shape(
             mgx_lens.clear();
           }
 
-          // Check if shapes match
-          if (mgx_lens != ort_lens) {
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Shape mismatch for input '" << name
-                                  << "': MIGraphX expects [" << mgx_lens.size() << " dims], "
-                                  << "got [" << ort_lens.size() << " dims]";
+          // Check if shapes match - with fine-grained symbolic dimension tracking
+          bool shape_mismatch = (mgx_lens != ort_lens);
 
-            // Check if it's specifically a batch size change
+          if (shape_mismatch) {
+            // Check if mismatch is only in symbolic dimensions (expected and handled)
+            auto sym_it = symbolic_dims.find(name);
+            bool is_symbolic_dim_change = false;
+
+            if (sym_it != symbolic_dims.end() && mgx_lens.size() == ort_lens.size()) {
+              // Check if only symbolic dimensions changed
+              is_symbolic_dim_change = true;
+              for (size_t i = 0; i < mgx_lens.size(); ++i) {
+                if (mgx_lens[i] != ort_lens[i]) {
+                  // Check if this dimension is symbolic
+                  bool is_symbolic = false;
+                  for (const auto& sym_dim : sym_it->second) {
+                    if (sym_dim.dim_index == static_cast<int>(i)) {
+                      is_symbolic = true;
+                      LOGS_DEFAULT(VERBOSE) << "[Compute] Symbolic dimension '" << sym_dim.dim_param
+                                            << "' (dim " << i << ") changed from " << mgx_lens[i]
+                                            << " to " << ort_lens[i] << " for input '" << name << "'";
+                      break;
+                    }
+                  }
+                  if (!is_symbolic) {
+                    is_symbolic_dim_change = false;
+                    LOGS_DEFAULT(WARNING) << "[Compute] Non-symbolic dimension " << i
+                                          << " changed from " << mgx_lens[i] << " to " << ort_lens[i]
+                                          << " for input '" << name << "' - unexpected shape change";
+                    break;
+                  }
+                }
+              }
+            }
+
+            if (is_symbolic_dim_change) {
+              LOGS_DEFAULT(VERBOSE) << "[Compute] Shape change in symbolic dimensions only for input '" << name << "'";
+            } else {
+              LOGS_DEFAULT(VERBOSE) << "[Compute] Shape mismatch for input '" << name
+                                    << "': MIGraphX expects [" << mgx_lens.size() << " dims], "
+                                    << "got [" << ort_lens.size() << " dims]";
+            }
+
+            // Check if it's specifically a batch size change (common case)
             if (mgx_lens.size() == ort_lens.size() && mgx_lens.size() > 0 && mgx_lens[0] != ort_lens[0]) {
-              LOGS_DEFAULT(VERBOSE) << "[Compute] Batch size changed from " << mgx_lens[0]
-                                    << " to " << ort_lens[0] << " for input '" << name << "'";
+              if (prog_has_dynamic_batch) {
+                LOGS_DEFAULT(VERBOSE) << "[Compute] Dynamic batch size changed from " << mgx_lens[0]
+                                      << " to " << ort_lens[0] << " for input '" << name << "'";
+              } else {
+                LOGS_DEFAULT(VERBOSE) << "[Compute] Batch size changed from " << mgx_lens[0]
+                                      << " to " << ort_lens[0] << " for input '" << name << "'";
+              }
             }
 
             cmp_options.set_input_parameter_shape(name, ort_lens);
@@ -1804,7 +1902,7 @@ constexpr std::uint64_t MIGraphX_Version =
 Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused_nodes,
                                           std::vector<NodeComputeInfo>& node_compute_funcs) {
   migraphx::onnx_options options;
-  bool no_input_shape = false;
+  bool defer_compilation = false;
   for (const auto& fused_node_graph : fused_nodes) {
     const GraphViewer& graph_body_viewer = fused_node_graph.filtered_graph;
     const Node& fused_node = fused_node_graph.fused_node;
@@ -1923,13 +2021,16 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     dump_model_as_onnx(onnx_string_buffer, std::string{fused_node.Name() + ".onnx"});
 
     std::vector<std::string> input_names, output_names;
-    no_input_shape = no_input_shape || get_input_output_names(graph_body_viewer, input_names, output_names);
+    auto names_result = get_input_output_names(graph_body_viewer, input_names, output_names);
+    defer_compilation = defer_compilation || names_result.defer_compilation;
+    bool prog_has_dynamic_batch = names_result.prog_has_dynamic_batch;
+    SymbolicDimsMap symbolic_dims = std::move(names_result.symbolic_dims);
 
     // Set default batch size for symbolic dimensions in onnx_options
     // NOTE: Only set shapes for actual model inputs, NOT for constants or initializers
     // MIGraphX will automatically infer shapes for constants and intermediate tensors
     constexpr std::size_t default_batch_size = 1;
-    if (no_input_shape) {
+    if (defer_compilation) {
       LOGS_DEFAULT(VERBOSE) << "[Compile] Setting default batch size of " << default_batch_size
                             << " for model input parameters (excluding constants)";
 
@@ -1976,7 +2077,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     // the input fused_node
     migraphx::program prog;
 
-    if (!no_input_shape) {
+    if (!defer_compilation) {
       if (!load_precompiled_model(prog, model_cache_file)) {
         LOGS_DEFAULT(VERBOSE) << "[Compile] Cache miss. Compiling model with batch size included in shapes";
         LOGS_DEFAULT(VERBOSE) << "[Compile] Model cache file will be: " << model_cache_file.string();
@@ -2047,7 +2148,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
     map_onnx_string_[fused_node.Name()] = onnx_string_buffer;
     map_input_index_[fused_node.Name()] = input_name_index;
-    map_no_input_shape_[fused_node.Name()] = no_input_shape;
+    map_defer_compilation_[fused_node.Name()] = defer_compilation;
+    map_symbolic_dims_[fused_node.Name()] = symbolic_dims;
+    map_prog_has_dynamic_batch_[fused_node.Name()] = prog_has_dynamic_batch;
 
     // Initialize the batched_programs map for this node if not already done
     if (batched_programs_.find(fused_node.Name()) == batched_programs_.end()) {
@@ -2059,10 +2162,12 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       std::unique_ptr<MIGraphXFuncState> p = std::make_unique<MIGraphXFuncState>();
       *p = {context->allocate_func, context->release_func, context->allocator_handle, map_progs_[context->node_name],
             map_onnx_string_[context->node_name], options, t_, map_input_index_[context->node_name], &mgx_mu_,
-            map_no_input_shape_[context->node_name], fp16_enable_, bf16_enable_, fp8_enable_, int8_enable_,
+            map_defer_compilation_[context->node_name], fp16_enable_, bf16_enable_, fp8_enable_, int8_enable_,
             int8_calibration_cache_available_, dynamic_range_map_,
             model_cache_path_.string(), dump_model_ops_, exhaustive_tune_, max_dynamic_batch_,
-            std::ref(batched_programs_[context->node_name])};
+            std::ref(batched_programs_[context->node_name]),
+            map_symbolic_dims_[context->node_name],
+            map_prog_has_dynamic_batch_[context->node_name]};
       *state = p.release();
       return 0;
     };
@@ -2079,11 +2184,14 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       std::unordered_map<std::string, std::size_t>& map_input_name_index = mgx_state->input_name_indexes;
       migraphx::program& prog = mgx_state->prog;
       migraphx::onnx_options& cmp_options = mgx_state->options;
-      bool& no_input_shape = mgx_state->no_input_shape;
+      bool& defer_compilation = mgx_state->defer_compilation;
+      const SymbolicDimsMap& symbolic_dims = mgx_state->symbolic_dims;
+      bool prog_has_dynamic_batch = mgx_state->prog_has_dynamic_batch;
 
       // Process input shapes and determine if recompilation is needed
+      // Using fine-grained symbolic dimension tracking for more precise shape matching
       auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
-          no_input_shape, map_input_name_index, ctx, cmp_options, prog);
+          defer_compilation, symbolic_dims, prog_has_dynamic_batch, map_input_name_index, ctx, cmp_options, prog);
 
       // input shapes are different, needs to re-parse onnx and
       // re-compile the program

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1478,6 +1478,114 @@ static void free_padded_inputs(MIGraphXFuncState* mgx_state) {
   mgx_state->last_padded_batch_size = 0;
 }
 
+// Helper: Extract output index from MIGraphX output parameter name
+// MIGraphX names outputs as "#output_0", "#output_1", etc.
+static int compute_output_index(const std::string_view sv) {
+  constexpr std::string_view out_name_prefix = "#output_";
+  const auto pos = sv.find(out_name_prefix);
+  if (pos == std::string_view::npos) {
+    return -1;
+  }
+  const auto index_str = sv.substr(pos + out_name_prefix.length());
+  return ToInteger(Trim(index_str, std::isdigit));
+}
+
+// Free temporary output buffers
+static void free_temp_output_buffers(MIGraphXFuncState* mgx_state) {
+  for (auto& buf : mgx_state->temp_output_buffers) {
+    if (buf.data != nullptr) {
+      hipFree(buf.data);  // Don't throw on cleanup
+      buf.data = nullptr;
+    }
+  }
+  mgx_state->temp_output_buffers.clear();
+  mgx_state->temp_output_padded_batch_size = 0;
+}
+
+// Clear cached MIGraphX shapes (call when program changes)
+static void clear_cached_mgx_shapes(MIGraphXFuncState* mgx_state) {
+  mgx_state->cached_mgx_param_shapes.reset();
+  mgx_state->cached_mgx_output_shapes.reset();
+  mgx_state->ultra_fast_caches_populated = false;
+  mgx_state->cached_program_hash.clear();
+}
+
+// Allocate or reuse temporary output buffers for slicing mode
+// Returns vector of raw pointers for use with handle_program_input_outputs
+static std::vector<void*> get_or_allocate_temp_output_buffers(
+    MIGraphXFuncState* mgx_state,
+    const migraphx::program_parameter_shapes& param_shapes,
+    const migraphx::shapes& output_shapes,
+    const std::unordered_map<std::string, std::size_t>& map_input_name_index,
+    std::size_t padded_batch_size)
+{
+  // Check if we can reuse existing buffers
+  bool can_reuse = (
+      mgx_state->temp_output_padded_batch_size == padded_batch_size &&
+      !mgx_state->temp_output_buffers.empty()
+  );
+  
+  if (can_reuse) {
+    LOGS_DEFAULT(VERBOSE) << "[get_or_allocate_temp_output_buffers] ✓✓✓ REUSING " 
+                          << mgx_state->temp_output_buffers.size() << " temp output buffers";
+    // Return raw pointers from existing buffers
+    std::vector<void*> ptrs;
+    ptrs.reserve(mgx_state->temp_output_buffers.size());
+    for (const auto& buf : mgx_state->temp_output_buffers) {
+      ptrs.push_back(buf.data);
+    }
+    return ptrs;
+  }
+  
+  // Free old buffers if they exist
+  free_temp_output_buffers(mgx_state);
+  
+  LOGS_DEFAULT(VERBOSE) << "[get_or_allocate_temp_output_buffers] Allocating NEW temp output buffers";
+  
+  // Count outputs and allocate
+  std::vector<void*> ptrs;
+  for (const auto& name : param_shapes.names()) {
+    // Skip inputs
+    if (map_input_name_index.find(name) != map_input_name_index.end()) {
+      continue;
+    }
+    
+    // This is an output
+    const auto output_index = compute_output_index(name);
+    if (output_index != -1) {
+      const auto& mgx_shape = param_shapes[name];
+      std::size_t size_bytes = mgx_shape.bytes();
+      
+      void* buffer = nullptr;
+      auto hip_status = hipMalloc(&buffer, size_bytes);
+      if (hip_status != hipSuccess) {
+        // Clean up any allocated buffers on failure
+        for (auto& buf : mgx_state->temp_output_buffers) {
+          if (buf.data) hipFree(buf.data);
+        }
+        mgx_state->temp_output_buffers.clear();
+        ORT_THROW("hipMalloc failed for temporary output buffer");
+      }
+      
+      MIGraphXFuncState::TempOutputBuffer temp_buf;
+      temp_buf.data = buffer;
+      temp_buf.size_bytes = size_bytes;
+      temp_buf.mgx_shape = mgx_shape;
+      mgx_state->temp_output_buffers.push_back(temp_buf);
+      ptrs.push_back(buffer);
+      
+      LOGS_DEFAULT(VERBOSE) << "[get_or_allocate_temp_output_buffers] Allocated output " 
+                            << output_index << ": " << size_bytes << " bytes";
+    }
+  }
+  
+  mgx_state->temp_output_padded_batch_size = padded_batch_size;
+  LOGS_DEFAULT(VERBOSE) << "[get_or_allocate_temp_output_buffers] Allocated " 
+                        << mgx_state->temp_output_buffers.size() << " temp output buffers";
+  
+  return ptrs;
+}
+
 // Order matters here especially if the program uses mixed quantization
 // Calibrate on full precision for int8/fp8 and then quantize down to fp16
 void calibrate_and_quantize(migraphx::program& prog,
@@ -2060,17 +2168,7 @@ static void handle_input_shape_mismatch(
   mgx_state->defer_compilation = false;
 }
 
-// Helper: Extract output index from MIGraphX output parameter name
-// MIGraphX names outputs as "#output_0", "#output_1", etc.
-static int compute_output_index(const std::string_view sv) {
-  constexpr std::string_view out_name_prefix = "#output_";
-  const auto pos = sv.find(out_name_prefix);
-  if (pos == std::string_view::npos) {
-    return -1;
-  }
-  const auto index_str = sv.substr(pos + out_name_prefix.length());
-  return ToInteger(Trim(index_str, std::isdigit));
-}
+
 
 // Overload: Handle program inputs and outputs binding with pre-cached output shapes
 // This avoids calling prog.get_output_shapes() when shapes are already cached
@@ -2121,20 +2219,30 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
                                 << ", temp_output_buffers=" << (temp_output_buffers != nullptr ? "valid" : "nullptr");
           
           if (needs_slicing && temp_output_buffers != nullptr) {
-            // When slicing, allocate temporary GPU buffer for padded output
+            // When slicing, use pre-allocated temp buffer or allocate new one
             // Don't add to prog_output_indices since these aren't pre-allocated ORT outputs
             std::size_t output_size_bytes = mgx_arg_shape.bytes();
             void* temp_buffer = nullptr;
-            auto hip_status = hipMalloc(&temp_buffer, output_size_bytes);
-            if (hip_status != hipSuccess) {
-              ORT_THROW("hipMalloc failed for temporary output buffer");
+            
+            // OPTIMIZATION: Check if buffer is already pre-allocated
+            if (temp_buffer_count < temp_output_buffers->size()) {
+              // Use pre-allocated buffer from previous run
+              temp_buffer = (*temp_output_buffers)[temp_buffer_count];
+              LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] ✓ REUSING pre-allocated TEMP BUFFER for output " 
+                                    << output_index << " '" << name << "' (" << output_size_bytes << " bytes)";
+            } else {
+              // Allocate new buffer (first run or buffer list is empty)
+              auto hip_status = hipMalloc(&temp_buffer, output_size_bytes);
+              if (hip_status != hipSuccess) {
+                ORT_THROW("hipMalloc failed for temporary output buffer");
+              }
+              temp_output_buffers->push_back(temp_buffer);
+              LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] ✓ Allocated NEW TEMP BUFFER for output " 
+                                    << output_index << " '" << name << "' (" << output_size_bytes << " bytes)";
             }
-            temp_output_buffers->push_back(temp_buffer);
             temp_buffer_count++;
             m.add(name, migraphx::argument(mgx_arg_shape, temp_buffer));
-            LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] ✓ Allocated TEMP BUFFER for output " 
-                                  << output_index << " '" << name << "' (" << output_size_bytes << " bytes)"
-                                  << " - NOT adding to prog_output_indices";
+            LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] - NOT adding to prog_output_indices";
           } else {
             // Normal path: bind directly to ORT output tensor
             LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] Using NORMAL PATH for output " 
@@ -2603,23 +2711,70 @@ static bool execute_fast_path(
     return false;
   }
 
+  // Determine which hash was used to find the program
+  // This is needed to detect program changes and invalidate caches
+  std::string effective_program_hash = current_hash;
+  if (needs_padding && padded_batch_size > 0) {
+    // If we used padded hash, compute it for tracking
+    std::vector<std::int64_t> padded_shapes_for_hash_tracking;
+    for (const auto& [name, index] : mgx_state->input_name_indexes) {
+      auto input_tensor = ctx.GetInput(index);
+      auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+      const auto tensor_shape = tensor_info.GetShape();
+      if (!tensor_shape.empty()) {
+        padded_shapes_for_hash_tracking.push_back(static_cast<std::int64_t>(padded_batch_size));
+        padded_shapes_for_hash_tracking.insert(padded_shapes_for_hash_tracking.end(), 
+                                               tensor_shape.begin() + 1, tensor_shape.end());
+      }
+    }
+    effective_program_hash = make_hash(padded_shapes_for_hash_tracking);
+  }
+
   // Found cached program - use it and populate caches
-  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Using cached program, populating caches";
+  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Using cached program (hash: " << effective_program_hash << ")";
   auto& prog = mgx_state->prog;
   prog = prog_it->second;
 
   const auto& map_input_name_index = mgx_state->input_name_indexes;
 
-  // Get shapes once
-  auto param_shapes = prog.get_parameter_shapes();
-  auto output_shapes = prog.get_output_shapes();
+  // ═══════════════════════════════════════════════════════════════════════════
+  // OPTIMIZATION 1: Cache MIGraphX API results (avoid redundant API calls)
+  // Check if program changed - if so, invalidate caches
+  // ═══════════════════════════════════════════════════════════════════════════
+  bool program_changed = (mgx_state->cached_program_hash != effective_program_hash);
+  
+  if (program_changed) {
+    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Program changed (old: " << mgx_state->cached_program_hash 
+                          << ", new: " << effective_program_hash << ") - clearing caches";
+    clear_cached_mgx_shapes(mgx_state);
+    free_temp_output_buffers(mgx_state);
+    mgx_state->cached_program_hash = effective_program_hash;
+  }
+  
+  if (!mgx_state->cached_mgx_param_shapes.has_value()) {
+    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Caching MIGraphX shapes (first time or after program change)";
+    mgx_state->cached_mgx_param_shapes = prog.get_parameter_shapes();
+    mgx_state->cached_mgx_output_shapes = prog.get_output_shapes();
+  } else {
+    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] ✓ Using cached MIGraphX shapes";
+  }
+  const auto& param_shapes = mgx_state->cached_mgx_param_shapes.value();
+  const auto& output_shapes = mgx_state->cached_mgx_output_shapes.value();
 
   bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 && 
                         original_batch_size < padded_batch_size);
   
-  // Populate optimized caches for ultra-fast path (disabled when slicing)
-  populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index,
-                            original_batch_size, padded_batch_size);
+  // ═══════════════════════════════════════════════════════════════════════════
+  // OPTIMIZATION 2: Skip populate_ultra_fast_caches when already populated
+  // ═══════════════════════════════════════════════════════════════════════════
+  if (!mgx_state->ultra_fast_caches_populated) {
+    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Populating ultra-fast caches (first time)";
+    populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index,
+                              original_batch_size, padded_batch_size);
+    mgx_state->ultra_fast_caches_populated = true;
+  } else {
+    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] ✓ Ultra-fast caches already populated";
+  }
 
   // Allocate and pad inputs if needed for dynamic batching
   bool using_padded_inputs = false;
@@ -2631,15 +2786,24 @@ static bool execute_fast_path(
                                                   padded_batch_size, rocm_stream);
   }
 
+  // ═══════════════════════════════════════════════════════════════════════════
+  // OPTIMIZATION 3: Reuse temp output buffers when slicing
+  // ═══════════════════════════════════════════════════════════════════════════
+  std::vector<void*> temp_output_buffer_ptrs;
+  if (needs_slicing) {
+    temp_output_buffer_ptrs = get_or_allocate_temp_output_buffers(
+        mgx_state, param_shapes, output_shapes, map_input_name_index, padded_batch_size);
+  }
+
   // Bind inputs/outputs (use temp buffers for outputs when slicing)
   LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Calling handle_program_input_outputs with needs_slicing=" << needs_slicing;
-  std::vector<void*> temp_output_buffers;
   auto [m, prog_output_indices] = handle_program_input_outputs(
-      param_shapes, output_shapes, map_input_name_index, ctx, needs_slicing, &temp_output_buffers);
+      param_shapes, output_shapes, map_input_name_index, ctx, needs_slicing, 
+      needs_slicing ? &temp_output_buffer_ptrs : nullptr);
 
   LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] handle_program_input_outputs returned:";
   LOGS_DEFAULT(VERBOSE) << "[FAST_PATH]   prog_output_indices.size()=" << prog_output_indices.size();
-  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH]   temp_output_buffers.size()=" << temp_output_buffers.size();
+  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH]   temp_output_buffer_ptrs.size()=" << temp_output_buffer_ptrs.size();
   if (needs_slicing && !prog_output_indices.empty()) {
     LOGS_DEFAULT(VERBOSE) << "[FAST_PATH]   ⚠️  WARNING: prog_output_indices is NOT empty with slicing enabled!";
   }
@@ -2675,15 +2839,8 @@ static bool execute_fast_path(
                        mgx_state->cached_prog_output_indices,
                        original_batch_size, padded_batch_size);
   
-  // Free temporary output buffers
-  for (void* buf : temp_output_buffers) {
-    if (buf != nullptr) {
-      hipFree(buf);
-    }
-  }
-  
-  // NOTE: Padded buffers are kept for reuse - they will be freed when batch size changes
-  // or when the state is destroyed
+  // NOTE: Temp output buffers are kept for reuse - they will be freed when batch size changes
+  // NOTE: Padded input buffers are also kept for reuse
   
   LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Complete";
   return true;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1340,16 +1340,10 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     // empty cache path means the MXR caching is disabled - always compile
     if (!model_cache_path_.empty() or first_start_) {
       std::vector<std::int64_t> input_shapes;
-
-      // Use input_tensor directly, not session_input_names.size()
-      for (std::size_t i = 0; i < input_tensor.size(); ++i) {
+      for (std::size_t i = 0; i < session_input_names.size(); ++i) {
         auto tensor_shape = input_tensor[i]->Shape();
-
-        // Check if shape is valid
-        if (tensor_shape == nullptr || tensor_shape->dim_size() == 0) {
-          LOGS_DEFAULT(WARNING) << "Input " << i << " has no shape information";
-          input_shapes.clear();
-          break;
+        for (int j = 1; j < tensor_shape->dim_size(); ++j) {
+          input_shapes.push_back(tensor_shape->dim(j).dim_value());
         }
 
         // Log batch size (first dimension) for tracking
@@ -1358,21 +1352,6 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
                                 << ") batch size: " << batch_size;
         }
-
-        // Include ALL dimensions (including batch), or skip only if dim_value is 0
-        for (int j = 0; j < tensor_shape->dim_size(); ++j) {
-          if (tensor_shape->dim(j).has_dim_value()) {
-            auto dim_val = tensor_shape->dim(j).dim_value();
-            if (dim_val > 0) {  // Only add valid dimensions
-              input_shapes.push_back(dim_val);
-            }
-          }
-        }
-      }
-
-      if(input_shapes.empty())
-      {
-        LOGS_DEFAULT(ERROR) << "Input shapes are empty, skipping model caching";
       }
       model_cache_file = model_cache_path_ / (mxr_filename_prefix + make_hash(input_shapes) + ".mxr");
       first_start_ = false;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1900,6 +1900,179 @@ static void populate_ultra_fast_caches(
   }
 }
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// EXECUTION PATH FUNCTIONS - Encapsulated paths for cleaner compute_func
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Ultra-fast path: Shapes unchanged from last run - just rebind pointers and execute
+// Returns true if executed successfully, false if shapes don't match
+static bool execute_ultra_fast_path(
+    MIGraphXFuncState* mgx_state,
+    const OrtApi* api,
+    OrtKernelContext* context,
+    Ort::KernelContext& ctx)
+{
+  if (!mgx_state->caches_valid || mgx_state->last_input_shapes_raw.empty()) {
+    return false;
+  }
+
+  // Quick shape comparison
+  bool shapes_match = true;
+  std::size_t offset = 0;
+  const auto& last_shapes = mgx_state->last_input_shapes_raw;
+
+  for (const auto& inp : mgx_state->cached_inputs) {
+    const auto& shape = ctx.GetInput(inp.ort_index).GetTensorTypeAndShapeInfo().GetShape();
+    if (offset + shape.size() > last_shapes.size()) {
+      shapes_match = false;
+      break;
+    }
+    for (std::size_t i = 0; i < shape.size(); ++i) {
+      if (last_shapes[offset + i] != shape[i]) {
+        shapes_match = false;
+        break;
+      }
+    }
+    if (!shapes_match) break;
+    offset += shape.size();
+  }
+
+  if (!shapes_match || offset != last_shapes.size()) {
+    return false;
+  }
+
+  // Shapes unchanged - rebind pointers and run directly
+  auto& m = mgx_state->cached_prog_params.value();
+  auto& prog = mgx_state->prog;
+
+  // Rebind inputs - direct iteration, no map lookups
+  for (const auto& inp : mgx_state->cached_inputs) {
+    const auto& input_tensor = ctx.GetInput(inp.ort_index);
+    m.add(inp.name.c_str(), migraphx::argument(inp.mgx_shape,
+                                       const_cast<void*>(input_tensor.GetTensorRawData())));
+  }
+
+  // Rebind outputs - direct iteration, uses pre-allocated shape vectors
+  for (std::size_t i = 0; i < mgx_state->cached_outputs.size(); ++i) {
+    const auto& out = mgx_state->cached_outputs[i];
+    const auto& ort_shape = mgx_state->cached_output_ort_shapes[i];
+    auto output_tensor = ctx.GetOutput(out.output_index, ort_shape.data(), ort_shape.size());
+    m.add(out.name.c_str(), migraphx::argument(out.mgx_shape,
+                                       output_tensor.GetTensorMutableRawData()));
+  }
+
+  // Run directly - minimal overhead path
+  run_migraphx_program(mgx_state->mgx_sem_ptr, api, context, ctx, prog, m,
+                       mgx_state->cached_prog_output_indices);
+  return true;
+}
+
+// Fast path: Found cached program for this shape hash - populate caches and execute
+// Returns true if a cached program was found and executed
+// Note: all_input_shapes is only consumed (moved) if the function returns true
+static bool execute_fast_path(
+    MIGraphXFuncState* mgx_state,
+    const OrtApi* api,
+    OrtKernelContext* context,
+    Ort::KernelContext& ctx,
+    const std::string& current_hash,
+    std::vector<std::int64_t>& all_input_shapes)
+{
+  if (mgx_state->defer_compilation || !mgx_state->cached_programs_ref.has_value()) {
+    return false;
+  }
+
+  auto& cached_programs = mgx_state->cached_programs_ref.value().get();
+  auto prog_it = cached_programs.find(current_hash);
+  if (prog_it == cached_programs.end()) {
+    return false;
+  }
+
+  // Found cached program - use it and populate caches
+  auto& prog = mgx_state->prog;
+  prog = prog_it->second;
+
+  const auto& map_input_name_index = mgx_state->input_name_indexes;
+
+  // Get shapes once
+  auto param_shapes = prog.get_parameter_shapes();
+  auto output_shapes = prog.get_output_shapes();
+
+  // Populate optimized caches for ultra-fast path
+  populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
+
+  // Bind inputs/outputs
+  auto [m, prog_output_indices] = handle_program_input_outputs(
+      param_shapes, output_shapes, map_input_name_index, ctx);
+
+  mgx_state->cached_prog_params = std::move(m);
+  mgx_state->cached_prog_output_indices = std::move(prog_output_indices);
+  mgx_state->last_input_shapes_raw = std::move(all_input_shapes);
+  mgx_state->last_input_shape_hash = current_hash;
+  mgx_state->caches_valid = true;
+
+  run_migraphx_program(mgx_state->mgx_sem_ptr, api, context, ctx, prog,
+                       mgx_state->cached_prog_params.value(),
+                       mgx_state->cached_prog_output_indices);
+  return true;
+}
+
+// Standard path: Shape checking, potential recompilation, and execution
+static void execute_standard_path(
+    MIGraphXFuncState* mgx_state,
+    const OrtApi* api,
+    OrtKernelContext* context,
+    Ort::KernelContext& ctx,
+    const std::string& current_hash,
+    std::vector<std::int64_t>&& all_input_shapes,
+    const std::filesystem::path& model_cache_path,
+    const std::filesystem::path& model_path,
+    const std::string& mxr_filename_prefix)
+{
+  auto& prog = mgx_state->prog;
+  auto& cmp_options = mgx_state->options;
+  const auto& map_input_name_index = mgx_state->input_name_indexes;
+
+  auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
+      mgx_state->defer_compilation, map_input_name_index, ctx, cmp_options, prog);
+
+  if (!input_shape_match) {
+    // Invalidate caches before recompilation
+    mgx_state->caches_valid = false;
+
+    handle_input_shape_mismatch(
+        mgx_state,
+        model_cache_path,
+        model_path,
+        mxr_filename_prefix,
+        ctx,
+        param_shapes,
+        input_shapes);
+
+    // Re-fetch param_shapes after recompilation
+    param_shapes = prog.get_parameter_shapes();
+  }
+
+  // Fetch output shapes once
+  auto output_shapes = prog.get_output_shapes();
+
+  // Populate optimized caches for ultra-fast path
+  populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
+
+  // Bind inputs and allocate outputs
+  auto [m, prog_output_indices] = handle_program_input_outputs(
+      param_shapes, output_shapes, map_input_name_index, ctx);
+
+  // Complete cache population
+  mgx_state->cached_prog_params = m;
+  mgx_state->cached_prog_output_indices = prog_output_indices;
+  mgx_state->last_input_shapes_raw = std::move(all_input_shapes);
+  mgx_state->last_input_shape_hash = current_hash;
+  mgx_state->caches_valid = true;
+
+  run_migraphx_program(mgx_state->mgx_sem_ptr, api, context, ctx, prog, m, prog_output_indices);
+}
+
 // Result structure for handle_input_shape function
 struct InputShapeResult {
   bool input_shape_match;
@@ -2142,68 +2315,19 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       Ort::KernelContext ctx(context);
       MIGraphXFuncState* mgx_state = reinterpret_cast<MIGraphXFuncState*>(state);
 
-      auto& map_input_name_index = mgx_state->input_name_indexes;
-      auto& prog = mgx_state->prog;
-      auto& cmp_options = mgx_state->options;
-
       // ═══════════════════════════════════════════════════════════════════════
-      // ULTRA-FAST PATH: Quick shape comparison without hash computation
-      // Directly compare raw shape values - avoids MurmurHash overhead
+      // ULTRA-FAST PATH: Shapes unchanged from last run
       // ═══════════════════════════════════════════════════════════════════════
-      if (mgx_state->caches_valid && !mgx_state->last_input_shapes_raw.empty()) {
-        bool shapes_match = true;
-        std::size_t offset = 0;
-        const auto& last_shapes = mgx_state->last_input_shapes_raw;
-
-        // Quick comparison using cached input list (already in correct order)
-        for (const auto& inp : mgx_state->cached_inputs) {
-          const auto& shape = ctx.GetInput(inp.ort_index).GetTensorTypeAndShapeInfo().GetShape();
-          if (offset + shape.size() > last_shapes.size()) {
-            shapes_match = false;
-            break;
-          }
-          for (std::size_t i = 0; i < shape.size(); ++i) {
-            if (last_shapes[offset + i] != shape[i]) {
-              shapes_match = false;
-              break;
-            }
-          }
-          if (!shapes_match) break;
-          offset += shape.size();
-        }
-
-        if (shapes_match && offset == last_shapes.size()) {
-          // Shapes unchanged - rebind pointers and run directly
-          auto& m = mgx_state->cached_prog_params.value();
-
-          // Rebind inputs - direct iteration, no map lookups
-          for (const auto& inp : mgx_state->cached_inputs) {
-            const auto& input_tensor = ctx.GetInput(inp.ort_index);
-            m.add(inp.name.c_str(), migraphx::argument(inp.mgx_shape,
-                                               const_cast<void*>(input_tensor.GetTensorRawData())));
-          }
-
-          // Rebind outputs - direct iteration, uses pre-allocated shape vectors
-          for (std::size_t i = 0; i < mgx_state->cached_outputs.size(); ++i) {
-            const auto& out = mgx_state->cached_outputs[i];
-            const auto& ort_shape = mgx_state->cached_output_ort_shapes[i];
-            auto output_tensor = ctx.GetOutput(out.output_index, ort_shape.data(), ort_shape.size());
-            m.add(out.name.c_str(), migraphx::argument(out.mgx_shape,
-                                               output_tensor.GetTensorMutableRawData()));
-          }
-
-          // Run directly - minimal overhead path
-          run_migraphx_program(mgx_state->mgx_sem_ptr, api, context, ctx, prog, m,
-                               mgx_state->cached_prog_output_indices);
-          return Status::OK();
-        }
+      if (execute_ultra_fast_path(mgx_state, api, context, ctx)) {
+        return Status::OK();
       }
 
       // ═══════════════════════════════════════════════════════════════════════
       // Build input shape hash - only computed when shapes change
       // ═══════════════════════════════════════════════════════════════════════
+      const auto& map_input_name_index = mgx_state->input_name_indexes;
       std::vector<std::int64_t> all_input_shapes;
-      all_input_shapes.reserve(map_input_name_index.size() * 4);  // Pre-allocate
+      all_input_shapes.reserve(map_input_name_index.size() * 4);
       for (const auto& [name, index] : map_input_name_index) {
         const auto& shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
         all_input_shapes.insert(all_input_shapes.end(), shape.begin(), shape.end());
@@ -2213,78 +2337,15 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       // ═══════════════════════════════════════════════════════════════════════
       // FAST PATH: Check cached programs for this shape hash
       // ═══════════════════════════════════════════════════════════════════════
-      if (!mgx_state->defer_compilation && mgx_state->cached_programs_ref.has_value()) {
-        auto& cached_programs = mgx_state->cached_programs_ref.value().get();
-        auto prog_it = cached_programs.find(current_hash);
-        if (prog_it != cached_programs.end()) {
-          // Found cached program - use it and populate caches
-          prog = prog_it->second;
-
-          // Get shapes once
-          auto param_shapes = prog.get_parameter_shapes();
-          auto output_shapes = prog.get_output_shapes();
-
-          // Populate optimized caches for ultra-fast path
-          populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
-
-          // Bind inputs/outputs
-          auto [m, prog_output_indices] = handle_program_input_outputs(
-              param_shapes, output_shapes, map_input_name_index, ctx);
-
-          mgx_state->cached_prog_params = std::move(m);
-          mgx_state->cached_prog_output_indices = std::move(prog_output_indices);
-          mgx_state->last_input_shapes_raw = std::move(all_input_shapes);  // Store for quick comparison
-          mgx_state->last_input_shape_hash = current_hash;
-          mgx_state->caches_valid = true;
-
-          run_migraphx_program(mgx_state->mgx_sem_ptr, api, context, ctx, prog,
-                               mgx_state->cached_prog_params.value(),
-                               mgx_state->cached_prog_output_indices);
-          return Status::OK();
-        }
+      if (execute_fast_path(mgx_state, api, context, ctx, current_hash, all_input_shapes)) {
+        return Status::OK();
       }
 
       // ═══════════════════════════════════════════════════════════════════════
       // STANDARD PATH: Shape checking and potential recompilation
       // ═══════════════════════════════════════════════════════════════════════
-      auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
-          mgx_state->defer_compilation, map_input_name_index, ctx, cmp_options, prog);
-
-      if (!input_shape_match) {
-        // Invalidate caches before recompilation
-        mgx_state->caches_valid = false;
-
-        handle_input_shape_mismatch(
-            mgx_state,
-            model_cache_path_,
-            model_path_,
-            mxr_filename_prefix,
-            ctx,
-            param_shapes,
-            input_shapes);
-
-        // Re-fetch param_shapes after recompilation
-        param_shapes = prog.get_parameter_shapes();
-      }
-
-      // Fetch output shapes once
-      auto output_shapes = prog.get_output_shapes();
-
-      // Populate optimized caches for ultra-fast path
-      populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
-
-      // Bind inputs and allocate outputs
-      auto [m, prog_output_indices] = handle_program_input_outputs(
-          param_shapes, output_shapes, map_input_name_index, ctx);
-
-      // Complete cache population
-      mgx_state->cached_prog_params = m;
-      mgx_state->cached_prog_output_indices = prog_output_indices;
-      mgx_state->last_input_shapes_raw = std::move(all_input_shapes);  // Store for quick comparison
-      mgx_state->last_input_shape_hash = current_hash;
-      mgx_state->caches_valid = true;
-
-      run_migraphx_program(mgx_state->mgx_sem_ptr, api, context, ctx, prog, m, prog_output_indices);
+      execute_standard_path(mgx_state, api, context, ctx, current_hash, std::move(all_input_shapes),
+                            model_cache_path_, model_path_, mxr_filename_prefix);
 
       return Status::OK();
     };

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1742,6 +1742,7 @@ static void handle_input_shape_mismatch(
   mgx_state->cached_output_ort_shapes.clear();
   mgx_state->cached_prog_params = std::nullopt;
   mgx_state->cached_prog_output_indices.clear();
+  mgx_state->last_input_shapes_raw.clear();
   mgx_state->last_input_shape_hash.clear();
 
   param_shapes = prog.get_parameter_shapes();
@@ -2146,7 +2147,60 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       auto& cmp_options = mgx_state->options;
 
       // ═══════════════════════════════════════════════════════════════════════
-      // Build input shape hash ONCE - used for all cache lookups
+      // ULTRA-FAST PATH: Quick shape comparison without hash computation
+      // Directly compare raw shape values - avoids MurmurHash overhead
+      // ═══════════════════════════════════════════════════════════════════════
+      if (mgx_state->caches_valid && !mgx_state->last_input_shapes_raw.empty()) {
+        bool shapes_match = true;
+        std::size_t offset = 0;
+        const auto& last_shapes = mgx_state->last_input_shapes_raw;
+
+        // Quick comparison using cached input list (already in correct order)
+        for (const auto& inp : mgx_state->cached_inputs) {
+          const auto& shape = ctx.GetInput(inp.ort_index).GetTensorTypeAndShapeInfo().GetShape();
+          if (offset + shape.size() > last_shapes.size()) {
+            shapes_match = false;
+            break;
+          }
+          for (std::size_t i = 0; i < shape.size(); ++i) {
+            if (last_shapes[offset + i] != shape[i]) {
+              shapes_match = false;
+              break;
+            }
+          }
+          if (!shapes_match) break;
+          offset += shape.size();
+        }
+
+        if (shapes_match && offset == last_shapes.size()) {
+          // Shapes unchanged - rebind pointers and run directly
+          auto& m = mgx_state->cached_prog_params.value();
+
+          // Rebind inputs - direct iteration, no map lookups
+          for (const auto& inp : mgx_state->cached_inputs) {
+            const auto& input_tensor = ctx.GetInput(inp.ort_index);
+            m.add(inp.name.c_str(), migraphx::argument(inp.mgx_shape,
+                                               const_cast<void*>(input_tensor.GetTensorRawData())));
+          }
+
+          // Rebind outputs - direct iteration, uses pre-allocated shape vectors
+          for (std::size_t i = 0; i < mgx_state->cached_outputs.size(); ++i) {
+            const auto& out = mgx_state->cached_outputs[i];
+            const auto& ort_shape = mgx_state->cached_output_ort_shapes[i];
+            auto output_tensor = ctx.GetOutput(out.output_index, ort_shape.data(), ort_shape.size());
+            m.add(out.name.c_str(), migraphx::argument(out.mgx_shape,
+                                               output_tensor.GetTensorMutableRawData()));
+          }
+
+          // Run directly - minimal overhead path
+          run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m,
+                               mgx_state->cached_prog_output_indices);
+          return Status::OK();
+        }
+      }
+
+      // ═══════════════════════════════════════════════════════════════════════
+      // Build input shape hash - only computed when shapes change
       // ═══════════════════════════════════════════════════════════════════════
       std::vector<std::int64_t> all_input_shapes;
       all_input_shapes.reserve(map_input_name_index.size() * 4);  // Pre-allocate
@@ -2155,35 +2209,6 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         all_input_shapes.insert(all_input_shapes.end(), shape.begin(), shape.end());
       }
       const auto current_hash = make_hash(all_input_shapes);
-
-      // ═══════════════════════════════════════════════════════════════════════
-      // ULTRA-FAST PATH: Same shapes as last run - just rebind pointers and run
-      // No map lookups, no string parsing, no vector allocations
-      // ═══════════════════════════════════════════════════════════════════════
-      if (mgx_state->caches_valid && current_hash == mgx_state->last_input_shape_hash) {
-        auto& m = mgx_state->cached_prog_params.value();
-
-        // Rebind inputs - direct iteration, no map lookups
-        for (const auto& inp : mgx_state->cached_inputs) {
-          const auto& input_tensor = ctx.GetInput(inp.ort_index);
-          m.add(inp.name.c_str(), migraphx::argument(inp.mgx_shape,
-                                             const_cast<void*>(input_tensor.GetTensorRawData())));
-        }
-
-        // Rebind outputs - direct iteration, uses pre-allocated shape vectors
-        for (std::size_t i = 0; i < mgx_state->cached_outputs.size(); ++i) {
-          const auto& out = mgx_state->cached_outputs[i];
-          const auto& ort_shape = mgx_state->cached_output_ort_shapes[i];
-          auto output_tensor = ctx.GetOutput(out.output_index, ort_shape.data(), ort_shape.size());
-          m.add(out.name.c_str(), migraphx::argument(out.mgx_shape,
-                                             output_tensor.GetTensorMutableRawData()));
-        }
-
-        // Run directly - minimal overhead path
-        run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m,
-                             mgx_state->cached_prog_output_indices);
-        return Status::OK();
-      }
 
       // ═══════════════════════════════════════════════════════════════════════
       // FAST PATH: Check cached programs for this shape hash
@@ -2208,6 +2233,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
           mgx_state->cached_prog_params = std::move(m);
           mgx_state->cached_prog_output_indices = std::move(prog_output_indices);
+          mgx_state->last_input_shapes_raw = std::move(all_input_shapes);  // Store for quick comparison
           mgx_state->last_input_shape_hash = current_hash;
           mgx_state->caches_valid = true;
 
@@ -2254,6 +2280,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       // Complete cache population
       mgx_state->cached_prog_params = m;
       mgx_state->cached_prog_output_indices = prog_output_indices;
+      mgx_state->last_input_shapes_raw = std::move(all_input_shapes);  // Store for quick comparison
       mgx_state->last_input_shape_hash = current_hash;
       mgx_state->caches_valid = true;
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1352,6 +1352,13 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           break;
         }
 
+        // Log batch size (first dimension) for tracking
+        if (tensor_shape->dim_size() > 0 && tensor_shape->dim(0).has_dim_value()) {
+          auto batch_size = tensor_shape->dim(0).dim_value();
+          LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                                << ") batch size: " << batch_size;
+        }
+
         // Include ALL dimensions (including batch), or skip only if dim_value is 0
         for (int j = 0; j < tensor_shape->dim_size(); ++j) {
           if (tensor_shape->dim(j).has_dim_value()) {
@@ -1476,6 +1483,11 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
           cmp_options.set_input_parameter_shape(name, ort_lens);
           input_shape_match = false;
+
+          // Log batch size for tracking
+          if (!tensor_shape.empty()) {
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' batch size: " << tensor_shape[0];
+          }
         }
       } else {
         LOGS_DEFAULT(VERBOSE) << "Assigning inputs, and parameters from compiled model";
@@ -1505,6 +1517,11 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
                 input_shape_match = false;
               }
               input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
+
+              // Log batch size for tracking
+              if (!tensor_shape.empty()) {
+                LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' batch size: " << tensor_shape[0];
+              }
             }
           }
         }
@@ -1606,6 +1623,12 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
               auto output_tensor = ctx.GetOutput(output_index, ort_output_shape.data(), ort_output_shape.size());
               void* output_data = output_tensor.GetTensorMutableRawData();
 
+              // Log output batch size for tracking
+              if (!ort_output_shape.empty()) {
+                LOGS_DEFAULT(VERBOSE) << "[Compute] Output " << output_index << " ('" << name
+                                      << "') batch size: " << ort_output_shape[0];
+              }
+
               // argument shape
               auto mgx_arg_shape = param_shapes[name];
               m.add(name, migraphx::argument(mgx_arg_shape, output_data));
@@ -1634,6 +1657,12 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
             auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
             void* output_data = output_tensor.GetTensorMutableRawData();
+
+            // Log output batch size for tracking
+            if (!ort_shape.empty()) {
+              LOGS_DEFAULT(VERBOSE) << "[Compute] Output " << i << " batch size: " << ort_shape[0];
+            }
+
             HIP_CALL_THROW(hipMemcpyWithStream(output_data,
                                                gpu_res.data(),
                                                res_shape.bytes(),

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1589,7 +1589,7 @@ static migraphx::program load_or_compile_model(
 // This function executes the compiled MIGraphX program and copies outputs that
 // were not pre-allocated (input parameters reused as outputs) to the ORT output tensors
 static void run_migraphx_program(
-    std::mutex* mgx_mu_ptr,
+    std::binary_semaphore* mgx_sem_ptr,
     const OrtApi* api,
     OrtKernelContext* context,
     Ort::KernelContext& ctx,
@@ -1601,10 +1601,10 @@ static void run_migraphx_program(
   Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &rocm_stream));
 
   std::optional<migraphx::arguments> prog_outputs;
-  {  // lock to avoid race condition
-     std::lock_guard<std::mutex> lock(*mgx_mu_ptr);
-     prog_outputs = prog.run_async(m, static_cast<hipStream_t>(rocm_stream));
-  }
+  // Use binary semaphore for synchronization (acquire/release pattern)
+  mgx_sem_ptr->acquire();
+  prog_outputs = prog.run_async(m, static_cast<hipStream_t>(rocm_stream));
+  mgx_sem_ptr->release();
 
   // In case of input parameters are reused as output parameter call hipMemcpy
   auto output_num = prog_outputs->size();
@@ -2124,7 +2124,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     compute_info.create_state_func = [=](ComputeContext* context, FunctionState* state) {
       std::unique_ptr<MIGraphXFuncState> p = std::make_unique<MIGraphXFuncState>();
       *p = {context->allocate_func, context->release_func, context->allocator_handle, map_progs_[context->node_name],
-            map_onnx_string_[context->node_name], options, t_, map_input_index_[context->node_name], &mgx_mu_,
+            map_onnx_string_[context->node_name], options, t_, map_input_index_[context->node_name], &mgx_sem_,
             map_defer_compilation_[context->node_name], fp16_enable_, bf16_enable_, fp8_enable_, int8_enable_,
             int8_calibration_cache_available_, dynamic_range_map_,
             model_cache_path_.string(), dump_model_ops_, exhaustive_tune_, max_dynamic_batch_,
@@ -2193,7 +2193,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           }
 
           // Run directly - minimal overhead path
-          run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m,
+          run_migraphx_program(mgx_state->mgx_sem_ptr, api, context, ctx, prog, m,
                                mgx_state->cached_prog_output_indices);
           return Status::OK();
         }
@@ -2237,7 +2237,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           mgx_state->last_input_shape_hash = current_hash;
           mgx_state->caches_valid = true;
 
-          run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog,
+          run_migraphx_program(mgx_state->mgx_sem_ptr, api, context, ctx, prog,
                                mgx_state->cached_prog_params.value(),
                                mgx_state->cached_prog_output_indices);
           return Status::OK();
@@ -2284,7 +2284,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       mgx_state->last_input_shape_hash = current_hash;
       mgx_state->caches_valid = true;
 
-      run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, prog_output_indices);
+      run_migraphx_program(mgx_state->mgx_sem_ptr, api, context, ctx, prog, m, prog_output_indices);
 
       return Status::OK();
     };

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1619,6 +1619,87 @@ static void handle_input_shape_mismatch(
   no_input_shape = false;
 }
 
+// Helper: Handle program inputs and outputs binding
+// This function binds input tensors and allocates output tensors for the MIGraphX program
+static
+std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program_input_outputs(
+    const migraphx::program_parameter_shapes& param_shapes,
+    const std::unordered_map<std::string, std::size_t>& map_input_name_index,
+    const Ort::KernelContext& ctx,
+    const migraphx::program& prog)
+{
+  migraphx::program_parameters m;
+  std::vector<std::size_t> prog_output_indices;
+  auto prog_output_shapes = prog.get_output_shapes();
+
+  if (param_shapes.size() > 0) {
+    for (auto&& name : param_shapes.names()) {
+      if (map_input_name_index.count(name) > 0) {
+        LOGS_DEFAULT(VERBOSE) << "Setting parameters for:" << name;
+        auto input_tensor = ctx.GetInput(map_input_name_index.at(name));
+        auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+        const auto tensor_shape = tensor_info.GetShape();
+        const auto tensor_type = tensor_info.GetElementType();
+
+        migraphx_shape_datatype_t mgx_type;
+        getMIGraphXType(tensor_type, mgx_type);
+        auto mgx_s = param_shapes[name];
+
+        if (mgx_type != mgx_s.type()) {
+          LOGS_DEFAULT(FATAL) << "MIGraphX: param type mismatch";
+        }
+
+        LOGS_DEFAULT(VERBOSE) << "Writing Raw tensor data ";
+        m.add(name, migraphx::argument(param_shapes[name],
+                                       const_cast<void*>(input_tensor.GetTensorRawData())));
+      }
+      // It is an output argument
+      else {
+        auto compute_output_index = [](const std::string_view sv) -> int {
+          constexpr std::string_view out_name_prefix = "#output_";
+          const auto pos = sv.find(out_name_prefix);
+          if (pos == std::string_view::npos) {
+            return -1;
+          }
+
+          const auto index_str = sv.substr(pos + out_name_prefix.length());
+          return ToInteger(Trim(index_str, std::isdigit));
+        };
+
+        int output_index = compute_output_index(name);
+        if (output_index != -1) {
+          prog_output_indices.push_back(static_cast<std::size_t>(output_index));
+          auto mgx_output_shape = prog_output_shapes[output_index];
+          auto lens = mgx_output_shape.lengths();
+          std::vector<int64_t> ort_output_shape(lens.begin(), lens.end());
+          auto output_tensor = ctx.GetOutput(output_index, ort_output_shape.data(), ort_output_shape.size());
+          void* output_data = output_tensor.GetTensorMutableRawData();
+
+          // Log output batch size for tracking
+          if (!ort_output_shape.empty()) {
+            LOGS_DEFAULT(INFO) << "[Compute] Output " << output_index << " ('" << name
+                                  << "') allocated with shape: ["
+                                  << [&]() {
+                                      std::ostringstream ss;
+                                      for (size_t j = 0; j < ort_output_shape.size(); ++j) {
+                                        if (j > 0) ss << ", ";
+                                        ss << ort_output_shape[j];
+                                      }
+                                      return ss.str();
+                                    }() << "]";
+            LOGS_DEFAULT(INFO) << "[Compute] Output " << output_index << " batch size: " << ort_output_shape[0];
+          }
+
+          // argument shape
+          auto mgx_arg_shape = param_shapes[name];
+          m.add(name, migraphx::argument(mgx_arg_shape, output_data));
+        }
+      }
+    }
+  }
+  return {m, prog_output_indices};
+}
+
 constexpr std::uint64_t MIGraphX_Version =
     ((MIGRAPHX_VERSION_MAJOR << 16) | (MIGRAPHX_VERSION_MINOR << 8) | MIGRAPHX_VERSION_PATCH);
 
@@ -2015,89 +2096,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             no_input_shape);
       }
 
-      migraphx::program_parameters m;
-      auto prog_output_shapes = prog.get_output_shapes();
-      std::vector<std::size_t> prog_output_indices;
-
-      // Log the output shapes from the compiled program to verify they match input batch
-      LOGS_DEFAULT(INFO) << "[Compute] Program has " << prog_output_shapes.size() << " outputs:";
-      for (std::size_t i = 0; i < prog_output_shapes.size(); ++i) {
-        auto out_lens = prog_output_shapes[i].lengths();
-        std::ostringstream ss;
-        ss << "[";
-        for (size_t j = 0; j < out_lens.size(); ++j) {
-          if (j > 0) ss << ", ";
-          ss << out_lens[j];
-        }
-        ss << "]";
-        LOGS_DEFAULT(INFO) << "[Compute] Program output " << i << " shape: " << ss.str();
-      }
-
-      if (param_shapes.size() > 0) {
-        for (auto&& name : param_shapes.names()) {
-          if (map_input_name_index.count(name) > 0) {
-            LOGS_DEFAULT(VERBOSE) << "Setting parameters for:" << name;
-            auto input_tensor = ctx.GetInput(map_input_name_index[name]);
-            auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-            const auto tensor_shape = tensor_info.GetShape();
-            const auto tensor_type = tensor_info.GetElementType();
-
-            migraphx_shape_datatype_t mgx_type;
-            getMIGraphXType(tensor_type, mgx_type);
-            auto mgx_s = param_shapes[name];
-
-            if (mgx_type != mgx_s.type()) {
-              LOGS_DEFAULT(FATAL) << "MIGraphX: param type mismatch";
-            }
-
-            LOGS_DEFAULT(VERBOSE) << "Writing Raw tensor data ";
-            m.add(name, migraphx::argument(param_shapes[name],
-                                           const_cast<void*>(input_tensor.GetTensorRawData())));
-          }
-          // It is an output argument
-          else {
-            auto compute_output_index = [](const std::string_view sv) -> int {
-              constexpr std::string_view out_name_prefix = "#output_";
-              const auto pos = sv.find(out_name_prefix);
-              if (pos == std::string_view::npos) {
-                return -1;
-              }
-
-              const auto index_str = sv.substr(pos + out_name_prefix.length());
-              return ToInteger(Trim(index_str, std::isdigit));
-            };
-
-            int output_index = compute_output_index(name);
-            if (output_index != -1) {
-              prog_output_indices.push_back(output_index);
-              auto mgx_output_shape = prog_output_shapes[output_index];
-              auto lens = mgx_output_shape.lengths();
-              std::vector<int64_t> ort_output_shape(lens.begin(), lens.end());
-              auto output_tensor = ctx.GetOutput(output_index, ort_output_shape.data(), ort_output_shape.size());
-              void* output_data = output_tensor.GetTensorMutableRawData();
-
-              // Log output batch size for tracking
-              if (!ort_output_shape.empty()) {
-                LOGS_DEFAULT(INFO) << "[Compute] Output " << output_index << " ('" << name
-                                      << "') allocated with shape: ["
-                                      << [&]() {
-                                          std::ostringstream ss;
-                                          for (size_t j = 0; j < ort_output_shape.size(); ++j) {
-                                            if (j > 0) ss << ", ";
-                                            ss << ort_output_shape[j];
-                                          }
-                                          return ss.str();
-                                        }() << "]";
-                LOGS_DEFAULT(INFO) << "[Compute] Output " << output_index << " batch size: " << ort_output_shape[0];
-              }
-
-              // argument shape
-              auto mgx_arg_shape = param_shapes[name];
-              m.add(name, migraphx::argument(mgx_arg_shape, output_data));
-            }
-          }
-        }
-      }
+      // Bind inputs and allocate outputs for the MIGraphX program
+      auto [m, prog_output_indices] = handle_program_input_outputs(param_shapes, map_input_name_index, ctx, prog);
 
       // Run the MIGraphX program and handle outputs
       run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, prog_output_indices);

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -3646,6 +3646,201 @@ static inline void precompile_static_model(
   LOGS_DEFAULT(INFO) << "[precompile_static_model] ✓ Static model precompiled and cached";
 }
 
+// Encapsulates precompilation decision logic from Compile()
+// Returns true if compilation should be deferred to runtime, false if precompilation succeeded
+static inline bool handle_precompilation_decision(
+    const std::string& node_name,
+    const std::vector<std::string>& input_names,
+    const std::vector<const NodeArg*>& input_tensor,
+    const InitializedTensorSet& initializers,
+    const std::unordered_map<std::string, std::size_t>& input_name_index,
+    const std::string& onnx_string_buffer,
+    migraphx::onnx_options& options,
+    const migraphx::target& t,
+    bool fp16_enable,
+    bool bf16_enable,
+    bool int8_enable,
+    bool fp8_enable,
+    bool int8_calibration_cache_available,
+    std::unordered_map<std::string, float>& dynamic_range_map,
+    bool exhaustive_tune,
+    const std::filesystem::path& model_path,
+    const std::filesystem::path& model_cache_path,
+    const std::string& mxr_filename_prefix,
+    std::unordered_map<std::string, migraphx::program>& cached_programs,
+    std::size_t max_dynamic_batch)
+{
+  // ═══════════════════════════════════════════════════════════════════════════
+  // PRECOMPILATION: Compile models during Compile() phase instead of compute_func()
+  // ═══════════════════════════════════════════════════════════════════════════
+  // 
+  // Precompilation rules:
+  // 1. max_dynamic_batch > 0 AND all non-batch dims are concrete:
+  //    -> Precompile all power-of-two batch models (symbolic batch dim is OK)
+  // 2. max_dynamic_batch > 0 AND some non-batch dims are symbolic:
+  //    -> Defer to runtime (cannot precompile without concrete non-batch shapes)
+  // 3. max_dynamic_batch == 0 AND all dims are concrete:
+  //    -> Precompile static model with concrete shapes
+  // 4. max_dynamic_batch == 0 AND some dims are symbolic:
+  //    -> Defer to runtime (cannot precompile with symbolic dimensions)
+  //
+  // IMPORTANT: We do NOT default symbolic dimensions to any value.
+  // Precompilation only happens when we have concrete shapes from the graph.
+  // ═══════════════════════════════════════════════════════════════════════════
+  
+  LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ════════════════════════════════════════════════════";
+  LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Starting precompilation decision for node '" << node_name << "'";
+  LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] max_dynamic_batch = " << max_dynamic_batch;
+  LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Number of inputs: " << input_names.size();
+  LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Number of input tensors: " << input_tensor.size();
+  LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Number of initializers: " << initializers.size();
+  
+  // Check if model has only dynamic batch dimension (other dims are static)
+  bool only_dynamic_batch = has_only_dynamic_batch_dimension(input_names, input_tensor, initializers);
+  LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] only_dynamic_batch = " << (only_dynamic_batch ? "true" : "false");
+  
+  if (max_dynamic_batch > 0) {
+    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Mode: DYNAMIC BATCH (max_dynamic_batch=" << max_dynamic_batch << ")";
+    
+    // Dynamic batch mode - try to precompile if all non-batch dimensions are concrete
+    if (only_dynamic_batch) {
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Model has only dynamic batch dimension - attempting to extract base shapes";
+      
+      // Extract base shapes - this will FAIL if any non-batch dim is symbolic
+      auto [shapes_valid, ordered_names, base_shapes] = extract_base_shapes_from_graph(
+          input_names, input_tensor, initializers, input_name_index);
+      
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] extract_base_shapes_from_graph result: shapes_valid=" 
+                            << (shapes_valid ? "true" : "false");
+      
+      if (shapes_valid) {
+        
+        // All non-batch dimensions are concrete - precompile all power-of-two batch models
+        auto power_of_two_batch_sizes = generate_power_of_two_batch_sizes(max_dynamic_batch);
+        
+        std::ostringstream batch_ss;
+        batch_ss << "[";
+        for (std::size_t i = 0; i < power_of_two_batch_sizes.size(); ++i) {
+          if (i > 0) batch_ss << ", ";
+          batch_ss << power_of_two_batch_sizes[i];
+        }
+        batch_ss << "]";
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Power-of-two batch sizes to compile: " << batch_ss.str();
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] >>> STARTING DYNAMIC BATCH PRECOMPILATION <<<";
+        
+        precompile_all_dynamic_batch_models(
+            power_of_two_batch_sizes,
+            ordered_names,
+            base_shapes,
+            onnx_string_buffer,
+            options,
+            t,
+            fp16_enable,
+            bf16_enable,
+            int8_enable,
+            fp8_enable,
+            int8_calibration_cache_available,
+            dynamic_range_map,
+            exhaustive_tune,
+            model_path,
+            model_cache_path,
+            mxr_filename_prefix,
+            cached_programs);
+        
+        // Precompilation complete - disable deferred compilation
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✓✓✓ Dynamic batch precompilation COMPLETE for node '" 
+                              << node_name << "'";
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to FALSE";
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] cached_programs size: " << cached_programs.size();
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ════════════════════════════════════════════════════";
+        return false;  // No need to defer
+      } else {
+        // Non-batch dimensions contain symbolic values - cannot precompile
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✗ CANNOT PRECOMPILE: Non-batch dimensions contain symbolic values";
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Deferring compilation to runtime for node '" << node_name << "'";
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to TRUE";
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ════════════════════════════════════════════════════";
+        return true;  // Defer to runtime
+      }
+    } else {
+      // Model has multiple dynamic dimensions (not just batch) - defer to runtime
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✗ CANNOT PRECOMPILE: Model has non-batch dynamic dimensions";
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Deferring compilation to runtime for node '" << node_name << "'";
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to TRUE";
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ════════════════════════════════════════════════════";
+      return true;  // Defer to runtime
+    }
+  } else {
+    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Mode: STATIC (max_dynamic_batch=0)";
+    
+    // Static model (max_dynamic_batch == 0) - only precompile if ALL dimensions are concrete
+    // Check if any dimension is symbolic
+    bool has_symbolic_dims = false;
+    std::string symbolic_info;
+    for (std::size_t i = 0; i < input_names.size(); ++i) {
+      if (initializers.count(input_names[i]) > 0) continue;  // Skip initializers
+      if (i < input_tensor.size()) {
+        auto tensor_shape = input_tensor[i]->Shape();
+        if (tensor_shape != nullptr) {
+          for (int j = 0; j < tensor_shape->dim_size(); ++j) {
+            if (!tensor_shape->dim(j).has_dim_value()) {
+              has_symbolic_dims = true;
+              symbolic_info = "Input '" + input_names[i] + "' dim " + std::to_string(j);
+              LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Found symbolic dimension: " << symbolic_info;
+              break;
+            }
+          }
+        }
+      }
+      if (has_symbolic_dims) break;
+    }
+    
+    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] has_symbolic_dims = " << (has_symbolic_dims ? "true" : "false");
+    
+    if (!has_symbolic_dims) {
+      // All dimensions are concrete - precompile static model
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] All dimensions are concrete - precompiling static model";
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] >>> STARTING STATIC MODEL PRECOMPILATION <<<";
+      
+      precompile_static_model(
+          input_names,
+          input_tensor,
+          initializers,
+          input_name_index,
+          onnx_string_buffer,
+          options,
+          t,
+          fp16_enable,
+          bf16_enable,
+          int8_enable,
+          fp8_enable,
+          int8_calibration_cache_available,
+          dynamic_range_map,
+          exhaustive_tune,
+          model_path,
+          model_cache_path,
+          mxr_filename_prefix,
+          cached_programs);
+      
+      // Precompilation complete - disable deferred compilation
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✓✓✓ Static model precompilation COMPLETE for node '" 
+                            << node_name << "'";
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to FALSE";
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] cached_programs size: " << cached_programs.size();
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ════════════════════════════════════════════════════";
+      return false;  // No need to defer
+    } else {
+      // Has symbolic dimensions and max_dynamic_batch == 0 - defer to runtime
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✗ CANNOT PRECOMPILE: Has symbolic dimensions but max_dynamic_batch=0";
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Symbolic dimension found: " << symbolic_info;
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Deferring compilation to runtime for node '" << node_name << "'";
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to TRUE";
+      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ════════════════════════════════════════════════════";
+      return true;  // Defer to runtime
+    }
+  }
+}
+
 constexpr std::uint64_t MIGraphX_Version =
     ((MIGRAPHX_VERSION_MAJOR << 16) | (MIGRAPHX_VERSION_MINOR << 8) | MIGRAPHX_VERSION_PATCH);
 
@@ -3698,214 +3893,28 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       cached_programs_[fused_node.Name()] = std::unordered_map<std::string, migraphx::program>();
     }
     
-    // ═══════════════════════════════════════════════════════════════════════════
-    // PRECOMPILATION: Compile models during Compile() phase instead of compute_func()
-    // ═══════════════════════════════════════════════════════════════════════════
-    // 
-    // Precompilation rules:
-    // 1. max_dynamic_batch > 0 AND all non-batch dims are concrete:
-    //    -> Precompile all power-of-two batch models (symbolic batch dim is OK)
-    // 2. max_dynamic_batch > 0 AND some non-batch dims are symbolic:
-    //    -> Defer to runtime (cannot precompile without concrete non-batch shapes)
-    // 3. max_dynamic_batch == 0 AND all dims are concrete:
-    //    -> Precompile static model with concrete shapes
-    // 4. max_dynamic_batch == 0 AND some dims are symbolic:
-    //    -> Defer to runtime (cannot precompile with symbolic dimensions)
-    //
-    // IMPORTANT: We do NOT default symbolic dimensions to any value.
-    // Precompilation only happens when we have concrete shapes from the graph.
-    // ═══════════════════════════════════════════════════════════════════════════
-    
-    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ════════════════════════════════════════════════════";
-    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Starting precompilation decision for node '" << fused_node.Name() << "'";
-    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] max_dynamic_batch_ = " << max_dynamic_batch_;
-    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Number of inputs: " << input_names.size();
-    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Number of input tensors: " << input_tensor.size();
-    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Number of initializers: " << initializers.size();
-    
-    // Log all input shapes from graph definition
-    for (std::size_t i = 0; i < input_names.size(); ++i) {
-      if (initializers.count(input_names[i]) > 0) {
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Input[" << i << "] '" << input_names[i] << "' -> INITIALIZER (skipped)";
-        continue;
-      }
-      if (i < input_tensor.size()) {
-        auto tensor_shape = input_tensor[i]->Shape();
-        if (tensor_shape != nullptr) {
-          std::ostringstream ss;
-          ss << "[";
-          for (int j = 0; j < tensor_shape->dim_size(); ++j) {
-            if (j > 0) ss << ", ";
-            const auto& dim = tensor_shape->dim(j);
-            if (dim.has_dim_value()) {
-              ss << dim.dim_value();
-            } else if (dim.has_dim_param()) {
-              ss << "'" << dim.dim_param() << "'";
-            } else {
-              ss << "?";
-            }
-          }
-          ss << "]";
-          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Input[" << i << "] '" << input_names[i] << "' shape: " << ss.str();
-        } else {
-          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Input[" << i << "] '" << input_names[i] << "' shape: NULL";
-        }
-      }
-    }
-    
-    // Check if model has only dynamic batch dimension (other dims are static)
-    bool only_dynamic_batch = has_only_dynamic_batch_dimension(input_names, input_tensor, initializers);
-    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] only_dynamic_batch = " << (only_dynamic_batch ? "true" : "false");
-    
-    if (max_dynamic_batch_ > 0) {
-      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Mode: DYNAMIC BATCH (max_dynamic_batch=" << max_dynamic_batch_ << ")";
-      
-      // Dynamic batch mode - try to precompile if all non-batch dimensions are concrete
-      if (only_dynamic_batch) {
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Model has only dynamic batch dimension - attempting to extract base shapes";
-        
-        // Extract base shapes - this will FAIL if any non-batch dim is symbolic
-        auto [shapes_valid, ordered_names, base_shapes] = extract_base_shapes_from_graph(
-            input_names, input_tensor, initializers, input_name_index);
-        
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] extract_base_shapes_from_graph result: shapes_valid=" 
-                              << (shapes_valid ? "true" : "false");
-        
-        if (shapes_valid) {
-          // Log extracted base shapes
-          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Successfully extracted " << ordered_names.size() << " base shapes:";
-          for (std::size_t i = 0; i < ordered_names.size(); ++i) {
-            std::ostringstream ss;
-            ss << "[";
-            for (std::size_t j = 0; j < base_shapes[i].size(); ++j) {
-              if (j > 0) ss << ", ";
-              ss << base_shapes[i][j];
-            }
-            ss << "]";
-            LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE]   '" << ordered_names[i] << "' base_shape: " << ss.str();
-          }
-          
-          // All non-batch dimensions are concrete - precompile all power-of-two batch models
-          auto power_of_two_batch_sizes = generate_power_of_two_batch_sizes(max_dynamic_batch_);
-          
-          std::ostringstream batch_ss;
-          batch_ss << "[";
-          for (std::size_t i = 0; i < power_of_two_batch_sizes.size(); ++i) {
-            if (i > 0) batch_ss << ", ";
-            batch_ss << power_of_two_batch_sizes[i];
-          }
-          batch_ss << "]";
-          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Power-of-two batch sizes to compile: " << batch_ss.str();
-          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] >>> STARTING DYNAMIC BATCH PRECOMPILATION <<<";
-          
-          precompile_all_dynamic_batch_models(
-              power_of_two_batch_sizes,
-              ordered_names,
-              base_shapes,
-              onnx_string_buffer,
-              options,
-              t_,
-              fp16_enable_,
-              bf16_enable_,
-              int8_enable_,
-              fp8_enable_,
-              int8_calibration_cache_available_,
-              dynamic_range_map_,
-              exhaustive_tune_,
-              model_path_,
-              model_cache_path_,
-              mxr_filename_prefix,
-              cached_programs_[fused_node.Name()]);
-          
-          // Precompilation complete - disable deferred compilation
-          map_defer_compilation_[fused_node.Name()] = false;
-          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✓✓✓ Dynamic batch precompilation COMPLETE for node '" 
-                                << fused_node.Name() << "'";
-          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to FALSE";
-          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] cached_programs size: " << cached_programs_[fused_node.Name()].size();
-        } else {
-          // Non-batch dimensions contain symbolic values - cannot precompile
-          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✗ CANNOT PRECOMPILE: Non-batch dimensions contain symbolic values";
-          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Deferring compilation to runtime for node '" << fused_node.Name() << "'";
-          map_defer_compilation_[fused_node.Name()] = true;
-          LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to TRUE";
-        }
-      } else {
-        // Model has multiple dynamic dimensions (not just batch) - defer to runtime
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✗ CANNOT PRECOMPILE: Model has non-batch dynamic dimensions";
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Deferring compilation to runtime for node '" << fused_node.Name() << "'";
-        map_defer_compilation_[fused_node.Name()] = true;
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to TRUE";
-      }
-    } else {
-      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Mode: STATIC (max_dynamic_batch=0)";
-      
-      // Static model (max_dynamic_batch == 0) - only precompile if ALL dimensions are concrete
-      // Check if any dimension is symbolic
-      bool has_symbolic_dims = false;
-      std::string symbolic_info;
-      for (std::size_t i = 0; i < input_names.size(); ++i) {
-        if (initializers.count(input_names[i]) > 0) continue;  // Skip initializers
-        if (i < input_tensor.size()) {
-          auto tensor_shape = input_tensor[i]->Shape();
-          if (tensor_shape != nullptr) {
-            for (int j = 0; j < tensor_shape->dim_size(); ++j) {
-              if (!tensor_shape->dim(j).has_dim_value()) {
-                has_symbolic_dims = true;
-                symbolic_info = "Input '" + input_names[i] + "' dim " + std::to_string(j);
-                LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Found symbolic dimension: " << symbolic_info;
-                break;
-              }
-            }
-          }
-        }
-        if (has_symbolic_dims) break;
-      }
-      
-      LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] has_symbolic_dims = " << (has_symbolic_dims ? "true" : "false");
-      
-      if (!has_symbolic_dims) {
-        // All dimensions are concrete - precompile static model
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] All dimensions are concrete - precompiling static model";
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] >>> STARTING STATIC MODEL PRECOMPILATION <<<";
-        
-        precompile_static_model(
-            input_names,
-            input_tensor,
-            initializers,
-            input_name_index,
-            onnx_string_buffer,
-            options,
-            t_,
-            fp16_enable_,
-            bf16_enable_,
-            int8_enable_,
-            fp8_enable_,
-            int8_calibration_cache_available_,
-            dynamic_range_map_,
-            exhaustive_tune_,
-            model_path_,
-            model_cache_path_,
-            mxr_filename_prefix,
-            cached_programs_[fused_node.Name()]);
-        
-        // Precompilation complete - disable deferred compilation
-        map_defer_compilation_[fused_node.Name()] = false;
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✓✓✓ Static model precompilation COMPLETE for node '" 
-                              << fused_node.Name() << "'";
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to FALSE";
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] cached_programs size: " << cached_programs_[fused_node.Name()].size();
-      } else {
-        // Has symbolic dimensions and max_dynamic_batch == 0 - defer to runtime
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ✗ CANNOT PRECOMPILE: Has symbolic dimensions but max_dynamic_batch=0";
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Symbolic dimension found: " << symbolic_info;
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Deferring compilation to runtime for node '" << fused_node.Name() << "'";
-        map_defer_compilation_[fused_node.Name()] = true;
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] defer_compilation set to TRUE";
-      }
-    }
-    
-    LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] ════════════════════════════════════════════════════";
+    // Perform precompilation decision and execution
+    map_defer_compilation_[fused_node.Name()] = handle_precompilation_decision(
+        fused_node.Name(),
+        input_names,
+        input_tensor,
+        initializers,
+        input_name_index,
+        onnx_string_buffer,
+        options,
+        t_,
+        fp16_enable_,
+        bf16_enable_,
+        int8_enable_,
+        fp8_enable_,
+        int8_calibration_cache_available_,
+        dynamic_range_map_,
+        exhaustive_tune_,
+        model_path_,
+        model_cache_path_,
+        mxr_filename_prefix,
+        cached_programs_[fused_node.Name()],
+        max_dynamic_batch_);
 
     // Create program object (may be empty if precompiled programs are in cache)
     migraphx::program prog;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1686,17 +1686,41 @@ static void handle_input_shape_mismatch(
   auto& cmp_options = mgx_state->options;
   const auto& map_input_name_index = mgx_state->input_name_indexes;
 
-  // Determine batch size from the first input tensor
+  // Determine batch size ONLY from inputs that have symbolic/dynamic dimensions
+  // We must NOT use weight/embedding tensors which have large fixed first dimensions
+  const auto& symbolic_dims = mgx_state->symbolic_dims;
   std::size_t current_batch_size = 0;
-  if (!map_input_name_index.empty()) {
-    auto first_it = map_input_name_index.begin();
-    auto input_tensor = ctx.GetInput(first_it->second);
-          auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-          const auto tensor_shape = tensor_info.GetShape();
-    if (!tensor_shape.empty()) {
-      current_batch_size = static_cast<std::size_t>(tensor_shape[0]);
+
+  // First, try to find batch size from inputs with symbolic batch dimension
+  for (const auto& it : map_input_name_index) {
+    const auto& name = it.first;
+
+    // Check if this input has a symbolic batch dimension (dim 0)
+    auto sym_it = symbolic_dims.find(name);
+    if (sym_it != symbolic_dims.end()) {
+      bool has_dynamic_batch = false;
+      for (const auto& sym_dim : sym_it->second) {
+        if (sym_dim.dim_index == 0) {
+          has_dynamic_batch = true;
+          break;
+        }
+      }
+
+      if (has_dynamic_batch) {
+        auto input_tensor = ctx.GetInput(it.second);
+        auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+        const auto tensor_shape = tensor_info.GetShape();
+        if (!tensor_shape.empty()) {
+          current_batch_size = static_cast<std::size_t>(tensor_shape[0]);
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Found dynamic batch input '" << name
+                                << "' with batch=" << current_batch_size;
+          break;  // Use first dynamic batch input found
+        }
+      }
     }
   }
+
+  LOGS_DEFAULT(VERBOSE) << "[Compute] Using batch size: " << current_batch_size;
 
   // Check in-memory batched_programs cache first (before disk cache)
   if (mgx_state->batched_programs_ref.has_value() && current_batch_size > 0) {
@@ -1717,32 +1741,32 @@ static void handle_input_shape_mismatch(
   std::filesystem::path model_cache_file;
   // empty cache path means the MXR caching is disabled - always compile
   if (!model_cache_path.empty()) {
-    // Ensure input_shapes has all updated dimensions including new batch sizes
-    if (input_shapes.empty()) {
-      LOGS_DEFAULT(WARNING) << "[Compute] Input shapes vector is empty, rebuilding from current inputs";
-      for (auto&& name : param_shapes.names()) {
-        if (map_input_name_index.count(name) > 0) {
-          auto input_tensor = ctx.GetInput(map_input_name_index.at(name));
-          auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-          const auto tensor_shape = tensor_info.GetShape();
-          input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
-        }
+    // Build cache key from ONLY inputs with symbolic/dynamic dimensions
+    // This ensures different batch sizes get different cache files
+    std::vector<std::int64_t> dynamic_input_shapes;
+
+    for (const auto& it : map_input_name_index) {
+      const auto& name = it.first;
+
+      // Check if this input has any symbolic dimensions
+      auto sym_it = symbolic_dims.find(name);
+      if (sym_it != symbolic_dims.end() && !sym_it->second.empty()) {
+        auto input_tensor = ctx.GetInput(it.second);
+        auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+        const auto tensor_shape = tensor_info.GetShape();
+
+        // Include ALL dimensions of dynamic inputs in cache key
+        dynamic_input_shapes.insert(dynamic_input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
       }
     }
 
-    // Log the shapes being used for cache key generation
-    std::ostringstream shapes_str;
-    shapes_str << "[";
-    for (size_t i = 0; i < input_shapes.size(); ++i) {
-      if (i > 0) shapes_str << ", ";
-      shapes_str << input_shapes[i];
+    // If no dynamic inputs found, fall back to using batch size directly
+    if (dynamic_input_shapes.empty()) {
+      dynamic_input_shapes.push_back(static_cast<std::int64_t>(current_batch_size));
     }
-    shapes_str << "]";
-    LOGS_DEFAULT(VERBOSE) << "[Compute] Cache key input shapes (including updated batch): " << shapes_str.str();
 
-    auto cache_hash = make_hash(input_shapes);
+    auto cache_hash = make_hash(dynamic_input_shapes);
     model_cache_file = mgx_state->model_cache_dir / (mxr_filename_prefix + cache_hash + ".mxr");
-    LOGS_DEFAULT(VERBOSE) << "[Compute] Cache file with batch-aware hash: " << model_cache_file.string();
   }
 
   if (!load_precompiled_model(prog, model_cache_file)) {
@@ -1794,14 +1818,14 @@ static void handle_input_shape_mismatch(
                           << model_cache_file.string();
     save_compiled_model(prog, model_cache_file);
   } else {
-    LOGS_DEFAULT(VERBOSE) << "[Compute] Cache hit! Loaded precompiled model with matching batch size";
+    LOGS_DEFAULT(VERBOSE) << "[Compute] Cache hit - loaded precompiled model";
   }
 
   // Store the compiled/loaded program in the in-memory batched_programs cache
   if (mgx_state->batched_programs_ref.has_value() && current_batch_size > 0) {
     mgx_state->batched_programs_ref.value().get()[current_batch_size] = prog;
     LOGS_DEFAULT(VERBOSE) << "[Compute] Stored program for batch size " << current_batch_size
-                       << " in in-memory batched_programs cache";
+                          << " in in-memory batched_programs cache";
   }
 
   param_shapes = prog.get_parameter_shapes();
@@ -1936,33 +1960,12 @@ static InputShapeResult handle_input_shape(
       cmp_options.set_input_parameter_shape(name, ort_lens);
       input_shape_match = false;
 
-      // Collect all shape dimensions including updated batch size for cache key
-      input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
-
-      // Log batch size and full shape for tracking dynamic shapes
-      if (!tensor_shape.empty()) {
-        LOGS_DEFAULT(VERBOSE) << "[Compute] Input parameter '" << name
-                              << "' batch size (runtime override): " << tensor_shape[0];
-
-        // Log which dimensions are symbolic for this input
-        auto sym_it = symbolic_dims.find(name);
-        if (sym_it != symbolic_dims.end()) {
-          for (const auto& sym_dim : sym_it->second) {
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' dimension " << sym_dim.dim_index
-                                  << " ('" << sym_dim.dim_param << "') resolved to: "
-                                  << (sym_dim.dim_index < static_cast<int>(tensor_shape.size())
-                                      ? std::to_string(tensor_shape[sym_dim.dim_index]) : "N/A");
-          }
-        }
-
-        std::ostringstream shape_str;
-        shape_str << "[";
-        for (size_t i = 0; i < tensor_shape.size(); ++i) {
-          if (i > 0) shape_str << ", ";
-          shape_str << tensor_shape[i];
-        }
-        shape_str << "]";
-        LOGS_DEFAULT(VERBOSE) << "[Compute] Input parameter '" << name << "' set as static shape: " << shape_str.str();
+      // Only include inputs with symbolic dimensions in cache key (for correct hashing)
+      // This ensures different batch sizes result in different cache files
+      auto sym_it = symbolic_dims.find(name);
+      if (sym_it != symbolic_dims.end() && !sym_it->second.empty()) {
+        input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
+        LOGS_DEFAULT(VERBOSE) << "[Compute] Including dynamic input '" << name << "' in cache key";
       }
     }
     LOGS_DEFAULT(VERBOSE) << "[Compute] All runtime input shapes set as static parameters in MIGraphX options";
@@ -2048,7 +2051,12 @@ static InputShapeResult handle_input_shape(
             cmp_options.set_input_parameter_shape(name, ort_lens);
             input_shape_match = false;
           }
-          input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
+
+          // Only include inputs with symbolic dimensions in cache key (for correct hashing)
+          auto sym_it = symbolic_dims.find(name);
+          if (sym_it != symbolic_dims.end() && !sym_it->second.empty()) {
+            input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
+          }
 
           // Log batch size and full shape for tracking
           if (!tensor_shape.empty()) {
@@ -2259,7 +2267,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
       // Fast path: If program has dynamic batch and we have a cached program for the current batch size,
       // use it directly without going through shape comparison and recompilation
-      if (prog_has_dynamic_batch && !defer_compilation && mgx_state->batched_programs_ref.has_value()) {
+      /* if (prog_has_dynamic_batch && mgx_state->max_dynamic_batch > 0 && mgx_state->batched_programs_ref.has_value()) {
         // Get current batch size from first input
         std::size_t current_batch_size = 0;
         if (!map_input_name_index.empty()) {
@@ -2267,7 +2275,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           auto input_tensor = ctx.GetInput(first_input->second);
           auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
           const auto tensor_shape = tensor_info.GetShape();
-          if (!tensor_shape.empty()) {
+          if (!tensor_shape.empty() && tensor_shape[0] == ) {
             current_batch_size = static_cast<std::size_t>(tensor_shape[0]);
           }
         }
@@ -2295,7 +2303,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
                                   << ", falling back to standard path";
           }
         }
-      }
+      } */
 
       // Standard path: Process input shapes and determine if recompilation is needed
       // Using fine-grained symbolic dimension tracking for more precise shape matching

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -2350,6 +2350,13 @@ static bool execute_ultra_fast_path(
     return false;
   }
 
+  // Ultra-fast path doesn't support output slicing because cached_output_ort_shapes
+  // contains padded shapes, not sliced shapes. Fall back to fast path which handles
+  // slicing properly via temp output buffers.
+  if (padded_batch_size > 0 && original_batch_size > 0 && padded_batch_size > original_batch_size) {
+    return false;
+  }
+
   // Shapes unchanged (or compatible with padding) - rebind pointers and run directly
   auto& m = mgx_state->cached_prog_params.value();
   auto& prog = mgx_state->prog;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1416,20 +1416,22 @@ static void run_migraphx_program(
     migraphx::program_parameters& m,
     const std::vector<std::size_t>& prog_output_indices)
 {
-
-  // lock to avoid race condition
-  std::lock_guard<std::mutex> lock(*mgx_mu_ptr);
   void* rocm_stream;
   Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &rocm_stream));
-  auto prog_outputs = prog.run_async(m, static_cast<hipStream_t>(rocm_stream));
+
+  std::optional<migraphx::arguments> prog_outputs;
+  {  // lock to avoid race condition
+     std::lock_guard<std::mutex> lock(*mgx_mu_ptr);
+     prog_outputs = prog.run_async(m, static_cast<hipStream_t>(rocm_stream));
+  }
 
   // In case of input parameters are reused as output parameter call hipMemcpy
-  auto output_num = prog_outputs.size();
+  auto output_num = prog_outputs->size();
   if (prog_output_indices.size() < output_num) {
     for (std::size_t i = 0; i < output_num; ++i) {
       if (std::find(prog_output_indices.begin(), prog_output_indices.end(), static_cast<int>(i)) != prog_output_indices.end())
         continue;
-      auto gpu_res = prog_outputs[i];
+      auto gpu_res = (*prog_outputs)[i];
       migraphx::shape res_shape = gpu_res.get_shape();
       auto res_lens = res_shape.lengths();
       std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1463,21 +1463,6 @@ static bool allocate_and_pad_inputs(
   return true;
 }
 
-// Free padded input buffers
-static void free_padded_inputs(MIGraphXFuncState* mgx_state) {
-  for (auto& buf : mgx_state->padded_input_buffers) {
-    if (buf.data != nullptr) {
-      (void)hipFree(buf.data);  // Don't throw on cleanup
-      buf.data = nullptr;
-    }
-  }
-  mgx_state->padded_input_buffers.clear();
-  
-  // Clear batch tracking when freeing buffers
-  mgx_state->last_original_batch_size = 0;
-  mgx_state->last_padded_batch_size = 0;
-}
-
 // Helper: Extract output index from MIGraphX output parameter name
 // MIGraphX names outputs as "#output_0", "#output_1", etc.
 static int compute_output_index(const std::string_view sv) {
@@ -3162,7 +3147,6 @@ static void execute_standard_path(
       std::vector<std::int64_t> padded_shapes;
       padded_shapes.reserve(all_input_shapes.size());
       
-      std::size_t shape_offset = 0;
       for (const auto& [name, index] : map_input_name_index) {
         auto input_tensor = ctx.GetInput(index);
         auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1358,6 +1358,19 @@ void save_compiled_model(const migraphx::program& prog, const std::filesystem::p
   }
 }
 
+// Generate a vector of power-of-2 batch sizes from 1 up to max_batch_size (inclusive)
+// E.g., max_batch_size=16 returns {1, 2, 4, 8, 16}
+static std::vector<std::size_t> generate_power_of_two_batch_sizes(std::size_t max_batch_size) {
+  std::vector<std::size_t> batch_sizes;
+  if (max_batch_size == 0) {
+    return batch_sizes;
+  }
+  for (std::size_t bs = 1; bs <= max_batch_size; bs *= 2) {
+    batch_sizes.push_back(bs);
+  }
+  return batch_sizes;
+}
+
 // Order matters here especially if the program uses mixed quantization
 // Calibrate on full precision for int8/fp8 and then quantize down to fp16
 void calibrate_and_quantize(migraphx::program& prog,

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1467,7 +1467,7 @@ static bool allocate_and_pad_inputs(
 static void free_padded_inputs(MIGraphXFuncState* mgx_state) {
   for (auto& buf : mgx_state->padded_input_buffers) {
     if (buf.data != nullptr) {
-      hipFree(buf.data);  // Don't throw on cleanup
+      (void)hipFree(buf.data);  // Don't throw on cleanup
       buf.data = nullptr;
     }
   }
@@ -1494,7 +1494,7 @@ static int compute_output_index(const std::string_view sv) {
 static void free_temp_output_buffers(MIGraphXFuncState* mgx_state) {
   for (auto& buf : mgx_state->temp_output_buffers) {
     if (buf.data != nullptr) {
-      hipFree(buf.data);  // Don't throw on cleanup
+      (void)hipFree(buf.data);  // Don't throw on cleanup
       buf.data = nullptr;
     }
   }
@@ -1561,7 +1561,7 @@ static std::vector<void*> get_or_allocate_temp_output_buffers(
       if (hip_status != hipSuccess) {
         // Clean up any allocated buffers on failure
         for (auto& buf : mgx_state->temp_output_buffers) {
-          if (buf.data) hipFree(buf.data);
+          if (buf.data) (void)hipFree(buf.data);
         }
         mgx_state->temp_output_buffers.clear();
         ORT_THROW("hipMalloc failed for temporary output buffer");
@@ -1991,7 +1991,7 @@ static void run_migraphx_program(
                                              static_cast<hipStream_t>(rocm_stream)));
           
           // Free temporary buffer
-          hipFree(temp_sliced_buffer);
+          (void)hipFree(temp_sliced_buffer);
           
           LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] ✓ Successfully sliced pre-allocated output " << i;
         } else {
@@ -3267,7 +3267,7 @@ static void execute_standard_path(
             // Free temporary output buffers
             for (void* buf : temp_output_buffers) {
               if (buf != nullptr) {
-                hipFree(buf);
+                (void)hipFree(buf);
               }
             }
             

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1857,25 +1857,8 @@ static void run_migraphx_program(
   bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 && 
                         original_batch_size < padded_batch_size);
 
-  LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] ==== ENTERING ====";
-  LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] original_batch_size=" << original_batch_size 
-                        << ", padded_batch_size=" << padded_batch_size 
-                        << ", needs_slicing=" << needs_slicing;
-  LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] prog_output_indices.size()=" << prog_output_indices.size();
-  if (!prog_output_indices.empty()) {
-    std::ostringstream ss;
-    ss << "[";
-    for (size_t i = 0; i < prog_output_indices.size(); ++i) {
-      if (i > 0) ss << ", ";
-      ss << prog_output_indices[i];
-    }
-    ss << "]";
-    LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] prog_output_indices=" << ss.str();
-  }
-
   // Process ALL outputs for proper slicing when needed
   auto output_num = prog_outputs->size();
-  LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Number of MIGraphX outputs: " << output_num;
   
   std::unordered_set<std::size_t> prog_output_indices_set(prog_output_indices.begin(), prog_output_indices.end());
   std::vector<std::size_t> outputs_to_copy;  // Outputs that need memcpy (not pre-allocated)
@@ -1886,21 +1869,9 @@ static void run_migraphx_program(
     }
   }
   
-  LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Pre-allocated outputs (in prog_output_indices): " 
-                        << prog_output_indices_set.size();
-  LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Outputs to copy (not pre-allocated): " 
-                        << outputs_to_copy.size();
-  
   // First, handle pre-allocated outputs (need slicing but were already bound)
-  // NOTE: This is a problematic state! Pre-allocated outputs should NOT exist when slicing is needed.
-  // The proper solution is to use temp buffers in handle_program_input_outputs when needs_slicing=true.
-  // This code handles the case defensively by copying sliced data to newly allocated ORT outputs.
+  // NOTE: This is a defensive path - pre-allocated outputs should NOT exist when slicing is needed.
   if (needs_slicing && !prog_output_indices_set.empty()) {
-    LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] ⚠️  WARNING: Handling " << prog_output_indices_set.size() 
-                         << " pre-allocated outputs with slicing";
-    LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] ⚠️  This indicates handle_program_input_outputs did NOT use temp buffers!";
-    LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] ⚠️  Pre-allocated outputs should be empty when slicing is needed.";
-    
     for (std::size_t i = 0; i < output_num; ++i) {
       if (prog_output_indices_set.count(i) > 0) {
         // This output was pre-allocated with padded shape - need to copy sliced data
@@ -1908,50 +1879,23 @@ static void run_migraphx_program(
         migraphx::shape res_shape = gpu_res.get_shape();
         auto res_lens = res_shape.lengths();
         
-        LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Pre-allocated output " << i 
-                             << " MIGraphX shape: [" << [&]() {
-          std::ostringstream ss;
-          for (size_t j = 0; j < res_lens.size(); ++j) {
-            if (j > 0) ss << ", ";
-            ss << res_lens[j];
-          }
-          return ss.str();
-        }() << "]";
-        
         // Create sliced shape for ORT output
         std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
         if (!ort_shape.empty() && static_cast<std::size_t>(ort_shape[0]) != original_batch_size) {
           ort_shape[0] = static_cast<int64_t>(original_batch_size);
           
-          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Slicing pre-allocated output " << i 
-                               << " from batch size " << padded_batch_size << " to " << original_batch_size;
-          
-          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Output " << i << " ORT shape (after slicing): [" << [&]() {
-            std::ostringstream ss;
-            for (size_t j = 0; j < ort_shape.size(); ++j) {
-              if (j > 0) ss << ", ";
-              ss << ort_shape[j];
-            }
-            return ss.str();
-          }() << "]";
-          
           // Calculate bytes to copy (sliced portion only)
           std::size_t bytes_per_batch = res_shape.bytes() / padded_batch_size;
           std::size_t bytes_to_copy = bytes_per_batch * original_batch_size;
-          
-          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Bytes per batch: " << bytes_per_batch
-                               << ", total bytes to copy: " << bytes_to_copy;
           
           // Allocate temp buffer for sliced data on GPU
           void* temp_sliced_buffer = nullptr;
           auto hip_status = hipMalloc(&temp_sliced_buffer, bytes_to_copy);
           if (hip_status != hipSuccess) {
-            LOGS_DEFAULT(ERROR) << "[run_migraphx_program] hipMalloc failed for sliced output buffer!";
             ORT_THROW("hipMalloc failed for sliced output buffer");
           }
           
           // Copy sliced data from MIGraphX output to temp buffer
-          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Copying sliced data to temp buffer...";
           HIP_CALL_THROW(hipMemcpyWithStream(temp_sliced_buffer,
                                              gpu_res.data(),
                                              bytes_to_copy,
@@ -1962,13 +1906,10 @@ static void run_migraphx_program(
           HIP_CALL_THROW(hipStreamSynchronize(static_cast<hipStream_t>(rocm_stream)));
           
           // Now allocate the ORT output tensor with the SLICED shape
-          // This should work because we're allocating fresh (not re-using the padded buffer)
-          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Allocating ORT output with sliced shape...";
           auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
           void* output_data = output_tensor.GetTensorMutableRawData();
           
           // Copy from temp buffer to ORT output
-          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Copying from temp buffer to ORT output...";
           HIP_CALL_THROW(hipMemcpyWithStream(output_data,
                                              temp_sliced_buffer,
                                              bytes_to_copy,
@@ -1977,11 +1918,6 @@ static void run_migraphx_program(
           
           // Free temporary buffer
           (void)hipFree(temp_sliced_buffer);
-          
-          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] ✓ Successfully sliced pre-allocated output " << i;
-        } else {
-          // No slicing needed for this output (batch dimension matches)
-          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Output " << i << " batch dim already matches, no slicing needed";
         }
       }
     }
@@ -1994,32 +1930,11 @@ static void run_migraphx_program(
       migraphx::shape res_shape = gpu_res.get_shape();
       auto res_lens = res_shape.lengths();
       
-      // Log the original MIGraphX output shape
-      LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Output " << i << " MIGraphX shape: [" << [&]() {
-        std::ostringstream ss;
-        for (size_t j = 0; j < res_lens.size(); ++j) {
-          if (j > 0) ss << ", ";
-          ss << res_lens[j];
-        }
-        return ss.str();
-      }() << "]";
-      
       // Adjust output shape if slicing is needed
       std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
       if (needs_slicing && !ort_shape.empty()) {
         ort_shape[0] = original_batch_size;  // Slice batch dimension
-        LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Slicing output " << i << " from batch size " 
-                             << padded_batch_size << " to " << original_batch_size;
       }
-      
-      LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Output " << i << " ORT shape (after slicing): [" << [&]() {
-        std::ostringstream ss;
-        for (size_t j = 0; j < ort_shape.size(); ++j) {
-          if (j > 0) ss << ", ";
-          ss << ort_shape[j];
-        }
-        return ss.str();
-      }() << "]";
       
       auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
       void* output_data = output_tensor.GetTensorMutableRawData();
@@ -2027,17 +1942,7 @@ static void run_migraphx_program(
       // Calculate bytes to copy (slice if needed)
       std::size_t bytes_to_copy = res_shape.bytes();
       if (needs_slicing && res_lens.size() > 0) {
-        // Calculate bytes per batch element
-        std::size_t elements_per_batch = 1;
-        for (std::size_t j = 1; j < res_lens.size(); ++j) {
-          elements_per_batch *= res_lens[j];
-        }
         bytes_to_copy = (res_shape.bytes() / padded_batch_size) * original_batch_size;
-        LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Copying " << bytes_to_copy 
-                             << " bytes (sliced from " << res_shape.bytes() << " bytes)";
-      } else {
-        LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Copying " << bytes_to_copy 
-                             << " bytes (no slicing)";
       }
 
       HIP_CALL_THROW(hipMemcpyWithStream(output_data,
@@ -2320,22 +2225,6 @@ static std::vector<std::int64_t> build_input_shapes_in_cached_order(
   std::vector<std::int64_t> shapes;
   shapes.reserve(mgx_state->cached_inputs.size() * 4);  // Estimate average 4 dims per input
   
-  LOGS_DEFAULT(VERBOSE) << "[build_input_shapes_in_cached_order] Building shapes in cached_inputs order";
-  LOGS_DEFAULT(VERBOSE) << "[build_input_shapes_in_cached_order] cached_inputs.size()=" << mgx_state->cached_inputs.size()
-                        << ", padded_batch_size=" << padded_batch_size;
-  
-  // Log first few input names to verify ordering
-  if (mgx_state->cached_inputs.size() > 0) {
-    std::ostringstream input_order_ss;
-    input_order_ss << "[build_input_shapes_in_cached_order] Input order (first 5): ";
-    for (size_t i = 0; i < std::min(mgx_state->cached_inputs.size(), static_cast<size_t>(5)); ++i) {
-      if (i > 0) input_order_ss << ", ";
-      input_order_ss << mgx_state->cached_inputs[i].name;
-    }
-    if (mgx_state->cached_inputs.size() > 5) input_order_ss << ", ...";
-    LOGS_DEFAULT(VERBOSE) << input_order_ss.str();
-  }
-  
   for (const auto& cached_inp : mgx_state->cached_inputs) {
     auto input_tensor = ctx.GetInput(cached_inp.ort_index);
     auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
@@ -2353,7 +2242,6 @@ static std::vector<std::int64_t> build_input_shapes_in_cached_order(
     }
   }
   
-  LOGS_DEFAULT(VERBOSE) << "[build_input_shapes_in_cached_order] Built " << shapes.size() << " shape dimensions";
   return shapes;
 }
 
@@ -2369,40 +2257,16 @@ static bool execute_ultra_fast_path(
     OrtKernelContext* context,
     Ort::KernelContext& ctx)
 {
-  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Checking cache validity";
-  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] caches_valid = " << mgx_state->caches_valid;
-  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] last_input_shapes_raw.size() = " 
-                        << mgx_state->last_input_shapes_raw.size();
-  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] cached_outputs.size() = " 
-                        << mgx_state->cached_outputs.size();
-  
   if (!mgx_state->caches_valid || mgx_state->last_input_shapes_raw.empty()) {
-    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Caches not valid or empty - skipping";
     return false;
   }
   
   // Ultra-fast path not supported when outputs need dynamic slicing
   if (mgx_state->cached_outputs.empty()) {
-    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] No cached outputs (slicing mode) - skipping";
     return false;
   }
 
   // Quick shape comparison
-  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Performing shape comparison";
-  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Number of cached inputs: " << mgx_state->cached_inputs.size();
-  
-  // Log first few input names to verify ordering consistency
-  if (mgx_state->cached_inputs.size() > 0) {
-    std::ostringstream input_order_ss;
-    input_order_ss << "[ULTRA_FAST_PATH] Input order (first 5): ";
-    for (size_t i = 0; i < std::min(mgx_state->cached_inputs.size(), static_cast<size_t>(5)); ++i) {
-      if (i > 0) input_order_ss << ", ";
-      input_order_ss << mgx_state->cached_inputs[i].name;
-    }
-    if (mgx_state->cached_inputs.size() > 5) input_order_ss << ", ...";
-    LOGS_DEFAULT(VERBOSE) << input_order_ss.str();
-  }
-  
   bool shapes_match = true;
   std::size_t offset = 0;
   const auto& last_shapes = mgx_state->last_input_shapes_raw;
@@ -2415,35 +2279,10 @@ static bool execute_ultra_fast_path(
   for (const auto& inp : mgx_state->cached_inputs) {
     const auto& shape = ctx.GetInput(inp.ort_index).GetTensorTypeAndShapeInfo().GetShape();
     
-    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Input " << input_idx << " '" << inp.name 
-                          << "': current shape size=" << shape.size() 
-                          << ", offset=" << offset 
-                          << ", last_shapes.size()=" << last_shapes.size();
-    
     if (offset + shape.size() > last_shapes.size()) {
-      LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Shape size mismatch - failing";
       shapes_match = false;
       break;
     }
-    
-    // Log current vs cached shapes
-    std::ostringstream current_ss, cached_ss;
-    current_ss << "[";
-    for (size_t i = 0; i < shape.size(); ++i) {
-      if (i > 0) current_ss << ", ";
-      current_ss << shape[i];
-    }
-    current_ss << "]";
-    
-    cached_ss << "[";
-    for (size_t i = 0; i < shape.size() && offset + i < last_shapes.size(); ++i) {
-      if (i > 0) cached_ss << ", ";
-      cached_ss << last_shapes[offset + i];
-    }
-    cached_ss << "]";
-    
-    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH]   Current: " << current_ss.str();
-    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH]   Cached:  " << cached_ss.str();
     
     // For dynamic batch, we check if the current batch needs padding
     if (mgx_state->has_dynamic_batch && !mgx_state->power_of_two_batch_sizes.empty()) {
@@ -2453,40 +2292,27 @@ static bool execute_ultra_fast_path(
         padded_batch_size = static_cast<std::size_t>(last_shapes[offset]);
         is_first = false;
         
-        LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Current batch: " << original_batch_size
-                              << ", cached padded batch: " << padded_batch_size;
-        
         // Check if the batch size matches (original or padded)
         if (shape[0] != last_shapes[offset]) {
           // Batch size changed - check if we can use padding
           std::size_t required_padded = find_nearest_power_of_two_batch(
               original_batch_size, mgx_state->power_of_two_batch_sizes);
           
-          LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Required padded: " << required_padded;
-          
           if (required_padded != padded_batch_size) {
-            LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Padded batch size mismatch - failing";
             shapes_match = false;
             break;
           }
         }
       }
       
-      // For ALL inputs with dynamic batching: verify batch size consistency and check non-batch dims
-      LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Checking dimensions for input " << input_idx;
-      
       // All current inputs should have the same batch size (original_batch_size)
       if (shape[0] != original_batch_size) {
-        LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Batch dimension mismatch: current=" 
-                              << shape[0] << ", expected original=" << original_batch_size;
         shapes_match = false;
         break;
       }
       
       // Cached shape should have padded batch size in dimension 0
       if (last_shapes[offset] != static_cast<std::int64_t>(padded_batch_size)) {
-        LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Cached batch mismatch: cached=" 
-                              << last_shapes[offset] << ", expected padded=" << padded_batch_size;
         shapes_match = false;
         break;
       }
@@ -2495,9 +2321,6 @@ static bool execute_ultra_fast_path(
       bool rest_matches = true;
       for (std::size_t i = 1; i < shape.size(); ++i) {
         if (last_shapes[offset + i] != shape[i]) {
-          LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Dimension " << i 
-                                << " mismatch: current=" << shape[i] 
-                                << ", cached=" << last_shapes[offset + i];
           rest_matches = false;
           break;
         }
@@ -2506,15 +2329,10 @@ static bool execute_ultra_fast_path(
         shapes_match = false;
         break;
       }
-      LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Input " << input_idx << " dims match!";
     } else {
       // No dynamic batching - strict comparison
       for (std::size_t i = 0; i < shape.size(); ++i) {
         if (last_shapes[offset + i] != shape[i]) {
-          LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Dimension " << i 
-                                << " mismatch at input " << input_idx 
-                                << ": current=" << shape[i] 
-                                << ", cached=" << last_shapes[offset + i];
           shapes_match = false;
           break;
         }
@@ -2523,16 +2341,13 @@ static bool execute_ultra_fast_path(
     
     if (!shapes_match) break;
     offset += shape.size();
-    input_idx++;
   }
 
   if (!shapes_match || offset != last_shapes.size()) {
-    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Shapes don't match - failing";
     return false;
   }
 
   // Shapes unchanged (or compatible with padding) - rebind pointers and run directly
-  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] ✓ Shapes match! Rebinding and executing";
   auto& m = mgx_state->cached_prog_params.value();
   auto& prog = mgx_state->prog;
   
@@ -2544,19 +2359,16 @@ static bool execute_ultra_fast_path(
     auto rocm_stream = static_cast<hipStream_t>(rocm_stream_ptr);
     using_padded_inputs = allocate_and_pad_inputs(mgx_state, ctx, original_batch_size, 
                                                   padded_batch_size, rocm_stream);
-    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Using padded inputs: " << using_padded_inputs;
   }
 
   // Rebind inputs - use padded buffers if available, otherwise use original inputs
   if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
-    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Binding padded input buffers";
     for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
       const auto& inp = mgx_state->cached_inputs[i];
       const auto& padded_buf = mgx_state->padded_input_buffers[i];
       m.add(inp.name.c_str(), migraphx::argument(padded_buf.mgx_shape, padded_buf.data));
     }
   } else {
-    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Binding original input buffers";
     for (const auto& inp : mgx_state->cached_inputs) {
       const auto& input_tensor = ctx.GetInput(inp.ort_index);
       m.add(inp.name.c_str(), migraphx::argument(inp.mgx_shape,
@@ -2573,15 +2385,10 @@ static bool execute_ultra_fast_path(
                                        output_tensor.GetTensorMutableRawData()));
   }
 
-  // Run directly - minimal overhead path (with slicing if needed)
-  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Running (original_batch=" << original_batch_size 
-                     << ", padded=" << padded_batch_size << ")";
+  // Run directly - minimal overhead path
   run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m,
                        mgx_state->cached_prog_output_indices,
                        original_batch_size, padded_batch_size);
-  
-  // NOTE: Padded buffers are kept for reuse - they will be freed when batch size changes
-  // or when the state is destroyed
   
   return true;
 }
@@ -3523,42 +3330,18 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       Ort::KernelContext ctx(context);
       MIGraphXFuncState* mgx_state = reinterpret_cast<MIGraphXFuncState*>(state);
 
-      LOGS_DEFAULT(VERBOSE) << "======================================";
-      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Starting inference";
-      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] has_dynamic_batch = " << mgx_state->has_dynamic_batch;
-      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] max_dynamic_batch = " << mgx_state->max_dynamic_batch;
-      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] caches_valid = " << mgx_state->caches_valid;
-      
-      // Log incoming batch sizes
       const auto& map_input_name_index = mgx_state->input_name_indexes;
-      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Incoming input shapes:";
-      for (const auto& [name, index] : map_input_name_index) {
-        const auto& shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
-        LOGS_DEFAULT(VERBOSE) << "[COMPUTE]   '" << name << "': [" << [&]() {
-          std::ostringstream ss;
-          for (size_t i = 0; i < shape.size(); ++i) {
-            if (i > 0) ss << ", ";
-            ss << shape[i];
-          }
-          return ss.str();
-        }() << "]";
-      }
 
       // ═══════════════════════════════════════════════════════════════════════
       // ULTRA-FAST PATH: Shapes unchanged from last run
       // ═══════════════════════════════════════════════════════════════════════
-      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Trying ULTRA-FAST PATH...";
       if (execute_ultra_fast_path(mgx_state, api, context, ctx)) {
-        LOGS_DEFAULT(VERBOSE) << "[COMPUTE] ✓ ULTRA-FAST PATH executed successfully";
-        LOGS_DEFAULT(VERBOSE) << "======================================";
         return Status::OK();
       }
-      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Ultra-fast path not taken";
 
       // ═══════════════════════════════════════════════════════════════════════
       // Build input shape hash - only computed when shapes change
       // ═══════════════════════════════════════════════════════════════════════
-      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Building input shape hash...";
       std::vector<std::int64_t> all_input_shapes;
       all_input_shapes.reserve(map_input_name_index.size() * 4);
       for (const auto& [name, index] : map_input_name_index) {
@@ -3566,28 +3349,20 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         all_input_shapes.insert(all_input_shapes.end(), shape.begin(), shape.end());
       }
       const auto current_hash = make_hash(all_input_shapes);
-      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Current shape hash: " << current_hash;
 
       // ═══════════════════════════════════════════════════════════════════════
       // FAST PATH: Check cached programs for this shape hash
       // ═══════════════════════════════════════════════════════════════════════
-      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Trying FAST PATH...";
       if (execute_fast_path(mgx_state, api, context, ctx, current_hash, all_input_shapes)) {
-        LOGS_DEFAULT(VERBOSE) << "[COMPUTE] ✓ FAST PATH executed successfully";
-        LOGS_DEFAULT(VERBOSE) << "======================================";
         return Status::OK();
       }
-      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Fast path not taken";
 
       // ═══════════════════════════════════════════════════════════════════════
       // STANDARD PATH: Shape checking and potential recompilation
       // ═══════════════════════════════════════════════════════════════════════
-      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Taking STANDARD PATH...";
       execute_standard_path(mgx_state, api, context, ctx, current_hash, std::move(all_input_shapes),
                             model_cache_path_, model_path_, mxr_filename_prefix);
 
-      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] ✓ STANDARD PATH complete";
-      LOGS_DEFAULT(VERBOSE) << "======================================";
       return Status::OK();
     };
     node_compute_funcs.push_back(compute_info);

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1922,13 +1922,58 @@ static InputShapeResult handle_input_shape(
   return {input_shape_match, param_shapes, input_shapes};
 }
 
+// Build MIGraphX ONNX options with default shapes for symbolic dimensions
+// Sets default batch size of 1 for symbolic batch dimensions, 1 for other symbolic dimensions
+static migraphx::onnx_options get_program_parameter_options(
+    const std::vector<std::string>& input_names,
+    const std::vector<const NodeArg*>& input_tensor,
+    const InitializedTensorSet& initializers) {
+  migraphx::onnx_options options;
+  constexpr std::size_t default_batch_size = 1;
+
+  for (std::size_t i = 0; i < input_names.size(); ++i) {
+    // Skip if this is an initializer/constant - let MIGraphX infer its shape
+    if (initializers.count(input_names[i]) > 0) {
+      LOGS_DEFAULT(VERBOSE) << "[Compile] Skipping '" << input_names[i] << "' (initializer/constant)";
+      continue;
+    }
+
+    if (i < input_tensor.size()) {
+      auto tensor_shape = input_tensor[i]->Shape();
+      if (tensor_shape != nullptr && tensor_shape->dim_size() > 0) {
+        std::vector<std::size_t> default_shape;
+        bool has_symbolic = false;
+
+        for (int j = 0; j < tensor_shape->dim_size(); ++j) {
+          const auto& dim = tensor_shape->dim(j);
+          if (dim.has_dim_value()) {
+            default_shape.push_back(static_cast<std::size_t>(dim.dim_value()));
+          } else if (dim.has_dim_param() || !dim.has_dim_value()) {
+            // Symbolic or unknown dimension - use default batch size for dim 0, 1 for others
+            has_symbolic = true;
+            default_shape.push_back(j == 0 ? default_batch_size : 1);
+            LOGS_DEFAULT(VERBOSE) << "[Compile] Input parameter '" << input_names[i]
+                                  << "' dimension " << j << " is symbolic, using default";
+          }
+        }
+
+        if (has_symbolic && !default_shape.empty()) {
+          options.set_input_parameter_shape(input_names[i], default_shape);
+          LOGS_DEFAULT(VERBOSE) << "[Compile] Set default shape for input parameter '" << input_names[i] << "'";
+        }
+      }
+    }
+  }
+  LOGS_DEFAULT(VERBOSE) << "[Compile] Constants and initializers will have shapes inferred by MIGraphX";
+
+  return options;
+}
+
 constexpr std::uint64_t MIGraphX_Version =
     ((MIGRAPHX_VERSION_MAJOR << 16) | (MIGRAPHX_VERSION_MINOR << 8) | MIGRAPHX_VERSION_PATCH);
 
 Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused_nodes,
                                           std::vector<NodeComputeInfo>& node_compute_funcs) {
-  migraphx::onnx_options options;
-  bool defer_compilation = false;
   for (const auto& fused_node_graph : fused_nodes) {
     const GraphViewer& graph_body_viewer = fused_node_graph.filtered_graph;
     const Node& fused_node = fused_node_graph.fused_node;
@@ -1946,8 +1991,6 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     for (auto i : input_tensor) {
       session_input_names.insert(i->Name());
     }
-
-    constexpr std::size_t default_batch_size = 1;
 
 
     // map parameter input name to index
@@ -1970,43 +2013,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     std::vector<std::string> input_names, output_names;
     get_io_names(graph_body_viewer, input_names, output_names);
 
-    // Get initializers to filter them out
+    // Get initializers and build ONNX options with default shapes for symbolic dimensions
     const auto& initializers = graph_body_viewer.GetAllInitializedTensors();
-
-    for (std::size_t i = 0; i < input_names.size(); ++i) {
-      // Skip if this is an initializer/constant - let MIGraphX infer its shape
-      if (initializers.count(input_names[i]) > 0) {
-        LOGS_DEFAULT(VERBOSE) << "[Compile] Skipping '" << input_names[i] << "' (initializer/constant)";
-        continue;
-      }
-
-      if (i < input_tensor.size()) {
-        auto tensor_shape = input_tensor[i]->Shape();
-        if (tensor_shape != nullptr && tensor_shape->dim_size() > 0) {
-          std::vector<std::size_t> default_shape;
-          bool has_symbolic = false;
-
-          for (int j = 0; j < tensor_shape->dim_size(); ++j) {
-            const auto& dim = tensor_shape->dim(j);
-            if (dim.has_dim_value()) {
-              default_shape.push_back(static_cast<std::size_t>(dim.dim_value()));
-            } else if (dim.has_dim_param() || !dim.has_dim_value()) {
-              // Symbolic or unknown dimension - use default batch size for dim 0, 1 for others
-              has_symbolic = true;
-              default_shape.push_back(j == 0 ? default_batch_size : 1);
-              LOGS_DEFAULT(VERBOSE) << "[Compile] Input parameter '" << input_names[i]
-                                    << "' dimension " << j << " is symbolic, using default";
-            }
-          }
-
-          if (has_symbolic && !default_shape.empty()) {
-            options.set_input_parameter_shape(input_names[i], default_shape);
-            LOGS_DEFAULT(VERBOSE) << "[Compile] Set default shape for input parameter '" << input_names[i] << "'";
-          }
-        }
-      }
-    }
-    LOGS_DEFAULT(VERBOSE) << "[Compile] Constants and initializers will have shapes inferred by MIGraphX";
+    migraphx::onnx_options options = get_program_parameter_options(input_names, input_tensor, initializers);
 
     // always defer compilation to compute for first inference
     // This is done as if the modic has static input shapes but batch changes we'll need to do an update anyway
@@ -2055,7 +2064,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       migraphx::onnx_options& cmp_options = mgx_state->options;
 
       // Fast path: If compilation is not deferred and we have cached programs, check for a match
-      if (!migx_state->defer_compilation && mgx_state->cached_programs_ref.has_value()) {
+      if (!mgx_state->defer_compilation && mgx_state->cached_programs_ref.has_value()) {
         // Build cache key from ALL inputs
         std::vector<std::int64_t> all_input_shapes;
         for (const auto& it : map_input_name_index) {
@@ -2091,7 +2100,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       // Standard path: Process input shapes and determine if recompilation is needed
       // Using fine-grained symbolic dimension tracking for more precise shape matching
       auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
-          defer_compilation, map_input_name_index, ctx, cmp_options, prog);
+          mgx_state->defer_compilation, map_input_name_index, ctx, cmp_options, prog);
 
       // input shapes are different, needs to re-parse onnx and
       // re-compile the program

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1204,17 +1204,185 @@ void save_compiled_model(const migraphx::program& prog, const std::filesystem::p
   }
 }
 
-// Generate a vector of power-of-2 batch sizes from 1 up to max_batch_size (inclusive)
-// E.g., max_batch_size=16 returns {1, 2, 4, 8, 16}
+// Generate a vector of power-of-2 batch sizes from 1 up to the nearest power of 2 >= max_batch_size
+// E.g., max_batch_size=100 returns {1, 2, 4, 8, 16, 32, 64, 128}
 static std::vector<std::size_t> generate_power_of_two_batch_sizes(std::size_t max_batch_size) {
   std::vector<std::size_t> batch_sizes;
   if (max_batch_size == 0) {
     return batch_sizes;
   }
-  for (std::size_t bs = 1; bs <= max_batch_size; bs *= 2) {
+  
+  // Find the nearest power of 2 >= max_batch_size
+  std::size_t target = 1;
+  while (target < max_batch_size) {
+    target *= 2;
+  }
+  
+  // Generate all powers of 2 up to target
+  for (std::size_t bs = 1; bs <= target; bs *= 2) {
     batch_sizes.push_back(bs);
   }
   return batch_sizes;
+}
+
+// Find the smallest power-of-two batch size that is >= the requested batch size
+// Returns 0 if no suitable batch size found in the list
+static std::size_t find_nearest_power_of_two_batch(std::size_t requested_batch, 
+                                                    const std::vector<std::size_t>& power_of_two_batches) {
+  for (const auto& bs : power_of_two_batches) {
+    if (bs >= requested_batch) {
+      return bs;
+    }
+  }
+  return 0;  // Not found - should not happen if list is properly generated
+}
+
+// Pad input tensor data to a larger batch size
+// Copies the original data and replicates the last batch element to fill the padding
+static void pad_input_tensor(const void* src_data, void* dst_data,
+                             std::size_t original_batch, std::size_t padded_batch,
+                             std::size_t element_size_bytes, std::size_t elements_per_batch,
+                             hipStream_t stream) {
+  std::size_t bytes_per_batch = element_size_bytes * elements_per_batch;
+  
+  // Copy original data
+  HIP_CALL_THROW(hipMemcpyAsync(dst_data, src_data, 
+                                original_batch * bytes_per_batch,
+                                hipMemcpyDeviceToDevice, stream));
+  
+  // Pad with last batch element replicated
+  if (original_batch > 0 && padded_batch > original_batch) {
+    const char* last_batch = static_cast<const char*>(src_data) + (original_batch - 1) * bytes_per_batch;
+    char* pad_start = static_cast<char*>(dst_data) + original_batch * bytes_per_batch;
+    
+    for (std::size_t i = original_batch; i < padded_batch; ++i) {
+      HIP_CALL_THROW(hipMemcpyAsync(pad_start, last_batch, bytes_per_batch,
+                                    hipMemcpyDeviceToDevice, stream));
+      pad_start += bytes_per_batch;
+    }
+  }
+}
+
+// Allocate padded input buffers and pad the data for dynamic batching
+// Returns true if padding was applied, false otherwise
+static bool allocate_and_pad_inputs(
+    MIGraphXFuncState* mgx_state,
+    Ort::KernelContext& ctx,
+    std::size_t original_batch_size,
+    std::size_t padded_batch_size,
+    hipStream_t stream) {
+  
+  if (padded_batch_size <= original_batch_size || mgx_state->cached_inputs.empty()) {
+    return false;  // No padding needed
+  }
+  
+  LOGS_DEFAULT(WARNING) << "[allocate_and_pad_inputs] Allocating and padding inputs: original=" 
+                        << original_batch_size << ", padded=" << padded_batch_size;
+  
+  // Free old buffers if they exist
+  for (auto& buf : mgx_state->padded_input_buffers) {
+    if (buf.data != nullptr) {
+      HIP_CALL_THROW(hipFree(buf.data));
+      buf.data = nullptr;
+    }
+  }
+  mgx_state->padded_input_buffers.clear();
+  
+  // Allocate and pad each input
+  mgx_state->padded_input_buffers.reserve(mgx_state->cached_inputs.size());
+  
+  for (const auto& cached_inp : mgx_state->cached_inputs) {
+    auto input_tensor = ctx.GetInput(cached_inp.ort_index);
+    auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+    const auto tensor_shape = tensor_info.GetShape();
+    
+    if (tensor_shape.empty()) {
+      LOGS_DEFAULT(WARNING) << "[allocate_and_pad_inputs] Skipping empty shape input";
+      continue;
+    }
+    
+    // Calculate padded shape
+    std::vector<std::size_t> padded_lens(tensor_shape.begin(), tensor_shape.end());
+    padded_lens[0] = padded_batch_size;  // Replace batch dimension
+    
+    // Create padded MIGraphX shape
+    migraphx::shape padded_mgx_shape{cached_inp.mgx_shape.type(), padded_lens};
+    std::size_t padded_bytes = padded_mgx_shape.bytes();
+    
+    // Allocate GPU buffer for padded data
+    void* padded_data = nullptr;
+    HIP_CALL_THROW(hipMalloc(&padded_data, padded_bytes));
+    
+    // Calculate elements per batch
+    std::size_t elements_per_batch = 1;
+    for (std::size_t i = 1; i < tensor_shape.size(); ++i) {
+      elements_per_batch *= tensor_shape[i];
+    }
+    
+    // Calculate element size from tensor type
+    std::size_t element_size_bytes;
+    switch (tensor_info.GetElementType()) {
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+        element_size_bytes = sizeof(float);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+        element_size_bytes = sizeof(uint16_t);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+        element_size_bytes = sizeof(int64_t);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
+        element_size_bytes = sizeof(int32_t);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
+        element_size_bytes = sizeof(int16_t);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:
+        element_size_bytes = sizeof(int8_t);
+        break;
+      default:
+        element_size_bytes = sizeof(float);  // Fallback to float
+        LOGS_DEFAULT(WARNING) << "[allocate_and_pad_inputs] Unknown element type, assuming float";
+        break;
+    }
+    
+    // Pad the data
+    const void* original_data = input_tensor.GetTensorRawData();
+    pad_input_tensor(original_data, padded_data, original_batch_size, padded_batch_size,
+                    element_size_bytes, elements_per_batch, stream);
+    
+    // Store padded buffer info
+    MIGraphXFuncState::PaddedBuffer buf;
+    buf.data = padded_data;
+    buf.size_bytes = padded_bytes;
+    buf.mgx_shape = padded_mgx_shape;
+    mgx_state->padded_input_buffers.push_back(buf);
+    
+    LOGS_DEFAULT(WARNING) << "[allocate_and_pad_inputs] Padded input '" << cached_inp.name 
+                         << "': " << padded_bytes << " bytes";
+  }
+  
+  LOGS_DEFAULT(WARNING) << "[allocate_and_pad_inputs] Allocated " 
+                        << mgx_state->padded_input_buffers.size() << " padded buffers";
+  return true;
+}
+
+// Free padded input buffers
+static void free_padded_inputs(MIGraphXFuncState* mgx_state) {
+  for (auto& buf : mgx_state->padded_input_buffers) {
+    if (buf.data != nullptr) {
+      hipFree(buf.data);  // Don't throw on cleanup
+      buf.data = nullptr;
+    }
+  }
+  mgx_state->padded_input_buffers.clear();
 }
 
 // Order matters here especially if the program uses mixed quantization
@@ -1468,6 +1636,7 @@ static migraphx::program load_or_compile_model(
 // Helper: Run the MIGraphX program and handle outputs
 // This function executes the compiled MIGraphX program and copies outputs that
 // were not pre-allocated (input parameters reused as outputs) to the ORT output tensors
+// If original_batch_size is provided and < padded batch size, slices the output to remove padding
 static void run_migraphx_program(
     std::mutex* mgx_mu_ptr,
     const OrtApi* api,
@@ -1475,7 +1644,9 @@ static void run_migraphx_program(
     Ort::KernelContext& ctx,
     migraphx::program& prog,
     migraphx::program_parameters& m,
-    const std::vector<std::size_t>& prog_output_indices)
+    const std::vector<std::size_t>& prog_output_indices,
+    std::size_t original_batch_size = 0,
+    std::size_t padded_batch_size = 0)
 {
   void* rocm_stream;
   Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &rocm_stream));
@@ -1486,8 +1657,17 @@ static void run_migraphx_program(
     prog_outputs = prog.run_async(m, static_cast<hipStream_t>(rocm_stream));
   }
 
+  bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 && 
+                        original_batch_size < padded_batch_size);
+
+  LOGS_DEFAULT(WARNING) << "[run_migraphx_program] original_batch_size=" << original_batch_size 
+                        << ", padded_batch_size=" << padded_batch_size 
+                        << ", needs_slicing=" << needs_slicing;
+
   // In case of input parameters are reused as output parameter call hipMemcpy
   auto output_num = prog_outputs->size();
+  LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Number of outputs: " << output_num;
+  
   if (prog_output_indices.size() < output_num) {
     std::unordered_set<std::size_t> prog_output_indices_set(prog_output_indices.begin(), prog_output_indices.end());
     for (std::size_t i = 0; i < output_num; ++i) {
@@ -1496,18 +1676,56 @@ static void run_migraphx_program(
       auto gpu_res = (*prog_outputs)[i];
       migraphx::shape res_shape = gpu_res.get_shape();
       auto res_lens = res_shape.lengths();
+      
+      // Log the original MIGraphX output shape
+      LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Output " << i << " MIGraphX shape: [" << [&]() {
+        std::ostringstream ss;
+        for (size_t j = 0; j < res_lens.size(); ++j) {
+          if (j > 0) ss << ", ";
+          ss << res_lens[j];
+        }
+        return ss.str();
+      }() << "]";
+      
+      // Adjust output shape if slicing is needed
       std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
+      if (needs_slicing && !ort_shape.empty()) {
+        ort_shape[0] = original_batch_size;  // Slice batch dimension
+        LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Slicing output " << i << " from batch size " 
+                             << padded_batch_size << " to " << original_batch_size;
+      }
+      
+      LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Output " << i << " ORT shape (after slicing): [" << [&]() {
+        std::ostringstream ss;
+        for (size_t j = 0; j < ort_shape.size(); ++j) {
+          if (j > 0) ss << ", ";
+          ss << ort_shape[j];
+        }
+        return ss.str();
+      }() << "]";
+      
       auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
       void* output_data = output_tensor.GetTensorMutableRawData();
 
-      // Log output batch size for tracking
-      if (!ort_shape.empty()) {
-        LOGS_DEFAULT(VERBOSE) << "[Compute] Output " << i << " batch size: " << ort_shape[0];
+      // Calculate bytes to copy (slice if needed)
+      std::size_t bytes_to_copy = res_shape.bytes();
+      if (needs_slicing && res_lens.size() > 0) {
+        // Calculate bytes per batch element
+        std::size_t elements_per_batch = 1;
+        for (std::size_t j = 1; j < res_lens.size(); ++j) {
+          elements_per_batch *= res_lens[j];
+        }
+        bytes_to_copy = (res_shape.bytes() / padded_batch_size) * original_batch_size;
+        LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Copying " << bytes_to_copy 
+                             << " bytes (sliced from " << res_shape.bytes() << " bytes)";
+      } else {
+        LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Copying " << bytes_to_copy 
+                             << " bytes (no slicing)";
       }
 
       HIP_CALL_THROW(hipMemcpyWithStream(output_data,
                                          gpu_res.data(),
-                                         res_shape.bytes(),
+                                         bytes_to_copy,
                                          hipMemcpyDeviceToDevice,
                                          static_cast<hipStream_t>(rocm_stream)));
     }
@@ -1728,44 +1946,178 @@ static bool execute_ultra_fast_path(
     OrtKernelContext* context,
     Ort::KernelContext& ctx)
 {
+  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Checking cache validity";
+  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] caches_valid = " << mgx_state->caches_valid;
+  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] last_input_shapes_raw.size() = " 
+                        << mgx_state->last_input_shapes_raw.size();
+  
   if (!mgx_state->caches_valid || mgx_state->last_input_shapes_raw.empty()) {
+    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Caches not valid or empty - skipping";
     return false;
   }
 
   // Quick shape comparison
+  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Performing shape comparison";
+  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Number of cached inputs: " << mgx_state->cached_inputs.size();
   bool shapes_match = true;
   std::size_t offset = 0;
   const auto& last_shapes = mgx_state->last_input_shapes_raw;
+  
+  std::size_t original_batch_size = 0;
+  std::size_t padded_batch_size = 0;
+  bool is_first = true;
+  int input_idx = 0;
 
   for (const auto& inp : mgx_state->cached_inputs) {
     const auto& shape = ctx.GetInput(inp.ort_index).GetTensorTypeAndShapeInfo().GetShape();
+    
+    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Input " << input_idx << " '" << inp.name 
+                          << "': current shape size=" << shape.size() 
+                          << ", offset=" << offset 
+                          << ", last_shapes.size()=" << last_shapes.size();
+    
     if (offset + shape.size() > last_shapes.size()) {
+      LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Shape size mismatch - failing";
       shapes_match = false;
       break;
     }
-    for (std::size_t i = 0; i < shape.size(); ++i) {
-      if (last_shapes[offset + i] != shape[i]) {
+    
+    // Log current vs cached shapes
+    std::ostringstream current_ss, cached_ss;
+    current_ss << "[";
+    for (size_t i = 0; i < shape.size(); ++i) {
+      if (i > 0) current_ss << ", ";
+      current_ss << shape[i];
+    }
+    current_ss << "]";
+    
+    cached_ss << "[";
+    for (size_t i = 0; i < shape.size() && offset + i < last_shapes.size(); ++i) {
+      if (i > 0) cached_ss << ", ";
+      cached_ss << last_shapes[offset + i];
+    }
+    cached_ss << "]";
+    
+    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH]   Current: " << current_ss.str();
+    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH]   Cached:  " << cached_ss.str();
+    
+    // For dynamic batch, we check if the current batch needs padding
+    if (mgx_state->has_dynamic_batch && !mgx_state->power_of_two_batch_sizes.empty()) {
+      // Get batch sizes from first input
+      if (is_first) {
+        original_batch_size = static_cast<std::size_t>(shape[0]);
+        padded_batch_size = static_cast<std::size_t>(last_shapes[offset]);
+        is_first = false;
+        
+        LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Current batch: " << original_batch_size
+                              << ", cached padded batch: " << padded_batch_size;
+        
+        // Check if the batch size matches (original or padded)
+        if (shape[0] != last_shapes[offset]) {
+          // Batch size changed - check if we can use padding
+          std::size_t required_padded = find_nearest_power_of_two_batch(
+              original_batch_size, mgx_state->power_of_two_batch_sizes);
+          
+          LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Required padded: " << required_padded;
+          
+          if (required_padded != padded_batch_size) {
+            LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Padded batch size mismatch - failing";
+            shapes_match = false;
+            break;
+          }
+        }
+      }
+      
+      // For ALL inputs with dynamic batching: verify batch size consistency and check non-batch dims
+      LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Checking dimensions for input " << input_idx;
+      
+      // All current inputs should have the same batch size (original_batch_size)
+      if (shape[0] != original_batch_size) {
+        LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Batch dimension mismatch: current=" 
+                              << shape[0] << ", expected original=" << original_batch_size;
         shapes_match = false;
         break;
       }
+      
+      // Cached shape should have padded batch size in dimension 0
+      if (last_shapes[offset] != static_cast<std::int64_t>(padded_batch_size)) {
+        LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Cached batch mismatch: cached=" 
+                              << last_shapes[offset] << ", expected padded=" << padded_batch_size;
+        shapes_match = false;
+        break;
+      }
+      
+      // Check non-batch dimensions (current vs cached)
+      bool rest_matches = true;
+      for (std::size_t i = 1; i < shape.size(); ++i) {
+        if (last_shapes[offset + i] != shape[i]) {
+          LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Dimension " << i 
+                                << " mismatch: current=" << shape[i] 
+                                << ", cached=" << last_shapes[offset + i];
+          rest_matches = false;
+          break;
+        }
+      }
+      if (!rest_matches) {
+        shapes_match = false;
+        break;
+      }
+      LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Input " << input_idx << " dims match!";
+    } else {
+      // No dynamic batching - strict comparison
+      for (std::size_t i = 0; i < shape.size(); ++i) {
+        if (last_shapes[offset + i] != shape[i]) {
+          LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Dimension " << i 
+                                << " mismatch at input " << input_idx 
+                                << ": current=" << shape[i] 
+                                << ", cached=" << last_shapes[offset + i];
+          shapes_match = false;
+          break;
+        }
+      }
     }
+    
     if (!shapes_match) break;
     offset += shape.size();
+    input_idx++;
   }
 
   if (!shapes_match || offset != last_shapes.size()) {
+    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Shapes don't match - failing";
     return false;
   }
 
-  // Shapes unchanged - rebind pointers and run directly
+  // Shapes unchanged (or compatible with padding) - rebind pointers and run directly
+  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] ✓ Shapes match! Rebinding and executing";
   auto& m = mgx_state->cached_prog_params.value();
   auto& prog = mgx_state->prog;
+  
+  // Allocate and pad inputs if needed for dynamic batching
+  bool using_padded_inputs = false;
+  if (padded_batch_size > original_batch_size) {
+    void* rocm_stream_ptr;
+    Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &rocm_stream_ptr));
+    auto rocm_stream = static_cast<hipStream_t>(rocm_stream_ptr);
+    using_padded_inputs = allocate_and_pad_inputs(mgx_state, ctx, original_batch_size, 
+                                                  padded_batch_size, rocm_stream);
+    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Using padded inputs: " << using_padded_inputs;
+  }
 
-  // Rebind inputs - direct iteration, no map lookups
-  for (const auto& inp : mgx_state->cached_inputs) {
-    const auto& input_tensor = ctx.GetInput(inp.ort_index);
-    m.add(inp.name.c_str(), migraphx::argument(inp.mgx_shape,
-                                       const_cast<void*>(input_tensor.GetTensorRawData())));
+  // Rebind inputs - use padded buffers if available, otherwise use original inputs
+  if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
+    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Binding padded input buffers";
+    for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
+      const auto& inp = mgx_state->cached_inputs[i];
+      const auto& padded_buf = mgx_state->padded_input_buffers[i];
+      m.add(inp.name.c_str(), migraphx::argument(padded_buf.mgx_shape, padded_buf.data));
+    }
+  } else {
+    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Binding original input buffers";
+    for (const auto& inp : mgx_state->cached_inputs) {
+      const auto& input_tensor = ctx.GetInput(inp.ort_index);
+      m.add(inp.name.c_str(), migraphx::argument(inp.mgx_shape,
+                                         const_cast<void*>(input_tensor.GetTensorRawData())));
+    }
   }
 
   // Rebind outputs - direct iteration, uses pre-allocated shape vectors
@@ -1777,9 +2129,18 @@ static bool execute_ultra_fast_path(
                                        output_tensor.GetTensorMutableRawData()));
   }
 
-  // Run directly - minimal overhead path
+  // Run directly - minimal overhead path (with slicing if needed)
+  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Running (original_batch=" << original_batch_size 
+                     << ", padded=" << padded_batch_size << ")";
   run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m,
-                       mgx_state->cached_prog_output_indices);
+                       mgx_state->cached_prog_output_indices,
+                       original_batch_size, padded_batch_size);
+  
+  // Free padded buffers after execution
+  if (using_padded_inputs) {
+    free_padded_inputs(mgx_state);
+  }
+  
   return true;
 }
 
@@ -1794,17 +2155,107 @@ static bool execute_fast_path(
     const std::string& current_hash,
     std::vector<std::int64_t>& all_input_shapes)
 {
+  LOGS_DEFAULT(WARNING) << "[FAST_PATH] Checking for cached program with hash: " << current_hash;
+  
   if (mgx_state->defer_compilation || !mgx_state->cached_programs_ref.has_value()) {
+    LOGS_DEFAULT(WARNING) << "[FAST_PATH] Skipping - defer_compilation=" << mgx_state->defer_compilation
+                          << ", has cache=" << mgx_state->cached_programs_ref.has_value();
     return false;
   }
 
   auto& cached_programs = mgx_state->cached_programs_ref.value().get();
+  LOGS_DEFAULT(WARNING) << "[FAST_PATH] Memory cache size: " << cached_programs.size();
   auto prog_it = cached_programs.find(current_hash);
+  
+  // If not found directly, check if we need to use a padded batch size
+  std::size_t original_batch_size = 0;
+  std::size_t padded_batch_size = 0;
+  bool needs_padding = false;
+  
+  if (prog_it == cached_programs.end() && mgx_state->has_dynamic_batch && 
+      !mgx_state->power_of_two_batch_sizes.empty()) {
+    LOGS_DEFAULT(WARNING) << "[FAST_PATH][DynamicBatch] Direct hash miss - checking for padded batch";
+    // Try to find a padded batch size
+    const auto& map_input_name_index = mgx_state->input_name_indexes;
+    
+    for (const auto& [name, index] : map_input_name_index) {
+      auto input_tensor = ctx.GetInput(index);
+      auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+      const auto tensor_shape = tensor_info.GetShape();
+      if (!tensor_shape.empty()) {
+        original_batch_size = static_cast<std::size_t>(tensor_shape[0]);
+        padded_batch_size = find_nearest_power_of_two_batch(original_batch_size, 
+                                                            mgx_state->power_of_two_batch_sizes);
+        needs_padding = (padded_batch_size > original_batch_size);
+        LOGS_DEFAULT(WARNING) << "[FAST_PATH][DynamicBatch] Original batch: " << original_batch_size
+                              << ", padded: " << padded_batch_size << ", needs_padding: " << needs_padding;
+        break;
+      }
+    }
+    
+    if (needs_padding && padded_batch_size > 0) {
+      LOGS_DEFAULT(WARNING) << "[FAST_PATH][DynamicBatch] Building padded shape key for hash lookup";
+      // Build padded shapes in alphabetical order (map order) for hash calculation
+      // This matches the order used during compilation in compile_dynamic_batch_models
+      std::vector<std::int64_t> padded_shapes_for_hash;
+      padded_shapes_for_hash.reserve(all_input_shapes.size());
+      
+      for (const auto& [name, index] : map_input_name_index) {
+        auto input_tensor = ctx.GetInput(index);
+        auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+        const auto tensor_shape = tensor_info.GetShape();
+        
+        if (!tensor_shape.empty()) {
+          padded_shapes_for_hash.push_back(static_cast<std::int64_t>(padded_batch_size));
+          padded_shapes_for_hash.insert(padded_shapes_for_hash.end(), tensor_shape.begin() + 1, tensor_shape.end());
+        }
+      }
+      
+      auto padded_hash = make_hash(padded_shapes_for_hash);
+      LOGS_DEFAULT(WARNING) << "[FAST_PATH][DynamicBatch] Padded hash (map order): " << padded_hash;
+      prog_it = cached_programs.find(padded_hash);
+      
+      if (prog_it != cached_programs.end()) {
+        LOGS_DEFAULT(WARNING) << "[FAST_PATH][DynamicBatch] ✓✓✓ CACHE HIT using padded batch size " 
+                           << padded_batch_size << " for original batch " << original_batch_size;
+        
+        // Now rebuild padded_shapes in cached_inputs order for saving to last_input_shapes_raw
+        // This ensures ultra-fast path shape comparison works correctly
+        if (!mgx_state->cached_inputs.empty()) {
+          LOGS_DEFAULT(WARNING) << "[FAST_PATH][DynamicBatch] Rebuilding in cached_inputs order for saving";
+          std::vector<std::int64_t> padded_shapes_for_cache;
+          padded_shapes_for_cache.reserve(mgx_state->cached_inputs.size() * 2);
+          
+          for (const auto& cached_inp : mgx_state->cached_inputs) {
+            auto input_tensor = ctx.GetInput(cached_inp.ort_index);
+            auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+            const auto tensor_shape = tensor_info.GetShape();
+            
+            if (!tensor_shape.empty()) {
+              padded_shapes_for_cache.push_back(static_cast<std::int64_t>(padded_batch_size));
+              padded_shapes_for_cache.insert(padded_shapes_for_cache.end(), tensor_shape.begin() + 1, tensor_shape.end());
+            }
+          }
+          all_input_shapes = std::move(padded_shapes_for_cache);
+        } else {
+          // Fallback: use map order (shouldn't happen if caches are populated)
+          all_input_shapes = std::move(padded_shapes_for_hash);
+        }
+      } else {
+        LOGS_DEFAULT(WARNING) << "[FAST_PATH][DynamicBatch] Cache miss for padded hash too";
+      }
+    }
+  } else if (prog_it != cached_programs.end()) {
+    LOGS_DEFAULT(WARNING) << "[FAST_PATH] ✓ CACHE HIT for exact hash";
+  }
+  
   if (prog_it == cached_programs.end()) {
+    LOGS_DEFAULT(WARNING) << "[FAST_PATH] No cached program found";
     return false;
   }
 
   // Found cached program - use it and populate caches
+  LOGS_DEFAULT(WARNING) << "[FAST_PATH] Using cached program, populating caches";
   auto& prog = mgx_state->prog;
   prog = prog_it->second;
 
@@ -1827,9 +2278,40 @@ static bool execute_fast_path(
   mgx_state->last_input_shape_hash = current_hash;
   mgx_state->caches_valid = true;
 
+  // Allocate and pad inputs if needed for dynamic batching
+  bool using_padded_inputs = false;
+  if (padded_batch_size > original_batch_size) {
+    void* rocm_stream_ptr;
+    Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &rocm_stream_ptr));
+    auto rocm_stream = static_cast<hipStream_t>(rocm_stream_ptr);
+    using_padded_inputs = allocate_and_pad_inputs(mgx_state, ctx, original_batch_size, 
+                                                  padded_batch_size, rocm_stream);
+    
+    // Rebind padded inputs to program parameters
+    if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
+      LOGS_DEFAULT(WARNING) << "[FAST_PATH] Rebinding padded input buffers";
+      auto& prog_params = mgx_state->cached_prog_params.value();
+      for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
+        const auto& inp = mgx_state->cached_inputs[i];
+        const auto& padded_buf = mgx_state->padded_input_buffers[i];
+        prog_params.add(inp.name.c_str(), migraphx::argument(padded_buf.mgx_shape, padded_buf.data));
+      }
+    }
+  }
+
+  LOGS_DEFAULT(WARNING) << "[FAST_PATH] Running program (original_batch=" << original_batch_size 
+                     << ", padded=" << padded_batch_size << ")";
   run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog,
                        mgx_state->cached_prog_params.value(),
-                       mgx_state->cached_prog_output_indices);
+                       mgx_state->cached_prog_output_indices,
+                       original_batch_size, padded_batch_size);
+  
+  // Free padded buffers after execution
+  if (using_padded_inputs) {
+    free_padded_inputs(mgx_state);
+  }
+  
+  LOGS_DEFAULT(WARNING) << "[FAST_PATH] Complete";
   return true;
 }
 
@@ -1919,6 +2401,161 @@ static InputShapeResult handle_input_shape(
   return {input_shape_match, param_shapes, input_shapes};
 }
 
+// Helper: Compile models for all power-of-two batch sizes and cache them
+static void compile_dynamic_batch_models(
+    MIGraphXFuncState* mgx_state,
+    const std::filesystem::path& model_cache_path,
+    const std::filesystem::path& model_path,
+    const std::string& mxr_filename_prefix,
+    const Ort::KernelContext& ctx) {
+  
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ==== ENTERING compile_dynamic_batch_models ====";
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] has_dynamic_batch = " << mgx_state->has_dynamic_batch;
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] power_of_two_batch_sizes.size() = " 
+                     << mgx_state->power_of_two_batch_sizes.size();
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] max_dynamic_batch = " << mgx_state->max_dynamic_batch;
+  
+  if (!mgx_state->has_dynamic_batch || mgx_state->power_of_two_batch_sizes.empty()) {
+    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Skipping - dynamic batch disabled or no batch sizes";
+    return;
+  }
+  
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Compiling models for " 
+                     << mgx_state->power_of_two_batch_sizes.size() << " power-of-two batch sizes";
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Batch sizes: ";
+  for (const auto& bs : mgx_state->power_of_two_batch_sizes) {
+    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE]   - " << bs;
+  }
+  
+  // Get input names and base shapes (without batch dimension)
+  const auto& map_input_name_index = mgx_state->input_name_indexes;
+  std::vector<std::string> input_names;
+  std::vector<std::vector<std::int64_t>> all_input_base_shapes;
+  
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Processing " << map_input_name_index.size() << " input parameters";
+  for (const auto& [name, index] : map_input_name_index) {
+    input_names.push_back(name);
+    auto input_tensor = ctx.GetInput(index);
+    auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+    const auto tensor_shape = tensor_info.GetShape();
+    
+    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Input '" << name << "' (index " << index 
+                       << ") runtime shape: [" << [&]() {
+                         std::ostringstream ss;
+                         for (size_t i = 0; i < tensor_shape.size(); ++i) {
+                           if (i > 0) ss << ", ";
+                           ss << tensor_shape[i];
+                         }
+                         return ss.str();
+                       }() << "]";
+    
+    // Store shape without batch dimension
+    std::vector<std::int64_t> base_shape;
+    if (tensor_shape.size() > 1) {
+      base_shape.assign(tensor_shape.begin() + 1, tensor_shape.end());
+    }
+    all_input_base_shapes.push_back(base_shape);
+    
+    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE]   Base shape (no batch): [" << [&]() {
+                         std::ostringstream ss;
+                         for (size_t i = 0; i < base_shape.size(); ++i) {
+                           if (i > 0) ss << ", ";
+                           ss << base_shape[i];
+                         }
+                         return ss.str();
+                       }() << "]";
+  }
+  
+  // Compile a model for each power-of-two batch size
+  for (const auto& batch_size : mgx_state->power_of_two_batch_sizes) {
+    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ---- Processing batch size: " << batch_size << " ----";
+    
+    // Build cache key for this batch size
+    std::vector<std::int64_t> batch_shape_key;
+    for (size_t i = 0; i < input_names.size(); ++i) {
+      batch_shape_key.push_back(batch_size);
+      batch_shape_key.insert(batch_shape_key.end(), 
+                            all_input_base_shapes[i].begin(), 
+                            all_input_base_shapes[i].end());
+    }
+    auto cache_hash = make_hash(batch_shape_key);
+    
+    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Shape key for batch " << batch_size << ": [" << [&]() {
+                         std::ostringstream ss;
+                         for (size_t i = 0; i < batch_shape_key.size(); ++i) {
+                           if (i > 0) ss << ", ";
+                           ss << batch_shape_key[i];
+                         }
+                         return ss.str();
+                       }() << "]";
+    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Cache hash: " << cache_hash;
+    
+    // Check if already cached
+    if (mgx_state->cached_programs_ref.has_value()) {
+      auto& cached_progs = mgx_state->cached_programs_ref.value().get();
+      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Checking in-memory cache (size: " 
+                         << cached_progs.size() << ")";
+      if (cached_progs.find(cache_hash) != cached_progs.end()) {
+        LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ✓ Batch size " << batch_size 
+                          << " already in memory cache, skipping";
+        continue;
+      }
+      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Cache miss - need to compile/load";
+    }
+    
+    // Build cache file path
+    std::filesystem::path batch_cache_file;
+    if (!model_cache_path.empty()) {
+      batch_cache_file = model_cache_path / (mxr_filename_prefix + cache_hash + ".mxr");
+      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Disk cache file: " << batch_cache_file.string();
+    } else {
+      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] No disk cache path configured";
+    }
+    
+    // Compile or load the model for this batch size
+    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Calling load_or_compile_model for batch " << batch_size;
+    migraphx::program batch_prog = load_or_compile_model(
+        batch_cache_file,
+        mgx_state->onnx_string,
+        mgx_state->options,
+        mgx_state->t,
+        mgx_state->fp16_enable,
+        mgx_state->bf16_enable,
+        mgx_state->int8_enable,
+        mgx_state->fp8_enable,
+        mgx_state->int8_calibration_cache_available,
+        mgx_state->dynamic_range_map,
+        mgx_state->exhaustive_tune,
+        model_path,
+        nullptr,  // ctx not needed for compilation
+        nullptr,  // map_input_name_index not needed
+        input_names,
+        all_input_base_shapes,
+        batch_size);
+    
+    // Store in cache
+    if (mgx_state->cached_programs_ref.has_value()) {
+      mgx_state->cached_programs_ref.value().get()[cache_hash] = batch_prog;
+      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ✓ Stored program for batch size " << batch_size 
+                         << " in memory cache with hash " << cache_hash;
+      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Memory cache now contains " 
+                         << mgx_state->cached_programs_ref.value().get().size() << " programs";
+    }
+  }
+  
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ==== All power-of-two batch models compiled and cached ====";
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Setting max_dynamic_batch to 0 to disable future compilation";
+  
+  // Disable dynamic batch compilation for subsequent runs (set max_dynamic_batch to 0)
+  mgx_state->max_dynamic_batch = 0;
+  
+  // Also disable defer_compilation since we've now compiled
+  mgx_state->defer_compilation = false;
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Set defer_compilation = false";
+  
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ==== EXITING compile_dynamic_batch_models ====";
+}
+
 // Standard path: Shape checking, potential recompilation, and execution
 static void execute_standard_path(
     MIGraphXFuncState* mgx_state,
@@ -1931,14 +2568,170 @@ static void execute_standard_path(
     const std::filesystem::path& model_path,
     const std::string& mxr_filename_prefix)
 {
+  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] ==== ENTERING execute_standard_path ====";
+  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] current_hash = " << current_hash;
+  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] has_dynamic_batch = " << mgx_state->has_dynamic_batch;
+  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] max_dynamic_batch = " << mgx_state->max_dynamic_batch;
+  
   auto& prog = mgx_state->prog;
   auto& cmp_options = mgx_state->options;
   const auto& map_input_name_index = mgx_state->input_name_indexes;
 
+  // Check if this is the first run with dynamic batch enabled
+  if (mgx_state->has_dynamic_batch && mgx_state->max_dynamic_batch > 0) {
+    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] *** FIRST RUN DETECTED ***";
+    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] max_dynamic_batch=" 
+                       << mgx_state->max_dynamic_batch;
+    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Initiating compilation of all power-of-two batch models";
+    
+    // Compile all power-of-two batch models
+    compile_dynamic_batch_models(mgx_state, model_cache_path, model_path, mxr_filename_prefix, ctx);
+    
+    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Compilation complete, max_dynamic_batch now = " 
+                       << mgx_state->max_dynamic_batch;
+    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Proceeding with normal execution using closest power-of-two batch";
+  } else if (mgx_state->has_dynamic_batch) {
+    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Dynamic batch enabled but max_dynamic_batch = 0 (already compiled)";
+  }
+
+  // Extract current batch size from first input
+  std::size_t original_batch_size = 0;
+  std::size_t padded_batch_size = 0;
+  bool needs_padding = false;
+  
+  if (mgx_state->has_dynamic_batch && !mgx_state->power_of_two_batch_sizes.empty()) {
+    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Checking for batch padding requirements";
+    // Get the batch size from the first input
+    for (const auto& [name, index] : map_input_name_index) {
+      auto input_tensor = ctx.GetInput(index);
+      auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+      const auto tensor_shape = tensor_info.GetShape();
+      if (!tensor_shape.empty()) {
+        original_batch_size = static_cast<std::size_t>(tensor_shape[0]);
+        padded_batch_size = find_nearest_power_of_two_batch(original_batch_size, 
+                                                            mgx_state->power_of_two_batch_sizes);
+        needs_padding = (padded_batch_size > original_batch_size);
+        
+        LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Original batch size: " << original_batch_size;
+        LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Padded batch size: " << padded_batch_size;
+        LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Needs padding: " << (needs_padding ? "YES" : "NO");
+        break;  // Only need batch size from first input
+      }
+    }
+    
+    if (needs_padding && padded_batch_size > 0) {
+      LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Building padded shape key for cache lookup";
+      // Update the shape hash and all_input_shapes to use the padded batch size
+      std::vector<std::int64_t> padded_shapes;
+      padded_shapes.reserve(all_input_shapes.size());
+      
+      std::size_t shape_offset = 0;
+      for (const auto& [name, index] : map_input_name_index) {
+        auto input_tensor = ctx.GetInput(index);
+        auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+        const auto tensor_shape = tensor_info.GetShape();
+        
+        // Replace batch dimension with padded size
+        if (!tensor_shape.empty()) {
+          padded_shapes.push_back(static_cast<std::int64_t>(padded_batch_size));
+          padded_shapes.insert(padded_shapes.end(), tensor_shape.begin() + 1, tensor_shape.end());
+        }
+      }
+      
+      // Look up the cached program for the padded batch size
+      auto padded_hash = make_hash(padded_shapes);
+      LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Padded shape hash: " << padded_hash;
+      
+      if (mgx_state->cached_programs_ref.has_value()) {
+        auto& cached_progs = mgx_state->cached_programs_ref.value().get();
+        LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Searching in memory cache (size: " 
+                          << cached_progs.size() << ")";
+        auto prog_it = cached_progs.find(padded_hash);
+        if (prog_it != cached_progs.end()) {
+          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] ✓✓✓ CACHE HIT for padded batch size " 
+                             << padded_batch_size;
+          prog = prog_it->second;
+          
+          // Get shapes for the padded program
+          auto param_shapes = prog.get_parameter_shapes();
+          auto output_shapes = prog.get_output_shapes();
+          
+          // Populate caches
+          populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
+          
+          // Rebuild padded_shapes in cached_inputs order (MIGraphX parameter order)
+          // This ensures consistency with ultra-fast path shape comparison
+          padded_shapes.clear();
+          padded_shapes.reserve(mgx_state->cached_inputs.size() * 2);
+          for (const auto& cached_inp : mgx_state->cached_inputs) {
+            auto input_tensor = ctx.GetInput(cached_inp.ort_index);
+            auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+            const auto tensor_shape = tensor_info.GetShape();
+            
+            if (!tensor_shape.empty()) {
+              padded_shapes.push_back(static_cast<std::int64_t>(padded_batch_size));
+              padded_shapes.insert(padded_shapes.end(), tensor_shape.begin() + 1, tensor_shape.end());
+            }
+          }
+          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Rebuilt padded_shapes in cached_inputs order";
+          
+          // Bind inputs and outputs
+          auto [m, prog_output_indices] = handle_program_input_outputs(
+              param_shapes, output_shapes, map_input_name_index, ctx);
+          
+          mgx_state->cached_prog_params = m;
+          mgx_state->cached_prog_output_indices = prog_output_indices;
+          mgx_state->last_input_shapes_raw = std::move(padded_shapes);
+          mgx_state->last_input_shape_hash = padded_hash;
+          mgx_state->caches_valid = true;
+          
+          // Allocate and pad inputs for dynamic batching
+          void* rocm_stream_ptr;
+          Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &rocm_stream_ptr));
+          auto rocm_stream = static_cast<hipStream_t>(rocm_stream_ptr);
+          bool using_padded_inputs = allocate_and_pad_inputs(mgx_state, ctx, original_batch_size, 
+                                                             padded_batch_size, rocm_stream);
+          
+          // Rebind padded inputs to program parameters
+          if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
+            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Rebinding padded input buffers";
+            for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
+              const auto& inp = mgx_state->cached_inputs[i];
+              const auto& padded_buf = mgx_state->padded_input_buffers[i];
+              m.add(inp.name.c_str(), migraphx::argument(padded_buf.mgx_shape, padded_buf.data));
+            }
+          }
+          
+          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Running with output slicing enabled";
+          // Run with slicing enabled
+          run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, 
+                              prog_output_indices, original_batch_size, padded_batch_size);
+          
+          // Free padded buffers after execution
+          if (using_padded_inputs) {
+            free_padded_inputs(mgx_state);
+          }
+          
+          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] ==== EXITING execute_standard_path (padded path) ====";
+          return;
+        } else {
+          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] ✗✗✗ CACHE MISS for padded hash " 
+                                << padded_hash;
+          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] This shouldn't happen - expected batch "
+                                << padded_batch_size << " to be pre-compiled";
+        }
+      }
+    }
+  }
+
+  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] Proceeding with normal shape checking";
   auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
       mgx_state->defer_compilation, map_input_name_index, ctx, cmp_options, prog);
 
+  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] input_shape_match = " << input_shape_match;
+  
   if (!input_shape_match) {
+    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] Shape mismatch detected - recompiling";
     // Invalidate caches before recompilation
     mgx_state->caches_valid = false;
 
@@ -1972,7 +2765,10 @@ static void execute_standard_path(
   mgx_state->last_input_shape_hash = current_hash;
   mgx_state->caches_valid = true;
 
-  run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, prog_output_indices);
+  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] Running program (no padding/slicing)";
+  run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, prog_output_indices, 
+                      original_batch_size, padded_batch_size);
+  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] ==== EXITING execute_standard_path (normal path) ====";
 }
 
 // Build MIGraphX ONNX options with default shapes for symbolic dimensions
@@ -2118,6 +2914,16 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             int8_calibration_cache_available_, dynamic_range_map_,
             model_cache_path_.string(), dump_model_ops_, exhaustive_tune_, max_dynamic_batch_,
             std::ref(cached_programs_[context->node_name])};
+      
+      // Initialize dynamic batch support if max_dynamic_batch > 0
+      if (max_dynamic_batch_ > 0) {
+        p->has_dynamic_batch = true;
+        p->power_of_two_batch_sizes = generate_power_of_two_batch_sizes(max_dynamic_batch_);
+        LOGS_DEFAULT(INFO) << "[Compile] Dynamic batch enabled for node '" << context->node_name 
+                           << "' with max_dynamic_batch=" << max_dynamic_batch_
+                           << ", generated " << p->power_of_two_batch_sizes.size() << " power-of-two batch sizes";
+      }
+      
       *state = p.release();
       return 0;
     };
@@ -2131,17 +2937,42 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       Ort::KernelContext ctx(context);
       MIGraphXFuncState* mgx_state = reinterpret_cast<MIGraphXFuncState*>(state);
 
+      LOGS_DEFAULT(WARNING) << "======================================";
+      LOGS_DEFAULT(WARNING) << "[COMPUTE] Starting inference";
+      LOGS_DEFAULT(WARNING) << "[COMPUTE] has_dynamic_batch = " << mgx_state->has_dynamic_batch;
+      LOGS_DEFAULT(WARNING) << "[COMPUTE] max_dynamic_batch = " << mgx_state->max_dynamic_batch;
+      LOGS_DEFAULT(WARNING) << "[COMPUTE] caches_valid = " << mgx_state->caches_valid;
+      
+      // Log incoming batch sizes
+      const auto& map_input_name_index = mgx_state->input_name_indexes;
+      LOGS_DEFAULT(WARNING) << "[COMPUTE] Incoming input shapes:";
+      for (const auto& [name, index] : map_input_name_index) {
+        const auto& shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
+        LOGS_DEFAULT(WARNING) << "[COMPUTE]   '" << name << "': [" << [&]() {
+          std::ostringstream ss;
+          for (size_t i = 0; i < shape.size(); ++i) {
+            if (i > 0) ss << ", ";
+            ss << shape[i];
+          }
+          return ss.str();
+        }() << "]";
+      }
+
       // ═══════════════════════════════════════════════════════════════════════
       // ULTRA-FAST PATH: Shapes unchanged from last run
       // ═══════════════════════════════════════════════════════════════════════
+      LOGS_DEFAULT(WARNING) << "[COMPUTE] Trying ULTRA-FAST PATH...";
       if (execute_ultra_fast_path(mgx_state, api, context, ctx)) {
+        LOGS_DEFAULT(WARNING) << "[COMPUTE] ✓ ULTRA-FAST PATH executed successfully";
+        LOGS_DEFAULT(WARNING) << "======================================";
         return Status::OK();
       }
+      LOGS_DEFAULT(WARNING) << "[COMPUTE] Ultra-fast path not taken";
 
       // ═══════════════════════════════════════════════════════════════════════
       // Build input shape hash - only computed when shapes change
       // ═══════════════════════════════════════════════════════════════════════
-      const auto& map_input_name_index = mgx_state->input_name_indexes;
+      LOGS_DEFAULT(WARNING) << "[COMPUTE] Building input shape hash...";
       std::vector<std::int64_t> all_input_shapes;
       all_input_shapes.reserve(map_input_name_index.size() * 4);
       for (const auto& [name, index] : map_input_name_index) {
@@ -2149,20 +2980,28 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         all_input_shapes.insert(all_input_shapes.end(), shape.begin(), shape.end());
       }
       const auto current_hash = make_hash(all_input_shapes);
+      LOGS_DEFAULT(WARNING) << "[COMPUTE] Current shape hash: " << current_hash;
 
       // ═══════════════════════════════════════════════════════════════════════
       // FAST PATH: Check cached programs for this shape hash
       // ═══════════════════════════════════════════════════════════════════════
+      LOGS_DEFAULT(WARNING) << "[COMPUTE] Trying FAST PATH...";
       if (execute_fast_path(mgx_state, api, context, ctx, current_hash, all_input_shapes)) {
+        LOGS_DEFAULT(WARNING) << "[COMPUTE] ✓ FAST PATH executed successfully";
+        LOGS_DEFAULT(WARNING) << "======================================";
         return Status::OK();
       }
+      LOGS_DEFAULT(WARNING) << "[COMPUTE] Fast path not taken";
 
       // ═══════════════════════════════════════════════════════════════════════
       // STANDARD PATH: Shape checking and potential recompilation
       // ═══════════════════════════════════════════════════════════════════════
+      LOGS_DEFAULT(WARNING) << "[COMPUTE] Taking STANDARD PATH...";
       execute_standard_path(mgx_state, api, context, ctx, current_hash, std::move(all_input_shapes),
                             model_cache_path_, model_path_, mxr_filename_prefix);
 
+      LOGS_DEFAULT(WARNING) << "[COMPUTE] ✓ STANDARD PATH complete";
+      LOGS_DEFAULT(WARNING) << "======================================";
       return Status::OK();
     };
     node_compute_funcs.push_back(compute_info);

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1392,6 +1392,71 @@ migraphx::program CompileProgramWithBatch(
   return prog;
 }
 
+// Helper: Run the MIGraphX program and handle outputs
+// This function executes the compiled MIGraphX program and copies outputs that
+// were not pre-allocated (input parameters reused as outputs) to the ORT output tensors
+static void run_migraphx_program(
+    std::mutex* mgx_mu_ptr,
+    const OrtApi* api,
+    OrtKernelContext* context,
+    Ort::KernelContext& ctx,
+    migraphx::program& prog,
+    migraphx::program_parameters& m,
+    const std::vector<std::size_t>& prog_output_indices)
+{
+
+  // lock to avoid race condition
+  std::lock_guard<std::mutex> lock(*mgx_mu_ptr);
+
+  void* rocm_stream;
+  Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &rocm_stream));
+  LOGS_DEFAULT(INFO) << "[Compute] Executing MIGraphX program...";
+  auto prog_outputs = prog.run_async(m, static_cast<hipStream_t>(rocm_stream));
+  LOGS_DEFAULT(INFO) << "[Compute] Execution complete, got " << prog_outputs.size() << " outputs";
+
+  // Verify actual output shapes match expectations
+  for (std::size_t i = 0; i < prog_outputs.size(); ++i) {
+    auto actual_shape = prog_outputs[i].get_shape();
+    auto actual_lens = actual_shape.lengths();
+    std::ostringstream ss;
+    ss << "[";
+    for (size_t j = 0; j < actual_lens.size(); ++j) {
+      if (j > 0) ss << ", ";
+      ss << actual_lens[j];
+    }
+    ss << "]";
+    LOGS_DEFAULT(INFO) << "[Compute] Actual output " << i << " shape after execution: " << ss.str()
+                          << (actual_lens.size() > 0 ? " (batch=" + std::to_string(actual_lens[0]) + ")" : "");
+  }
+
+  // In case of input parameters are reused as output parameter call hipMemcpy
+  auto output_num = prog_outputs.size();
+  if (prog_output_indices.size() < output_num) {
+    for (std::size_t i = 0; i < output_num; ++i) {
+      if (std::find(prog_output_indices.begin(), prog_output_indices.end(), static_cast<int>(i)) != prog_output_indices.end())
+        continue;
+      auto gpu_res = prog_outputs[i];
+      migraphx::shape res_shape = gpu_res.get_shape();
+      auto res_lens = res_shape.lengths();
+      std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
+      auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
+      void* output_data = output_tensor.GetTensorMutableRawData();
+
+      // Log output batch size for tracking
+      if (!ort_shape.empty()) {
+        LOGS_DEFAULT(INFO) << "[Compute] Output " << i << " batch size: " << ort_shape[0];
+      }
+
+      HIP_CALL_THROW(hipMemcpyWithStream(output_data,
+                                         gpu_res.data(),
+                                         res_shape.bytes(),
+                                         hipMemcpyDeviceToDevice,
+                                         static_cast<hipStream_t>(rocm_stream)));
+    }
+  }
+
+}
+
 constexpr std::uint64_t MIGraphX_Version =
     ((MIGRAPHX_VERSION_MAJOR << 16) | (MIGRAPHX_VERSION_MINOR << 8) | MIGRAPHX_VERSION_PATCH);
 
@@ -1987,57 +2052,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         }
       }
 
-      {
-        // lock to avoid race condition
-        std::lock_guard<std::mutex> lock(*(mgx_state->mgx_mu_ptr));
-
-        void* rocm_stream;
-        Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &rocm_stream));
-        LOGS_DEFAULT(INFO) << "[Compute] Executing MIGraphX program...";
-        auto prog_outputs = prog.run_async(m, static_cast<hipStream_t>(rocm_stream));
-        LOGS_DEFAULT(INFO) << "[Compute] Execution complete, got " << prog_outputs.size() << " outputs";
-
-        // Verify actual output shapes match expectations
-        for (std::size_t i = 0; i < prog_outputs.size(); ++i) {
-          auto actual_shape = prog_outputs[i].get_shape();
-          auto actual_lens = actual_shape.lengths();
-          std::ostringstream ss;
-          ss << "[";
-          for (size_t j = 0; j < actual_lens.size(); ++j) {
-            if (j > 0) ss << ", ";
-            ss << actual_lens[j];
-          }
-          ss << "]";
-          LOGS_DEFAULT(INFO) << "[Compute] Actual output " << i << " shape after execution: " << ss.str()
-                                << (actual_lens.size() > 0 ? " (batch=" + std::to_string(actual_lens[0]) + ")" : "");
-        }
-
-        // In case of input parameters are reused as output parameter call hipMemcpy
-        auto output_num = prog_outputs.size();
-        if (prog_output_indices.size() < output_num) {
-          for (std::size_t i = 0; i < output_num; ++i) {
-            if (std::find(prog_output_indices.begin(), prog_output_indices.end(), i) != prog_output_indices.end())
-              continue;
-            auto gpu_res = prog_outputs[i];
-            migraphx::shape res_shape = gpu_res.get_shape();
-            auto res_lens = res_shape.lengths();
-            std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
-            auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
-            void* output_data = output_tensor.GetTensorMutableRawData();
-
-            // Log output batch size for tracking
-            if (!ort_shape.empty()) {
-              LOGS_DEFAULT(INFO) << "[Compute] Output " << i << " batch size: " << ort_shape[0];
-            }
-
-            HIP_CALL_THROW(hipMemcpyWithStream(output_data,
-                                               gpu_res.data(),
-                                               res_shape.bytes(),
-                                               hipMemcpyDeviceToDevice,
-                                               static_cast<hipStream_t>(rocm_stream)));
-          }
-        }
-      }
+      // Run the MIGraphX program and handle outputs
+      run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, prog_output_indices);
 
       return Status::OK();
     };

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1341,6 +1341,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     if (!model_cache_path_.empty() or first_start_) {
       std::vector<std::int64_t> input_shapes;
       bool has_symbolic_dims = false;
+      constexpr int64_t default_batch_size = 1;
 
       for (std::size_t i = 0; i < session_input_names.size(); ++i) {
         auto tensor_shape = input_tensor[i]->Shape();
@@ -1351,6 +1352,32 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
                                 << ") has no shape information";
           has_symbolic_dims = true;
           continue;
+        }
+
+        // Handle batch dimension (first dimension) specially
+        if (tensor_shape->dim_size() > 0) {
+          const auto& batch_dim = tensor_shape->dim(0);
+          int64_t batch_size_to_use = default_batch_size;
+
+          if (batch_dim.has_dim_value()) {
+            batch_size_to_use = batch_dim.dim_value();
+            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                                  << ") batch size: " << batch_size_to_use;
+          } else if (batch_dim.has_dim_param()) {
+            // Symbolic batch dimension - default to 1
+            has_symbolic_dims = true;
+            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                                  << ") batch size is symbolic: " << batch_dim.dim_param()
+                                  << ", defaulting to " << default_batch_size;
+          } else {
+            // Unknown batch dimension - default to 1
+            has_symbolic_dims = true;
+            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                                  << ") batch size is unknown, defaulting to " << default_batch_size;
+          }
+
+          // Add batch size to input shapes for hash calculation
+          input_shapes.push_back(batch_size_to_use);
         }
 
         // Process all dimensions (skip batch dimension at j=0, start at j=1)
@@ -1375,26 +1402,12 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             has_symbolic_dims = true;
           }
         }
-
-        // Log batch size (first dimension) for tracking
-        if (tensor_shape->dim_size() > 0) {
-          const auto& batch_dim = tensor_shape->dim(0);
-          if (batch_dim.has_dim_value()) {
-            auto batch_size = batch_dim.dim_value();
-            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                                  << ") batch size: " << batch_size;
-          } else if (batch_dim.has_dim_param()) {
-            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                                  << ") batch size is symbolic: " << batch_dim.dim_param();
-          } else {
-            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                                  << ") batch size is unknown";
-          }
-        }
       }
 
       if (has_symbolic_dims) {
-        LOGS_DEFAULT(WARNING) << "[Compile] Model has symbolic dimensions, cache file may not be unique for all shapes";
+        LOGS_DEFAULT(WARNING) << "[Compile] Model has symbolic dimensions, "
+                              << "dynamic batch dimensions defaulted to " << default_batch_size
+                              << " (will be overridden at runtime if needed)";
       }
 
       if (!input_shapes.empty()) {
@@ -1425,6 +1438,40 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
     std::vector<std::string> input_names, output_names;
     no_input_shape = no_input_shape || get_input_output_names(graph_body_viewer, input_names, output_names);
+
+    // Set default batch size for symbolic dimensions in onnx_options
+    constexpr std::size_t default_batch_size = 1;
+    if (no_input_shape) {
+      LOGS_DEFAULT(VERBOSE) << "[Compile] Setting default batch size of " << default_batch_size
+                            << " for inputs with symbolic dimensions";
+      for (std::size_t i = 0; i < input_names.size(); ++i) {
+        if (i < input_tensor.size()) {
+          auto tensor_shape = input_tensor[i]->Shape();
+          if (tensor_shape != nullptr && tensor_shape->dim_size() > 0) {
+            std::vector<std::size_t> default_shape;
+            bool has_symbolic = false;
+
+            for (int j = 0; j < tensor_shape->dim_size(); ++j) {
+              const auto& dim = tensor_shape->dim(j);
+              if (dim.has_dim_value()) {
+                default_shape.push_back(static_cast<std::size_t>(dim.dim_value()));
+              } else if (dim.has_dim_param() || !dim.has_dim_value()) {
+                // Symbolic or unknown dimension - use default batch size for dim 0, 1 for others
+                has_symbolic = true;
+                default_shape.push_back(j == 0 ? default_batch_size : 1);
+                LOGS_DEFAULT(VERBOSE) << "[Compile] Input '" << input_names[i]
+                                      << "' dimension " << j << " is symbolic, using default";
+              }
+            }
+
+            if (has_symbolic && !default_shape.empty()) {
+              options.set_input_parameter_shape(input_names[i], default_shape);
+              LOGS_DEFAULT(VERBOSE) << "[Compile] Set default shape for '" << input_names[i] << "'";
+            }
+          }
+        }
+      }
+    }
 
     // by parsing the model_proto, create a program corresponding to
     // the input fused_node
@@ -1501,7 +1548,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       std::vector<std::int64_t> input_shapes;
 
       if (no_input_shape) {
-        LOGS_DEFAULT(VERBOSE) << "Missing input shape setting input parameters again";
+        LOGS_DEFAULT(VERBOSE) << "[Compute] Missing input shape, overriding with runtime input shapes";
         for (auto& it : map_input_name_index) {
           auto& name = it.first;
           auto& index = it.second;
@@ -1509,12 +1556,15 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
           const auto tensor_shape = tensor_info.GetShape();
           std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
+
+          // Override default batch size with incoming batch size
           cmp_options.set_input_parameter_shape(name, ort_lens);
           input_shape_match = false;
 
           // Log batch size and full shape for tracking dynamic shapes
           if (!tensor_shape.empty()) {
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' batch size: " << tensor_shape[0];
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name
+                                  << "' batch size (overriding default): " << tensor_shape[0];
 
             std::ostringstream shape_str;
             shape_str << "[";
@@ -1556,6 +1606,13 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
                 LOGS_DEFAULT(VERBOSE) << "[Compute] Shape mismatch for input '" << name
                                       << "': MIGraphX expects [" << mgx_lens.size() << " dims], "
                                       << "got [" << ort_lens.size() << " dims]";
+
+                // Check if it's specifically a batch size change
+                if (mgx_lens.size() == ort_lens.size() && mgx_lens.size() > 0 && mgx_lens[0] != ort_lens[0]) {
+                  LOGS_DEFAULT(VERBOSE) << "[Compute] Batch size changed from " << mgx_lens[0]
+                                        << " to " << ort_lens[0] << " for input '" << name << "'";
+                }
+
                 cmp_options.set_input_parameter_shape(name, ort_lens);
                 input_shape_match = false;
               }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1312,63 +1312,74 @@ std::string make_hash(const char* v) {
   return make_hash(std::string_view{v});
 }
 
-// Helper: Compile a single program with specific batch size for all inputs
+// Helper: Compile a MIGraphX program from ONNX buffer
+// If input_names and all_input_base_shapes are provided, sets batch-specific shapes.
+// Otherwise, uses shapes already configured in options.
+// If ctx and map_input_name_index are provided, populates quant_params for int8/fp8 calibration.
 migraphx::program CompileProgramWithBatch(
-  const std::string& onnx_string,
-  const std::vector<std::string>& input_names,
-  const std::vector<std::vector<std::int64_t>>& all_input_base_shapes,
-  //const std::unordered_map<std::string, std::size_t>& map_input_name_index,
-  size_t batch_size,
-  migraphx::onnx_options options,
-  const migraphx::target& t,
-  bool fp16_enable,
-  bool bf16_enable,
-  bool int8_enable,
-  bool fp8_enable,
-  bool int8_calibration_cache_available,
-  std::unordered_map<std::string, float>& dynamic_range_map,
-  bool exhaustive_tune,
-  const std::filesystem::path& model_path)
+    const std::string& onnx_string,
+    migraphx::onnx_options& options,
+    const migraphx::target& t,
+    bool fp16_enable,
+    bool bf16_enable,
+    bool int8_enable,
+    bool fp8_enable,
+    bool int8_calibration_cache_available,
+    std::unordered_map<std::string, float>& dynamic_range_map,
+    bool exhaustive_tune,
+    const std::filesystem::path& model_path,
+    Ort::KernelContext* ctx = nullptr,
+    const std::unordered_map<std::string, std::size_t>* map_input_name_index = nullptr,
+    const std::vector<std::string>& input_names = {},
+    const std::vector<std::vector<std::int64_t>>& all_input_base_shapes = {},
+    size_t batch_size = 0)
 {
+  LOGS_DEFAULT(VERBOSE) << "[CompileBatch] Starting compilation";
 
-  LOGS_DEFAULT(VERBOSE) << "[CompileBatch] Compiling for batch size: " << batch_size;
+  // Set input shapes with the specified batch size for ALL inputs (if provided)
+  if (!input_names.empty() && !all_input_base_shapes.empty() && batch_size > 0) {
+    LOGS_DEFAULT(VERBOSE) << "[CompileBatch] Setting batch size " << batch_size << " for " << input_names.size() << " inputs";
+    for (size_t i = 0; i < input_names.size() && i < all_input_base_shapes.size(); ++i) {
+      std::vector<std::size_t> shape_with_batch;
+      shape_with_batch.push_back(batch_size);
+      for (auto dim : all_input_base_shapes[i]) {
+        shape_with_batch.push_back(static_cast<std::size_t>(dim));
+      }
+      options.set_input_parameter_shape(input_names[i], shape_with_batch);
 
-  // Set input shapes with the specified batch size for ALL inputs
-  for (size_t i = 0; i < input_names.size() && i < all_input_base_shapes.size(); ++i) {
-    std::vector<std::size_t> shape_with_batch;
-    shape_with_batch.push_back(batch_size);
-    for (auto dim : all_input_base_shapes[i]) {
-      shape_with_batch.push_back(static_cast<std::size_t>(dim));
+      std::ostringstream ss;
+      ss << "[";
+      for (size_t j = 0; j < shape_with_batch.size(); ++j) {
+        if (j > 0) ss << ", ";
+        ss << shape_with_batch[j];
+      }
+      ss << "]";
+      LOGS_DEFAULT(VERBOSE) << "[CompileBatch] Input '" << input_names[i] << "' shape: " << ss.str();
     }
-    options.set_input_parameter_shape(input_names[i], shape_with_batch);
-
-    std::ostringstream ss;
-    ss << "[";
-    for (size_t j = 0; j < shape_with_batch.size(); ++j) {
-      if (j > 0) ss << ", ";
-      ss << shape_with_batch[j];
-    }
-    ss << "]";
-    LOGS_DEFAULT(VERBOSE) << "[CompileBatch] Input '" << input_names[i] << "' shape: " << ss.str();
+  } else {
+    LOGS_DEFAULT(VERBOSE) << "[CompileBatch] Using shapes already configured in options";
   }
 
-  #ifndef ENABLE_TRAINING_CORE
-  #ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
+#ifndef ENABLE_TRAINING_CORE
+#ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
   if (!model_path.empty()) {
     options.set_external_data_path(model_path.parent_path().string());
   }
-  #endif
-  #endif
+#endif
+#endif
 
+  LOGS_DEFAULT(VERBOSE) << "[CompileBatch] Parsing ONNX buffer";
   migraphx::program prog = migraphx::parse_onnx_buffer(onnx_string, options);
-  migraphx::program_parameters quant_params;
+  LOGS_DEFAULT(VERBOSE) << "[CompileBatch] ONNX parsing complete";
 
-  /* if ((int8_enable ^ fp8_enable) && int8_calibration_cache_available) {
+  // Populate quant_params if int8/fp8 calibration is needed and runtime context is available
+  migraphx::program_parameters quant_params;
+  if ((int8_enable ^ fp8_enable) && int8_calibration_cache_available && ctx != nullptr && map_input_name_index != nullptr) {
+    LOGS_DEFAULT(VERBOSE) << "[CompileBatch] Setting up quantization parameters from runtime tensors";
     auto local_param_shapes = prog.get_parameter_shapes();
-    // Add input parameter data and the values they're set to
     for (auto&& name : local_param_shapes.names()) {
-      if (map_input_name_index.count(name) > 0) {
-        auto input_tensor = ctx.GetInput(map_input_name_index[name]);
+      if (map_input_name_index->count(name) > 0) {
+        auto input_tensor = ctx->GetInput(map_input_name_index->at(name));
         auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
         const auto tensor_shape = tensor_info.GetShape();
         const auto tensor_type = tensor_info.GetElementType();
@@ -1383,13 +1394,13 @@ migraphx::program CompileProgramWithBatch(
         quant_params.add(name, migraphx::argument(local_param_shapes[name], const_cast<void*>(input_tensor.GetTensorRawData())));
       }
     }
-  } */
+  }
 
   calibrate_and_quantize(prog, t, quant_params, fp16_enable, bf16_enable, int8_enable,
-                        fp8_enable, int8_calibration_cache_available, dynamic_range_map);
+                         fp8_enable, int8_calibration_cache_available, dynamic_range_map);
   compile_program(prog, t, exhaustive_tune);
 
-  LOGS_DEFAULT(VERBOSE) << "[CompileBatch] Compilation complete for batch size: " << batch_size;
+  LOGS_DEFAULT(VERBOSE) << "[CompileBatch] Compilation complete";
   return prog;
 }
 
@@ -1474,10 +1485,7 @@ static void handle_input_shape_mismatch(
   // Extract references from mgx_state for convenience
   auto& prog = mgx_state->prog;
   auto& cmp_options = mgx_state->options;
-  auto& onnx_string = mgx_state->onnx_string;
   const auto& map_input_name_index = mgx_state->input_name_indexes;
-  auto& map_dynamic_range = mgx_state->dynamic_range_map;
-  const auto& t = mgx_state->t;
 
   std::filesystem::path model_cache_file;
   // empty cache path means the MXR caching is disabled - always compile
@@ -1513,10 +1521,7 @@ static void handle_input_shape_mismatch(
   if (!load_precompiled_model(prog, model_cache_file)) {
     LOGS_DEFAULT(INFO) << "[Compute] Cache miss. Compiling model with updated batch size";
 
-    // CRITICAL: Ensure ALL input parameter shapes are explicitly set as static shapes in cmp_options
-    // This must be done BEFORE parsing to treat dynamic shapes as static for compilation
-    // NOTE: Only set shapes for actual runtime input parameters, NOT for constants/initializers
-    // MIGraphX will automatically infer shapes for constants and intermediate tensors
+    // Set input parameter shapes from runtime tensors before compilation
     LOGS_DEFAULT(INFO) << "[Compute] Setting " << map_input_name_index.size()
                           << " input parameter shapes as static in MIGraphX options (excluding constants)";
 
@@ -1527,9 +1532,6 @@ static void handle_input_shape_mismatch(
       auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
       const auto tensor_shape = tensor_info.GetShape();
       std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
-
-      // Set shape as static parameter for MIGraphX compilation
-      // Only for actual input parameters - constants/initializers are handled by MIGraphX
       cmp_options.set_input_parameter_shape(name, ort_lens);
 
       LOGS_DEFAULT(INFO) << "[Compute] Set static shape for input parameter '" << name << "': ["
@@ -1542,66 +1544,23 @@ static void handle_input_shape_mismatch(
                                 return ss.str();
                               }() << "]";
     }
-    LOGS_DEFAULT(INFO) << "[Compute] All input parameter shapes set as static";
-    LOGS_DEFAULT(INFO) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
 
-#ifndef ENABLE_TRAINING_CORE
-#ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
-    cmp_options.set_external_data_path(model_path.parent_path().string());
-#endif
-#endif
-    LOGS_DEFAULT(INFO) << "[Compute] Parsing ONNX buffer with static input shapes";
-    prog = migraphx::parse_onnx_buffer(onnx_string, cmp_options);
-    LOGS_DEFAULT(INFO) << "[Compute] ONNX parsing complete";
-
-    // Verify that MIGraphX parsed with correct shapes for input parameters
-    auto parsed_param_shapes = prog.get_parameter_shapes();
-    LOGS_DEFAULT(INFO) << "[Compute] Verifying parsed parameter shapes ("
-                          << parsed_param_shapes.size() << " total parameters):";
-    for (auto&& param_name : parsed_param_shapes.names()) {
-      auto shape = parsed_param_shapes[param_name];
-      auto lens = shape.lengths();
-      std::ostringstream ss;
-      ss << "[";
-      for (size_t i = 0; i < lens.size(); ++i) {
-        if (i > 0) ss << ", ";
-        ss << lens[i];
-      }
-      ss << "]";
-
-      // Distinguish between input parameters we set and constants MIGraphX inferred
-      bool is_input_param = (map_input_name_index.count(param_name) > 0);
-      LOGS_DEFAULT(INFO) << "[Compute] Parameter '" << param_name << "' parsed shape: " << ss.str()
-                            << (is_input_param ? " (input parameter)" : " (constant/internal)");
-    }
-
-    migraphx::program_parameters quant_params;
-
-    if ((mgx_state->int8_enable ^ mgx_state->fp8_enable) && mgx_state->int8_calibration_cache_available) {
-      auto local_param_shapes = prog.get_parameter_shapes();
-      // Add input parameter data and the values they're set to
-      for (auto&& name : local_param_shapes.names()) {
-        if (map_input_name_index.count(name) > 0) {
-          auto input_tensor = ctx.GetInput(map_input_name_index.at(name));
-          auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-          const auto tensor_shape = tensor_info.GetShape();
-          const auto tensor_type = tensor_info.GetElementType();
-
-          migraphx_shape_datatype_t mgx_type;
-          getMIGraphXType(tensor_type, mgx_type);
-          auto mgx_s = local_param_shapes[name];
-
-          if (mgx_type != mgx_s.type()) {
-            LOGS_DEFAULT(FATAL) << "MIGraphX: param type mismatch";
-          }
-          quant_params.add(name, migraphx::argument(local_param_shapes[name], const_cast<void*>(input_tensor.GetTensorRawData())));
-        }
-      }
-    }
-    calibrate_and_quantize(prog, t, quant_params, mgx_state->fp16_enable, mgx_state->bf16_enable,
-                           mgx_state->int8_enable, mgx_state->fp8_enable,
-                           mgx_state->int8_calibration_cache_available, map_dynamic_range);
-    compile_program(prog, t, mgx_state->exhaustive_tune);
+    // Compile using the helper function (shapes already set in cmp_options)
+    // Pass ctx and map_input_name_index for quant_params population if int8/fp8 calibration is needed
+    prog = CompileProgramWithBatch(
+        mgx_state->onnx_string,
+        cmp_options,
+        mgx_state->t,
+        mgx_state->fp16_enable,
+        mgx_state->bf16_enable,
+        mgx_state->int8_enable,
+        mgx_state->fp8_enable,
+        mgx_state->int8_calibration_cache_available,
+        mgx_state->dynamic_range_map,
+        mgx_state->exhaustive_tune,
+        mgx_state->model_cache_dir,
+        &ctx,
+        &map_input_name_index);
 
     // Save compiled model with batch-aware filename
     LOGS_DEFAULT(INFO) << "[Compute] Saving compiled model with updated batch size to: "
@@ -2001,17 +1960,21 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       if (!load_precompiled_model(prog, model_cache_file)) {
         LOGS_DEFAULT(VERBOSE) << "[Compile] Cache miss. Compiling model with batch size included in shapes";
         LOGS_DEFAULT(VERBOSE) << "[Compile] Model cache file will be: " << model_cache_file.string();
-#ifndef ENABLE_TRAINING_CORE
-#ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
-        options.set_external_data_path(model_path_.parent_path().string());
-#endif
-#endif
-        prog = migraphx::parse_onnx_buffer(onnx_string_buffer, options);
-        migraphx::program_parameters quant_params;
 
-        calibrate_and_quantize(prog, t_, quant_params, fp16_enable_, bf16_enable_, int8_enable_,
-                               fp8_enable_, int8_calibration_cache_available_, dynamic_range_map_);
-        compile_program(prog, t_, exhaustive_tune_);
+        // Compile using the helper function (shapes already set in options)
+        // No runtime context available during initial compile - pass nullptr
+        prog = CompileProgramWithBatch(
+            onnx_string_buffer,
+            options,
+            t_,
+            fp16_enable_,
+            bf16_enable_,
+            int8_enable_,
+            fp8_enable_,
+            int8_calibration_cache_available_,
+            dynamic_range_map_,
+            exhaustive_tune_,
+            model_path_);
 
         LOGS_DEFAULT(VERBOSE) << "[Compile] Saving compiled model to cache: " << model_cache_file.string();
         save_compiled_model(prog, model_cache_file);

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1557,7 +1557,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       std::vector<std::int64_t> input_shapes;
 
       if (no_input_shape) {
-        LOGS_DEFAULT(VERBOSE) << "[Compute] Missing input shape, overriding with runtime input shapes";
+        LOGS_DEFAULT(VERBOSE) << "[Compute] No static input shapes available, setting from runtime inputs";
         for (auto& it : map_input_name_index) {
           auto& name = it.first;
           auto& index = it.second;
@@ -1566,7 +1566,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           const auto tensor_shape = tensor_info.GetShape();
           std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
 
-          // Override default batch size with incoming batch size
+          // Override default batch size with incoming batch size and treat as static
           cmp_options.set_input_parameter_shape(name, ort_lens);
           input_shape_match = false;
 
@@ -1576,7 +1576,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           // Log batch size and full shape for tracking dynamic shapes
           if (!tensor_shape.empty()) {
             LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name
-                                  << "' batch size (overriding default): " << tensor_shape[0];
+                                  << "' batch size (runtime override): " << tensor_shape[0];
 
             std::ostringstream shape_str;
             shape_str << "[";
@@ -1585,10 +1585,10 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
               shape_str << tensor_shape[i];
             }
             shape_str << "]";
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' shape (dynamic): " << shape_str.str();
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' set as static shape: " << shape_str.str();
           }
         }
-        LOGS_DEFAULT(VERBOSE) << "[Compute] All runtime shapes collected for cache key generation";
+        LOGS_DEFAULT(VERBOSE) << "[Compute] All runtime shapes set as static parameters in MIGraphX options";
       } else {
         LOGS_DEFAULT(VERBOSE) << "Assigning inputs, and parameters from compiled model";
         param_shapes = prog.get_parameter_shapes();
@@ -1688,12 +1688,58 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
         if (!load_precompiled_model(prog, model_cache_file)) {
           LOGS_DEFAULT(VERBOSE) << "[Compute] Cache miss. Compiling model with updated batch size";
+
+          // CRITICAL: Ensure ALL input shapes are explicitly set as static shapes in cmp_options
+          // This must be done BEFORE parsing to treat dynamic shapes as static for compilation
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Setting all input shapes as static in MIGraphX options";
+          for (auto& it : map_input_name_index) {
+            auto& name = it.first;
+            auto& index = it.second;
+            auto input_tensor = ctx.GetInput(index);
+            auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+            const auto tensor_shape = tensor_info.GetShape();
+            std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
+
+            // Set shape as static parameter for MIGraphX compilation
+            cmp_options.set_input_parameter_shape(name, ort_lens);
+
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Set static shape for '" << name << "': ["
+                                  << [&]() {
+                                      std::ostringstream ss;
+                                      for (size_t i = 0; i < ort_lens.size(); ++i) {
+                                        if (i > 0) ss << ", ";
+                                        ss << ort_lens[i];
+                                      }
+                                      return ss.str();
+                                    }() << "]";
+          }
+          LOGS_DEFAULT(VERBOSE) << "[Compute] All input shapes set as static parameters";
+
 #ifndef ENABLE_TRAINING_CORE
 #ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
           cmp_options.set_external_data_path(model_path_.parent_path().string());
 #endif
 #endif
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Parsing ONNX buffer with static shapes";
           prog = migraphx::parse_onnx_buffer(onnx_string, cmp_options);
+          LOGS_DEFAULT(VERBOSE) << "[Compute] ONNX parsing complete";
+
+          // Verify that MIGraphX parsed with correct shapes
+          auto parsed_param_shapes = prog.get_parameter_shapes();
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Verifying parsed parameter shapes:";
+          for (auto&& param_name : parsed_param_shapes.names()) {
+            auto shape = parsed_param_shapes[param_name];
+            auto lens = shape.lengths();
+            std::ostringstream ss;
+            ss << "[";
+            for (size_t i = 0; i < lens.size(); ++i) {
+              if (i > 0) ss << ", ";
+              ss << lens[i];
+            }
+            ss << "]";
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Parameter '" << param_name << "' parsed shape: " << ss.str();
+          }
+
           migraphx::program_parameters quant_params;
 
           if ((int8_enable ^ fp8_enable) && int8_calibration_cache_available) {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1551,6 +1551,71 @@ migraphx::program CompileProgramWithBatch(
   return prog;
 }
 
+// Helper: Load a precompiled model from cache or compile and save it
+// This function encapsulates the common pattern of:
+// 1. Try to load from cache
+// 2. If cache miss, compile using CompileProgramWithBatch
+// 3. Save the compiled model to cache
+// Returns the loaded or compiled program
+static migraphx::program load_or_compile_model(
+    const std::filesystem::path& cache_file,
+    const std::string& onnx_string,
+    migraphx::onnx_options& options,
+    const migraphx::target& t,
+    bool fp16_enable,
+    bool bf16_enable,
+    bool int8_enable,
+    bool fp8_enable,
+    bool int8_calibration_cache_available,
+    std::unordered_map<std::string, float>& dynamic_range_map,
+    bool exhaustive_tune,
+    const std::filesystem::path& model_path,
+    const std::vector<std::string>& input_names = {},
+    const std::vector<std::vector<std::int64_t>>& all_input_base_shapes = {},
+    size_t batch_size = 0)
+{
+  migraphx::program prog;
+
+  if (!load_precompiled_model(prog, cache_file)) {
+    if (batch_size > 0) {
+      LOGS_DEFAULT(VERBOSE) << "[LoadOrCompile] Cache miss for batch size " << batch_size << ", compiling...";
+    } else {
+      LOGS_DEFAULT(VERBOSE) << "[LoadOrCompile] Cache miss, compiling...";
+    }
+
+    prog = CompileProgramWithBatch(
+        onnx_string,
+        options,
+        t,
+        fp16_enable,
+        bf16_enable,
+        int8_enable,
+        fp8_enable,
+        int8_calibration_cache_available,
+        dynamic_range_map,
+        exhaustive_tune,
+        model_path,
+        nullptr,  // No runtime context during compile
+        nullptr,  // No input name index map needed
+        input_names,
+        all_input_base_shapes,
+        batch_size);
+
+    save_compiled_model(prog, cache_file);
+    if (!cache_file.empty()) {
+      LOGS_DEFAULT(VERBOSE) << "[LoadOrCompile] Saved compiled model to: " << cache_file.string();
+    }
+  } else {
+    if (batch_size > 0) {
+      LOGS_DEFAULT(VERBOSE) << "[LoadOrCompile] Cache hit for batch size " << batch_size;
+    } else {
+      LOGS_DEFAULT(VERBOSE) << "[LoadOrCompile] Cache hit! Loaded from: " << cache_file.string();
+    }
+  }
+
+  return prog;
+}
+
 // Helper: Run the MIGraphX program and handle outputs
 // This function executes the compiled MIGraphX program and copies outputs that
 // were not pre-allocated (input parameters reused as outputs) to the ORT output tensors

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1592,7 +1592,7 @@ static migraphx::program load_or_compile_model(
 // This function executes the compiled MIGraphX program and copies outputs that
 // were not pre-allocated (input parameters reused as outputs) to the ORT output tensors
 static void run_migraphx_program(
-    std::binary_semaphore* mgx_sem_ptr,
+    std::mutex* mgx_mu_ptr,
     const OrtApi* api,
     OrtKernelContext* context,
     Ort::KernelContext& ctx,
@@ -1604,10 +1604,10 @@ static void run_migraphx_program(
   Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &rocm_stream));
 
   std::optional<migraphx::arguments> prog_outputs;
-  // Use binary semaphore for synchronization (acquire/release pattern)
-  mgx_sem_ptr->acquire();
-  prog_outputs = prog.run_async(m, static_cast<hipStream_t>(rocm_stream));
-  mgx_sem_ptr->release();
+  {  // Scoped lock for thread safety
+    std::lock_guard<std::mutex> lock(*mgx_mu_ptr);
+    prog_outputs = prog.run_async(m, static_cast<hipStream_t>(rocm_stream));
+  }
 
   // In case of input parameters are reused as output parameter call hipMemcpy
   auto output_num = prog_outputs->size();
@@ -1954,7 +1954,7 @@ static bool execute_ultra_fast_path(
   }
 
   // Run directly - minimal overhead path
-  run_migraphx_program(mgx_state->mgx_sem_ptr, api, context, ctx, prog, m,
+  run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m,
                        mgx_state->cached_prog_output_indices);
   return true;
 }
@@ -2003,66 +2003,10 @@ static bool execute_fast_path(
   mgx_state->last_input_shape_hash = current_hash;
   mgx_state->caches_valid = true;
 
-  run_migraphx_program(mgx_state->mgx_sem_ptr, api, context, ctx, prog,
+  run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog,
                        mgx_state->cached_prog_params.value(),
                        mgx_state->cached_prog_output_indices);
   return true;
-}
-
-// Standard path: Shape checking, potential recompilation, and execution
-static void execute_standard_path(
-    MIGraphXFuncState* mgx_state,
-    const OrtApi* api,
-    OrtKernelContext* context,
-    Ort::KernelContext& ctx,
-    const std::string& current_hash,
-    std::vector<std::int64_t>&& all_input_shapes,
-    const std::filesystem::path& model_cache_path,
-    const std::filesystem::path& model_path,
-    const std::string& mxr_filename_prefix)
-{
-  auto& prog = mgx_state->prog;
-  auto& cmp_options = mgx_state->options;
-  const auto& map_input_name_index = mgx_state->input_name_indexes;
-
-  auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
-      mgx_state->defer_compilation, map_input_name_index, ctx, cmp_options, prog);
-
-  if (!input_shape_match) {
-    // Invalidate caches before recompilation
-    mgx_state->caches_valid = false;
-
-    handle_input_shape_mismatch(
-        mgx_state,
-        model_cache_path,
-        model_path,
-        mxr_filename_prefix,
-        ctx,
-        param_shapes,
-        input_shapes);
-
-    // Re-fetch param_shapes after recompilation
-    param_shapes = prog.get_parameter_shapes();
-  }
-
-  // Fetch output shapes once
-  auto output_shapes = prog.get_output_shapes();
-
-  // Populate optimized caches for ultra-fast path
-  populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
-
-  // Bind inputs and allocate outputs
-  auto [m, prog_output_indices] = handle_program_input_outputs(
-      param_shapes, output_shapes, map_input_name_index, ctx);
-
-  // Complete cache population
-  mgx_state->cached_prog_params = m;
-  mgx_state->cached_prog_output_indices = prog_output_indices;
-  mgx_state->last_input_shapes_raw = std::move(all_input_shapes);
-  mgx_state->last_input_shape_hash = current_hash;
-  mgx_state->caches_valid = true;
-
-  run_migraphx_program(mgx_state->mgx_sem_ptr, api, context, ctx, prog, m, prog_output_indices);
 }
 
 // Result structure for handle_input_shape function
@@ -2149,6 +2093,62 @@ static InputShapeResult handle_input_shape(
   }
 
   return {input_shape_match, param_shapes, input_shapes};
+}
+
+// Standard path: Shape checking, potential recompilation, and execution
+static void execute_standard_path(
+    MIGraphXFuncState* mgx_state,
+    const OrtApi* api,
+    OrtKernelContext* context,
+    Ort::KernelContext& ctx,
+    const std::string& current_hash,
+    std::vector<std::int64_t>&& all_input_shapes,
+    const std::filesystem::path& model_cache_path,
+    const std::filesystem::path& model_path,
+    const std::string& mxr_filename_prefix)
+{
+  auto& prog = mgx_state->prog;
+  auto& cmp_options = mgx_state->options;
+  const auto& map_input_name_index = mgx_state->input_name_indexes;
+
+  auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
+      mgx_state->defer_compilation, map_input_name_index, ctx, cmp_options, prog);
+
+  if (!input_shape_match) {
+    // Invalidate caches before recompilation
+    mgx_state->caches_valid = false;
+
+    handle_input_shape_mismatch(
+        mgx_state,
+        model_cache_path,
+        model_path,
+        mxr_filename_prefix,
+        ctx,
+        param_shapes,
+        input_shapes);
+
+    // Re-fetch param_shapes after recompilation
+    param_shapes = prog.get_parameter_shapes();
+  }
+
+  // Fetch output shapes once
+  auto output_shapes = prog.get_output_shapes();
+
+  // Populate optimized caches for ultra-fast path
+  populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
+
+  // Bind inputs and allocate outputs
+  auto [m, prog_output_indices] = handle_program_input_outputs(
+      param_shapes, output_shapes, map_input_name_index, ctx);
+
+  // Complete cache population
+  mgx_state->cached_prog_params = m;
+  mgx_state->cached_prog_output_indices = prog_output_indices;
+  mgx_state->last_input_shapes_raw = std::move(all_input_shapes);
+  mgx_state->last_input_shape_hash = current_hash;
+  mgx_state->caches_valid = true;
+
+  run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, prog_output_indices);
 }
 
 // Build MIGraphX ONNX options with default shapes for symbolic dimensions
@@ -2289,7 +2289,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     compute_info.create_state_func = [=](ComputeContext* context, FunctionState* state) {
       std::unique_ptr<MIGraphXFuncState> p = std::make_unique<MIGraphXFuncState>();
       *p = {context->allocate_func, context->release_func, context->allocator_handle, map_progs_[context->node_name],
-            map_onnx_string_[context->node_name], options, t_, map_input_index_[context->node_name], &mgx_sem_,
+            map_onnx_string_[context->node_name], options, t_, map_input_index_[context->node_name], &mgx_mu_,
             map_defer_compilation_[context->node_name], fp16_enable_, bf16_enable_, fp8_enable_, int8_enable_,
             int8_calibration_cache_available_, dynamic_range_map_,
             model_cache_path_.string(), dump_model_ops_, exhaustive_tune_, max_dynamic_batch_,

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1458,6 +1458,167 @@ static void run_migraphx_program(
 
 }
 
+// Helper: Handle input shape mismatch by recompiling the model with new input shapes
+// This function is called when runtime input shapes differ from compiled shapes
+static void handle_input_shape_mismatch(
+    const std::filesystem::path& model_cache_path,
+    const std::filesystem::path& model_cache_dir,
+    const std::string& mxr_filename_prefix,
+    const std::filesystem::path& model_path,
+    bool exhaustive_tune,
+    bool fp16_enable,
+    bool bf16_enable,
+    bool fp8_enable,
+    bool int8_enable,
+    bool int8_calibration_cache_available,
+    const migraphx::target& t,
+    Ort::KernelContext& ctx,
+    const std::unordered_map<std::string, std::size_t>& map_input_name_index,
+    std::unordered_map<std::string, float>& map_dynamic_range,
+    const std::string& onnx_string,
+    migraphx::onnx_options& cmp_options,
+    migraphx::program& prog,
+    migraphx::program_parameter_shapes& param_shapes,
+    std::vector<std::int64_t>& input_shapes,
+    bool& no_input_shape)
+{
+  LOGS_DEFAULT(INFO) << "[Compute] Input shape mismatch detected, initiating recompilation";
+
+  std::filesystem::path model_cache_file;
+  // empty cache path means the MXR caching is disabled - always compile
+  if (!model_cache_path.empty()) {
+    // Ensure input_shapes has all updated dimensions including new batch sizes
+    if (input_shapes.empty()) {
+      LOGS_DEFAULT(WARNING) << "[Compute] Input shapes vector is empty, rebuilding from current inputs";
+      for (auto&& name : param_shapes.names()) {
+        if (map_input_name_index.count(name) > 0) {
+          auto input_tensor = ctx.GetInput(map_input_name_index.at(name));
+          auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+          const auto tensor_shape = tensor_info.GetShape();
+          input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
+        }
+      }
+    }
+
+    // Log the shapes being used for cache key generation
+    std::ostringstream shapes_str;
+    shapes_str << "[";
+    for (size_t i = 0; i < input_shapes.size(); ++i) {
+      if (i > 0) shapes_str << ", ";
+      shapes_str << input_shapes[i];
+    }
+    shapes_str << "]";
+    LOGS_DEFAULT(INFO) << "[Compute] Cache key input shapes (including updated batch): " << shapes_str.str();
+
+    auto cache_hash = make_hash(input_shapes);
+    model_cache_file = model_cache_dir / (mxr_filename_prefix + cache_hash + ".mxr");
+    LOGS_DEFAULT(INFO) << "[Compute] Cache file with batch-aware hash: " << model_cache_file.string();
+  }
+
+  if (!load_precompiled_model(prog, model_cache_file)) {
+    LOGS_DEFAULT(INFO) << "[Compute] Cache miss. Compiling model with updated batch size";
+
+    // CRITICAL: Ensure ALL input parameter shapes are explicitly set as static shapes in cmp_options
+    // This must be done BEFORE parsing to treat dynamic shapes as static for compilation
+    // NOTE: Only set shapes for actual runtime input parameters, NOT for constants/initializers
+    // MIGraphX will automatically infer shapes for constants and intermediate tensors
+    LOGS_DEFAULT(INFO) << "[Compute] Setting " << map_input_name_index.size()
+                          << " input parameter shapes as static in MIGraphX options (excluding constants)";
+
+    for (const auto& it : map_input_name_index) {
+      const auto& name = it.first;
+      const auto& index = it.second;
+      auto input_tensor = ctx.GetInput(index);
+      auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+      const auto tensor_shape = tensor_info.GetShape();
+      std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
+
+      // Set shape as static parameter for MIGraphX compilation
+      // Only for actual input parameters - constants/initializers are handled by MIGraphX
+      cmp_options.set_input_parameter_shape(name, ort_lens);
+
+      LOGS_DEFAULT(INFO) << "[Compute] Set static shape for input parameter '" << name << "': ["
+                            << [&]() {
+                                std::ostringstream ss;
+                                for (size_t i = 0; i < ort_lens.size(); ++i) {
+                                  if (i > 0) ss << ", ";
+                                  ss << ort_lens[i];
+                                }
+                                return ss.str();
+                              }() << "]";
+    }
+    LOGS_DEFAULT(INFO) << "[Compute] All input parameter shapes set as static";
+    LOGS_DEFAULT(INFO) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
+
+#ifndef ENABLE_TRAINING_CORE
+#ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
+    cmp_options.set_external_data_path(model_path.parent_path().string());
+#endif
+#endif
+    LOGS_DEFAULT(INFO) << "[Compute] Parsing ONNX buffer with static input shapes";
+    prog = migraphx::parse_onnx_buffer(onnx_string, cmp_options);
+    LOGS_DEFAULT(INFO) << "[Compute] ONNX parsing complete";
+
+    // Verify that MIGraphX parsed with correct shapes for input parameters
+    auto parsed_param_shapes = prog.get_parameter_shapes();
+    LOGS_DEFAULT(INFO) << "[Compute] Verifying parsed parameter shapes ("
+                          << parsed_param_shapes.size() << " total parameters):";
+    for (auto&& param_name : parsed_param_shapes.names()) {
+      auto shape = parsed_param_shapes[param_name];
+      auto lens = shape.lengths();
+      std::ostringstream ss;
+      ss << "[";
+      for (size_t i = 0; i < lens.size(); ++i) {
+        if (i > 0) ss << ", ";
+        ss << lens[i];
+      }
+      ss << "]";
+
+      // Distinguish between input parameters we set and constants MIGraphX inferred
+      bool is_input_param = (map_input_name_index.count(param_name) > 0);
+      LOGS_DEFAULT(INFO) << "[Compute] Parameter '" << param_name << "' parsed shape: " << ss.str()
+                            << (is_input_param ? " (input parameter)" : " (constant/internal)");
+    }
+
+    migraphx::program_parameters quant_params;
+
+    if ((int8_enable ^ fp8_enable) && int8_calibration_cache_available) {
+      auto local_param_shapes = prog.get_parameter_shapes();
+      // Add input parameter data and the values they're set to
+      for (auto&& name : local_param_shapes.names()) {
+        if (map_input_name_index.count(name) > 0) {
+          auto input_tensor = ctx.GetInput(map_input_name_index.at(name));
+          auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+          const auto tensor_shape = tensor_info.GetShape();
+          const auto tensor_type = tensor_info.GetElementType();
+
+          migraphx_shape_datatype_t mgx_type;
+          getMIGraphXType(tensor_type, mgx_type);
+          auto mgx_s = local_param_shapes[name];
+
+          if (mgx_type != mgx_s.type()) {
+            LOGS_DEFAULT(FATAL) << "MIGraphX: param type mismatch";
+          }
+          quant_params.add(name, migraphx::argument(local_param_shapes[name], const_cast<void*>(input_tensor.GetTensorRawData())));
+        }
+      }
+    }
+    calibrate_and_quantize(prog, t, quant_params, fp16_enable, bf16_enable, int8_enable,
+                           fp8_enable, int8_calibration_cache_available, map_dynamic_range);
+    compile_program(prog, t, exhaustive_tune);
+
+    // Save compiled model with batch-aware filename
+    LOGS_DEFAULT(INFO) << "[Compute] Saving compiled model with updated batch size to: "
+                          << model_cache_file.string();
+    save_compiled_model(prog, model_cache_file);
+  } else {
+    LOGS_DEFAULT(INFO) << "[Compute] Cache hit! Loaded precompiled model with matching batch size";
+  }
+
+  param_shapes = prog.get_parameter_shapes();
+  no_input_shape = false;
+}
+
 constexpr std::uint64_t MIGraphX_Version =
     ((MIGRAPHX_VERSION_MAJOR << 16) | (MIGRAPHX_VERSION_MINOR << 8) | MIGRAPHX_VERSION_PATCH);
 
@@ -1831,142 +1992,27 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       // input shapes are different, needs to re-parse onnx and
       // re-compile the program
       if (!input_shape_match) {
-        LOGS_DEFAULT(INFO) << "[Compute] Input shape mismatch detected, initiating recompilation";
-
-        std::filesystem::path model_cache_file;
-        // empty cache path means the MXR caching is disabled - always compile
-        if (!model_cache_path_.empty()) {
-          // Ensure input_shapes has all updated dimensions including new batch sizes
-          if (input_shapes.empty()) {
-            LOGS_DEFAULT(WARNING) << "[Compute] Input shapes vector is empty, rebuilding from current inputs";
-            for (auto&& name : param_shapes.names()) {
-              if (map_input_name_index.count(name) > 0) {
-                auto input_tensor = ctx.GetInput(map_input_name_index[name]);
-                auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-                const auto tensor_shape = tensor_info.GetShape();
-                input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
-              }
-            }
-          }
-
-          // Log the shapes being used for cache key generation
-          std::ostringstream shapes_str;
-          shapes_str << "[";
-          for (size_t i = 0; i < input_shapes.size(); ++i) {
-            if (i > 0) shapes_str << ", ";
-            shapes_str << input_shapes[i];
-          }
-          shapes_str << "]";
-          LOGS_DEFAULT(INFO) << "[Compute] Cache key input shapes (including updated batch): " << shapes_str.str();
-
-          auto cache_hash = make_hash(input_shapes);
-          model_cache_file = mgx_state->model_cache_dir / (mxr_filename_prefix + cache_hash + ".mxr");
-          LOGS_DEFAULT(INFO) << "[Compute] Cache file with batch-aware hash: " << model_cache_file.string();
-        }
-
-        if (!load_precompiled_model(prog, model_cache_file)) {
-          LOGS_DEFAULT(INFO) << "[Compute] Cache miss. Compiling model with updated batch size";
-
-          // CRITICAL: Ensure ALL input parameter shapes are explicitly set as static shapes in cmp_options
-          // This must be done BEFORE parsing to treat dynamic shapes as static for compilation
-          // NOTE: Only set shapes for actual runtime input parameters, NOT for constants/initializers
-          // MIGraphX will automatically infer shapes for constants and intermediate tensors
-          LOGS_DEFAULT(INFO) << "[Compute] Setting " << map_input_name_index.size()
-                                << " input parameter shapes as static in MIGraphX options (excluding constants)";
-
-          for (auto& it : map_input_name_index) {
-            auto& name = it.first;
-            auto& index = it.second;
-            auto input_tensor = ctx.GetInput(index);
-            auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-            const auto tensor_shape = tensor_info.GetShape();
-            std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
-
-            // Set shape as static parameter for MIGraphX compilation
-            // Only for actual input parameters - constants/initializers are handled by MIGraphX
-            cmp_options.set_input_parameter_shape(name, ort_lens);
-
-            LOGS_DEFAULT(INFO) << "[Compute] Set static shape for input parameter '" << name << "': ["
-                                  << [&]() {
-                                      std::ostringstream ss;
-                                      for (size_t i = 0; i < ort_lens.size(); ++i) {
-                                        if (i > 0) ss << ", ";
-                                        ss << ort_lens[i];
-                                      }
-                                      return ss.str();
-                                    }() << "]";
-          }
-          LOGS_DEFAULT(INFO) << "[Compute] All input parameter shapes set as static";
-          LOGS_DEFAULT(INFO) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
-
-#ifndef ENABLE_TRAINING_CORE
-#ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
-          cmp_options.set_external_data_path(model_path_.parent_path().string());
-#endif
-#endif
-          LOGS_DEFAULT(INFO) << "[Compute] Parsing ONNX buffer with static input shapes";
-          prog = migraphx::parse_onnx_buffer(onnx_string, cmp_options);
-          LOGS_DEFAULT(INFO) << "[Compute] ONNX parsing complete";
-
-          // Verify that MIGraphX parsed with correct shapes for input parameters
-          auto parsed_param_shapes = prog.get_parameter_shapes();
-          LOGS_DEFAULT(INFO) << "[Compute] Verifying parsed parameter shapes ("
-                                << parsed_param_shapes.size() << " total parameters):";
-          for (auto&& param_name : parsed_param_shapes.names()) {
-            auto shape = parsed_param_shapes[param_name];
-            auto lens = shape.lengths();
-            std::ostringstream ss;
-            ss << "[";
-            for (size_t i = 0; i < lens.size(); ++i) {
-              if (i > 0) ss << ", ";
-              ss << lens[i];
-            }
-            ss << "]";
-
-            // Distinguish between input parameters we set and constants MIGraphX inferred
-            bool is_input_param = (map_input_name_index.count(param_name) > 0);
-            LOGS_DEFAULT(INFO) << "[Compute] Parameter '" << param_name << "' parsed shape: " << ss.str()
-                                  << (is_input_param ? " (input parameter)" : " (constant/internal)");
-          }
-
-          migraphx::program_parameters quant_params;
-
-          if ((int8_enable ^ fp8_enable) && int8_calibration_cache_available) {
-            auto local_param_shapes = prog.get_parameter_shapes();
-            // Add input parameter data and the values they're set to
-            for (auto&& name : local_param_shapes.names()) {
-              if (map_input_name_index.count(name) > 0) {
-                auto input_tensor = ctx.GetInput(map_input_name_index[name]);
-                auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-                const auto tensor_shape = tensor_info.GetShape();
-                const auto tensor_type = tensor_info.GetElementType();
-
-                migraphx_shape_datatype_t mgx_type;
-                getMIGraphXType(tensor_type, mgx_type);
-                auto mgx_s = local_param_shapes[name];
-
-                if (mgx_type != mgx_s.type()) {
-                  LOGS_DEFAULT(FATAL) << "MIGraphX: param type mismatch";
-                }
-                quant_params.add(name, migraphx::argument(local_param_shapes[name], const_cast<void*>(input_tensor.GetTensorRawData())));
-              }
-            }
-          }
-          calibrate_and_quantize(prog, t, quant_params, fp16_enable, bf16_enable, int8_enable,
-                                 fp8_enable, int8_calibration_cache_available, map_dynamic_range);
-          compile_program(prog, t, exhaustive_tune_);
-
-          // Save compiled model with batch-aware filename
-          LOGS_DEFAULT(INFO) << "[Compute] Saving compiled model with updated batch size to: "
-                                << model_cache_file.string();
-          save_compiled_model(prog, model_cache_file);
-        } else {
-          LOGS_DEFAULT(INFO) << "[Compute] Cache hit! Loaded precompiled model with matching batch size";
-        }
-
-        mgx_state->prog = prog;
-        param_shapes = prog.get_parameter_shapes();
-        no_input_shape = false;
+        handle_input_shape_mismatch(
+            model_cache_path_,
+            mgx_state->model_cache_dir,
+            mxr_filename_prefix,
+            model_path_,
+            exhaustive_tune_,
+            fp16_enable,
+            bf16_enable,
+            fp8_enable,
+            int8_enable,
+            int8_calibration_cache_available,
+            t,
+            ctx,
+            map_input_name_index,
+            map_dynamic_range,
+            onnx_string,
+            cmp_options,
+            prog,
+            param_shapes,
+            input_shapes,
+            no_input_shape);
       }
 
       migraphx::program_parameters m;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1479,7 +1479,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
     if (!no_input_shape) {
       if (!load_precompiled_model(prog, model_cache_file)) {
-        LOGS_DEFAULT(VERBOSE) << "No input shapes detected quantizing model";
+        LOGS_DEFAULT(VERBOSE) << "[Compile] Cache miss. Compiling model with batch size included in shapes";
+        LOGS_DEFAULT(VERBOSE) << "[Compile] Model cache file will be: " << model_cache_file.string();
 #ifndef ENABLE_TRAINING_CORE
 #ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
         options.set_external_data_path(model_path_.parent_path().string());
@@ -1491,7 +1492,12 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         calibrate_and_quantize(prog, t_, quant_params, fp16_enable_, bf16_enable_, int8_enable_,
                                fp8_enable_, int8_calibration_cache_available_, dynamic_range_map_);
         compile_program(prog, t_, exhaustive_tune_);
+
+        LOGS_DEFAULT(VERBOSE) << "[Compile] Saving compiled model to cache: " << model_cache_file.string();
         save_compiled_model(prog, model_cache_file);
+        LOGS_DEFAULT(VERBOSE) << "[Compile] Model saved successfully with batch-aware filename";
+      } else {
+        LOGS_DEFAULT(VERBOSE) << "[Compile] Cache hit! Loaded precompiled model from: " << model_cache_file.string();
       }
 
       auto prog_output_shapes = prog.get_output_shapes();
@@ -1499,6 +1505,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         auto out_len = prog_output_shapes[i].lengths();
         options.set_input_parameter_shape(output_names[i], out_len);
       }
+    } else {
+      LOGS_DEFAULT(VERBOSE) << "[Compile] Deferring compilation until runtime (no static input shapes available)";
+      LOGS_DEFAULT(VERBOSE) << "[Compile] Will use default batch size of 1, then recompile with actual batch at runtime";
     }
 
     // compile the program
@@ -1561,6 +1570,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           cmp_options.set_input_parameter_shape(name, ort_lens);
           input_shape_match = false;
 
+          // Collect all shape dimensions including updated batch size for cache key
+          input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
+
           // Log batch size and full shape for tracking dynamic shapes
           if (!tensor_shape.empty()) {
             LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name
@@ -1576,6 +1588,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' shape (dynamic): " << shape_str.str();
           }
         }
+        LOGS_DEFAULT(VERBOSE) << "[Compute] All runtime shapes collected for cache key generation";
       } else {
         LOGS_DEFAULT(VERBOSE) << "Assigning inputs, and parameters from compiled model";
         param_shapes = prog.get_parameter_shapes();
@@ -1645,6 +1658,19 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         std::filesystem::path model_cache_file;
         // empty cache path means the MXR caching is disabled - always compile
         if (!model_cache_path_.empty()) {
+          // Ensure input_shapes has all updated dimensions including new batch sizes
+          if (input_shapes.empty()) {
+            LOGS_DEFAULT(WARNING) << "[Compute] Input shapes vector is empty, rebuilding from current inputs";
+            for (auto&& name : param_shapes.names()) {
+              if (map_input_name_index.count(name) > 0) {
+                auto input_tensor = ctx.GetInput(map_input_name_index[name]);
+                auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+                const auto tensor_shape = tensor_info.GetShape();
+                input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
+              }
+            }
+          }
+
           // Log the shapes being used for cache key generation
           std::ostringstream shapes_str;
           shapes_str << "[";
@@ -1653,14 +1679,15 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             shapes_str << input_shapes[i];
           }
           shapes_str << "]";
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Cache key input shapes: " << shapes_str.str();
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Cache key input shapes (including updated batch): " << shapes_str.str();
 
-          model_cache_file = mgx_state->model_cache_dir / (mxr_filename_prefix + make_hash(input_shapes) + ".mxr");
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Looking for cached model at: " << model_cache_file.string();
+          auto cache_hash = make_hash(input_shapes);
+          model_cache_file = mgx_state->model_cache_dir / (mxr_filename_prefix + cache_hash + ".mxr");
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Cache file with batch-aware hash: " << model_cache_file.string();
         }
 
         if (!load_precompiled_model(prog, model_cache_file)) {
-          LOGS_DEFAULT(VERBOSE) << "Input shape mismatch detected. Recompiling";
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Cache miss. Compiling model with updated batch size";
 #ifndef ENABLE_TRAINING_CORE
 #ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
           cmp_options.set_external_data_path(model_path_.parent_path().string());
@@ -1693,7 +1720,13 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           calibrate_and_quantize(prog, t, quant_params, fp16_enable, bf16_enable, int8_enable,
                                  fp8_enable, int8_calibration_cache_available, map_dynamic_range);
           compile_program(prog, t, exhaustive_tune_);
+
+          // Save compiled model with batch-aware filename
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Saving compiled model with updated batch size to: "
+                                << model_cache_file.string();
           save_compiled_model(prog, model_cache_file);
+        } else {
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Cache hit! Loaded precompiled model with matching batch size";
         }
 
         mgx_state->prog = prog;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1526,6 +1526,7 @@ migraphx::program CompileProgramWithBatch(
 // 2. If cache miss, compile using CompileProgramWithBatch
 // 3. Save the compiled model to cache
 // Returns the loaded or compiled program
+// Optional ctx and map_input_name_index can be provided for int8/fp8 calibration during compilation
 static migraphx::program load_or_compile_model(
     const std::filesystem::path& cache_file,
     const std::string& onnx_string,
@@ -1539,6 +1540,8 @@ static migraphx::program load_or_compile_model(
     std::unordered_map<std::string, float>& dynamic_range_map,
     bool exhaustive_tune,
     const std::filesystem::path& model_path,
+    Ort::KernelContext* ctx = nullptr,
+    const std::unordered_map<std::string, std::size_t>* map_input_name_index = nullptr,
     const std::vector<std::string>& input_names = {},
     const std::vector<std::vector<std::int64_t>>& all_input_base_shapes = {},
     size_t batch_size = 0)
@@ -1564,8 +1567,8 @@ static migraphx::program load_or_compile_model(
         dynamic_range_map,
         exhaustive_tune,
         model_path,
-        nullptr,  // No runtime context during compile
-        nullptr,  // No input name index map needed
+        ctx,
+        map_input_name_index,
         input_names,
         all_input_base_shapes,
         batch_size);
@@ -1678,57 +1681,46 @@ static void handle_input_shape_mismatch(
     model_cache_file = mgx_state->model_cache_dir / (mxr_filename_prefix + cache_hash + ".mxr");
   }
 
-  if (!load_precompiled_model(prog, model_cache_file)) {
-    LOGS_DEFAULT(VERBOSE) << "[Compute] Cache miss. Compiling model with updated batch size";
+  // Set input parameter shapes from runtime tensors before compilation
+  LOGS_DEFAULT(VERBOSE) << "[Compute] Setting " << map_input_name_index.size()
+                        << " input parameter shapes as static in MIGraphX options (excluding constants)";
 
-    // Set input parameter shapes from runtime tensors before compilation
-    LOGS_DEFAULT(VERBOSE) << "[Compute] Setting " << map_input_name_index.size()
-                          << " input parameter shapes as static in MIGraphX options (excluding constants)";
+  for (const auto& it : map_input_name_index) {
+    const auto& name = it.first;
+    const auto& index = it.second;
+    auto input_tensor = ctx.GetInput(index);
+    auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+    const auto tensor_shape = tensor_info.GetShape();
+    std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
+    cmp_options.set_input_parameter_shape(name, ort_lens);
 
-    for (const auto& it : map_input_name_index) {
-      const auto& name = it.first;
-      const auto& index = it.second;
-      auto input_tensor = ctx.GetInput(index);
-      auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-      const auto tensor_shape = tensor_info.GetShape();
-      std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
-      cmp_options.set_input_parameter_shape(name, ort_lens);
-
-      LOGS_DEFAULT(VERBOSE) << "[Compute] Set static shape for input parameter '" << name << "': ["
-                            << [&]() {
-                                std::ostringstream ss;
-                                for (size_t i = 0; i < ort_lens.size(); ++i) {
-                                  if (i > 0) ss << ", ";
-                                  ss << ort_lens[i];
-                                }
-                                return ss.str();
-                              }() << "]";
-    }
-
-    // Compile using the helper function (shapes already set in cmp_options)
-    // Pass ctx and map_input_name_index for quant_params population if int8/fp8 calibration is needed
-    prog = CompileProgramWithBatch(
-        mgx_state->onnx_string,
-        cmp_options,
-        mgx_state->t,
-        mgx_state->fp16_enable,
-        mgx_state->bf16_enable,
-        mgx_state->int8_enable,
-        mgx_state->fp8_enable,
-        mgx_state->int8_calibration_cache_available,
-        mgx_state->dynamic_range_map,
-        mgx_state->exhaustive_tune,
-        mgx_state->model_cache_dir,
-        &ctx,
-        &map_input_name_index);
-
-    // Save compiled model with batch-aware filename
-    LOGS_DEFAULT(VERBOSE) << "[Compute] Saving compiled model with updated batch size to: "
-                          << model_cache_file.string();
-    save_compiled_model(prog, model_cache_file);
-  } else {
-    LOGS_DEFAULT(VERBOSE) << "[Compute] Cache hit - loaded precompiled model";
+    LOGS_DEFAULT(VERBOSE) << "[Compute] Set static shape for input parameter '" << name << "': ["
+                          << [&]() {
+                              std::ostringstream ss;
+                              for (size_t i = 0; i < ort_lens.size(); ++i) {
+                                if (i > 0) ss << ", ";
+                                ss << ort_lens[i];
+                              }
+                              return ss.str();
+                            }() << "]";
   }
+
+  // Use load_or_compile_model helper - handles cache loading, compilation, and saving
+  prog = load_or_compile_model(
+      model_cache_file,
+      mgx_state->onnx_string,
+      cmp_options,
+      mgx_state->t,
+      mgx_state->fp16_enable,
+      mgx_state->bf16_enable,
+      mgx_state->int8_enable,
+      mgx_state->fp8_enable,
+      mgx_state->int8_calibration_cache_available,
+      mgx_state->dynamic_range_map,
+      mgx_state->exhaustive_tune,
+      mgx_state->model_cache_dir,
+      &ctx,
+      &map_input_name_index);
 
   // Store the compiled/loaded program in the in-memory cached_programs cache
   if (mgx_state->cached_programs_ref.has_value()) {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -184,7 +184,7 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
   // Verify configuration correctness and adjust accordingly.
 
 #if HIP_VERSION_MAJOR < 6 || (HIP_VERSION_MAJOR == 6 && (HIP_VERSION_MINOR < 4 || (HIP_VERSION_MINOR == 4 && HIP_VERSION_PATCH < 2)))
-  LOGS_DEFAULT(WARNING) << "MIGraphX: BF16 Quantization requires ROCm 6.4.2 or greater";
+  LOGS_DEFAULT(VERBOSE) << "MIGraphX: BF16 Quantization requires ROCm 6.4.2 or greater";
   bf16_enable_ = false;
 #endif
 
@@ -195,7 +195,7 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
   }
 
 #if HIP_VERSION_MAJOR < 6 || (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR < 4)
-  LOGS_DEFAULT(WARNING) << "MIGraphX: FP8 Quantization requires ROCm 6.4 or greater";
+  LOGS_DEFAULT(VERBOSE) << "MIGraphX: FP8 Quantization requires ROCm 6.4 or greater";
   fp8_enable_ = false;
 #endif
 
@@ -358,8 +358,8 @@ static bool getMIGraphXType(ONNXTensorElementDataType type,
       mgx_type = migraphx_shape_bool_type;
       break;
     default:
-      LOGS_DEFAULT(WARNING) << "MiGraphx: unsupported data type " << type << ", fallback to CPU";
-      LOGS_DEFAULT(WARNING) << "implementation";
+      LOGS_DEFAULT(VERBOSE) << "MiGraphx: unsupported data type " << type << ", fallback to CPU";
+      LOGS_DEFAULT(VERBOSE) << "implementation";
       return false;
   }
 
@@ -1124,11 +1124,11 @@ MIGraphXExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_v
   const auto unsupported_nodes = GetUnsupportedNodeIndices(graph_viewer, mgx_required_initializers, *GetLogger());
 
   if (unsupported_nodes.size() > 0) {
-    LOGS_DEFAULT(WARNING) << "============= Unsupported nodes ====================";
+    LOGS_DEFAULT(VERBOSE) << "============= Unsupported nodes ====================";
     for (auto idx : unsupported_nodes) {
-      LOGS_DEFAULT(WARNING) << graph_viewer.GetNode(idx)->OpType();
+      LOGS_DEFAULT(VERBOSE) << graph_viewer.GetNode(idx)->OpType();
     }
-    LOGS_DEFAULT(WARNING) << "************* Unsupported nodes ********************";
+    LOGS_DEFAULT(VERBOSE) << "************* Unsupported nodes ********************";
   }
 
   if (unsupported_nodes.size() > 10) {
@@ -1184,29 +1184,29 @@ static std::pair<std::vector<std::string>, std::vector<std::string>> get_io_name
 // Useful to default to EP to trigger the compile if file doesn't exist or loading fails.
 bool load_precompiled_model(migraphx::program& prog, const std::filesystem::path& path) try {
   if (!path.empty() && exists(path)) {
-    LOGS_DEFAULT(WARNING) << "[load_precompiled_model] Attempting to load model from disk: " << path.string();
+    LOGS_DEFAULT(VERBOSE) << "[load_precompiled_model] Attempting to load model from disk: " << path.string();
     prog = migraphx::load(path.string().c_str());
-    LOGS_DEFAULT(WARNING) << "[load_precompiled_model] ✓ Successfully loaded model from disk";
+    LOGS_DEFAULT(VERBOSE) << "[load_precompiled_model] ✓ Successfully loaded model from disk";
     return true;
   }
-  LOGS_DEFAULT(WARNING) << "[load_precompiled_model] Cache file does not exist: " 
+  LOGS_DEFAULT(VERBOSE) << "[load_precompiled_model] Cache file does not exist: " 
                         << (path.empty() ? "(no path specified)" : path.string());
   return false;
 } catch (const std::exception& e) {
-  LOGS_DEFAULT(WARNING) << "[load_precompiled_model] ✗ Failed to load model from disk: " << e.what();
+  LOGS_DEFAULT(VERBOSE) << "[load_precompiled_model] ✗ Failed to load model from disk: " << e.what();
   return false;
 } catch (...) {
-  LOGS_DEFAULT(WARNING) << "[load_precompiled_model] ✗ Failed to load model from disk (unknown exception)";
+  LOGS_DEFAULT(VERBOSE) << "[load_precompiled_model] ✗ Failed to load model from disk (unknown exception)";
   return false;
 }
 
 void save_compiled_model(const migraphx::program& prog, const std::filesystem::path& path) {
   if (!path.empty()) {
-    LOGS_DEFAULT(WARNING) << "[save_compiled_model] Saving compiled model to disk: " << path.string();
+    LOGS_DEFAULT(VERBOSE) << "[save_compiled_model] Saving compiled model to disk: " << path.string();
     migraphx::file_options fo;
     fo.set_file_format("msgpack");
     save(prog, path.string().c_str(), fo);
-    LOGS_DEFAULT(WARNING) << "[save_compiled_model] ✓ Model saved successfully";
+    LOGS_DEFAULT(VERBOSE) << "[save_compiled_model] ✓ Model saved successfully";
   }
 }
 
@@ -1356,6 +1356,12 @@ static bool allocate_and_pad_inputs(
     mgx_state->last_original_batch_size = original_batch_size;
     
     return true;
+  }
+  
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Normal path: Allocate new buffers (batch size changed or first run)
+  // ═══════════════════════════════════════════════════════════════════════════
+  LOGS_DEFAULT(VERBOSE) << "[allocate_and_pad_inputs] Allocating NEW padded buffers: original=" 
                         << original_batch_size << ", padded=" << padded_batch_size;
   
   // Free old buffers if they exist
@@ -1376,7 +1382,7 @@ static bool allocate_and_pad_inputs(
     const auto tensor_shape = tensor_info.GetShape();
     
     if (tensor_shape.empty()) {
-      LOGS_DEFAULT(WARNING) << "[allocate_and_pad_inputs] Skipping empty shape input";
+      LOGS_DEFAULT(VERBOSE) << "[allocate_and_pad_inputs] Skipping empty shape input";
       continue;
     }
     
@@ -1428,7 +1434,7 @@ static bool allocate_and_pad_inputs(
         break;
       default:
         element_size_bytes = sizeof(float);  // Fallback to float
-        LOGS_DEFAULT(WARNING) << "[allocate_and_pad_inputs] Unknown element type, assuming float";
+        LOGS_DEFAULT(VERBOSE) << "[allocate_and_pad_inputs] Unknown element type, assuming float";
         break;
     }
     
@@ -1444,7 +1450,7 @@ static bool allocate_and_pad_inputs(
     buf.mgx_shape = padded_mgx_shape;
     mgx_state->padded_input_buffers.push_back(buf);
     
-    LOGS_DEFAULT(WARNING) << "[allocate_and_pad_inputs] Padded input '" << cached_inp.name 
+    LOGS_DEFAULT(VERBOSE) << "[allocate_and_pad_inputs] Padded input '" << cached_inp.name 
                          << "': " << padded_bytes << " bytes";
   }
   
@@ -1452,6 +1458,7 @@ static bool allocate_and_pad_inputs(
   mgx_state->last_original_batch_size = original_batch_size;
   mgx_state->last_padded_batch_size = padded_batch_size;
   
+  LOGS_DEFAULT(VERBOSE) << "[allocate_and_pad_inputs] Allocated " 
                         << mgx_state->padded_input_buffers.size() << " padded buffers";
   return true;
 }
@@ -1484,7 +1491,7 @@ void calibrate_and_quantize(migraphx::program& prog,
                             std::unordered_map<std::string, float>& dynamic_range_map) {
   // Read in the calibration data and map it to an migraphx paramater map for the calibration ops
   if ((int8_enable ^ fp8_enable) && int8_calibration_cache_available) {
-    LOGS_DEFAULT(WARNING) << "Quantizing input program";
+    LOGS_DEFAULT(VERBOSE) << "Quantizing input program";
 
     auto param_shapes = prog.get_parameter_shapes();
 
@@ -1496,36 +1503,36 @@ void calibrate_and_quantize(migraphx::program& prog,
 
     // perform static quantization on the programs
     if (int8_enable) {
-      LOGS_DEFAULT(WARNING) << "Quantizing input program to int8";
+      LOGS_DEFAULT(VERBOSE) << "Quantizing input program to int8";
       migraphx::quantize_int8_options quant_opts;
       quant_opts.add_calibration_data(quant_params);
       // specify thing we want to int8 quantize
       quant_opts.add_op_name("convolution");
       quant_opts.add_op_name("dot");
       migraphx::quantize_int8(prog, t, quant_opts);
-      LOGS_DEFAULT(WARNING) << "Quantizing int8: Complete";
+      LOGS_DEFAULT(VERBOSE) << "Quantizing int8: Complete";
     } else if (fp8_enable) {
 #if HIP_VERSION_MAJOR > 6 || (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 4)
-      LOGS_DEFAULT(WARNING) << "Quantizing input program to fp8";
+      LOGS_DEFAULT(VERBOSE) << "Quantizing input program to fp8";
       migraphx::quantize_fp8_options quant_opts;
       quant_opts.add_calibration_data(quant_params);
       migraphx::quantize_fp8(prog, t, quant_opts);
-      LOGS_DEFAULT(WARNING) << "Quantizing fp8: Complete";
+      LOGS_DEFAULT(VERBOSE) << "Quantizing fp8: Complete";
 #endif
     }
   }
 
   if (fp16_enable) {
-    LOGS_DEFAULT(WARNING) << "Quantizing input program to fp16";
+    LOGS_DEFAULT(VERBOSE) << "Quantizing input program to fp16";
     migraphx::quantize_fp16(prog);
-    LOGS_DEFAULT(WARNING) << "Quantizing fp16: Complete";
+    LOGS_DEFAULT(VERBOSE) << "Quantizing fp16: Complete";
   }
 
 #if HIP_VERSION_MAJOR > 6 || (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 4 && HIP_VERSION_PATCH >= 2)
   if (bf16_enable) {
-    LOGS_DEFAULT(WARNING) << "Quantizing input program to bf16";
+    LOGS_DEFAULT(VERBOSE) << "Quantizing input program to bf16";
     migraphx::quantize_bf16(prog);
-    LOGS_DEFAULT(WARNING) << "Quantizing bf16: Complete";
+    LOGS_DEFAULT(VERBOSE) << "Quantizing bf16: Complete";
   }
 #endif
 }
@@ -1533,12 +1540,12 @@ void calibrate_and_quantize(migraphx::program& prog,
 void compile_program(migraphx::program& prog,
                      const migraphx::target& t,
                      bool exhaustive_tune) {
-  LOGS_DEFAULT(WARNING) << "Model Compile: Begin";
+  LOGS_DEFAULT(VERBOSE) << "Model Compile: Begin";
   migraphx::compile_options co;
   co.set_fast_math(false);
   co.set_exhaustive_tune_flag(exhaustive_tune);
   prog.compile(t, co);
-  LOGS_DEFAULT(WARNING) << "Model Compile: Complete";
+  LOGS_DEFAULT(VERBOSE) << "Model Compile: Complete";
 }
 
 std::string to_hex(const uint64_t v) {
@@ -1679,18 +1686,18 @@ static migraphx::program load_or_compile_model(
 {
   migraphx::program prog;
 
-  LOGS_DEFAULT(WARNING) << "[load_or_compile_model] ==== ENTERING ====";
-  LOGS_DEFAULT(WARNING) << "[load_or_compile_model] Cache file: " << (cache_file.empty() ? "(none)" : cache_file.string());
-  LOGS_DEFAULT(WARNING) << "[load_or_compile_model] Batch size: " << (batch_size > 0 ? std::to_string(batch_size) : "(default)");
+  LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] ==== ENTERING ====";
+  LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] Cache file: " << (cache_file.empty() ? "(none)" : cache_file.string());
+  LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] Batch size: " << (batch_size > 0 ? std::to_string(batch_size) : "(default)");
 
   if (!load_precompiled_model(prog, cache_file)) {
     // Cache miss - need to compile
     if (batch_size > 0) {
-      LOGS_DEFAULT(WARNING) << "[load_or_compile_model] ✗ CACHE MISS for batch size " << batch_size << " - COMPILING...";
+      LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] ✗ CACHE MISS for batch size " << batch_size << " - COMPILING...";
     } else {
-      LOGS_DEFAULT(WARNING) << "[load_or_compile_model] ✗ CACHE MISS - COMPILING...";
+      LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] ✗ CACHE MISS - COMPILING...";
     }
-    LOGS_DEFAULT(WARNING) << "[load_or_compile_model] Compilation started (this may take a while)...";
+    LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] Compilation started (this may take a while)...";
 
     prog = CompileProgramWithBatch(
         onnx_string,
@@ -1710,23 +1717,23 @@ static migraphx::program load_or_compile_model(
         all_input_base_shapes,
         batch_size);
 
-    LOGS_DEFAULT(WARNING) << "[load_or_compile_model] Compilation finished";
+    LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] Compilation finished";
     
     save_compiled_model(prog, cache_file);
     if (!cache_file.empty()) {
-      LOGS_DEFAULT(WARNING) << "[load_or_compile_model] Saved compiled model to disk: " << cache_file.string();
+      LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] Saved compiled model to disk: " << cache_file.string();
     }
   } else {
     // Cache hit - loaded from disk
     if (batch_size > 0) {
-      LOGS_DEFAULT(WARNING) << "[load_or_compile_model] ✓ CACHE HIT - LOADING FROM DISK for batch size " << batch_size;
+      LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] ✓ CACHE HIT - LOADING FROM DISK for batch size " << batch_size;
     } else {
-      LOGS_DEFAULT(WARNING) << "[load_or_compile_model] ✓ CACHE HIT - LOADING FROM DISK";
+      LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] ✓ CACHE HIT - LOADING FROM DISK";
     }
-    LOGS_DEFAULT(WARNING) << "[load_or_compile_model] Loaded precompiled model from: " << cache_file.string();
+    LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] Loaded precompiled model from: " << cache_file.string();
   }
 
-  LOGS_DEFAULT(WARNING) << "[load_or_compile_model] ==== EXITING ====";
+  LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] ==== EXITING ====";
   return prog;
 }
 
@@ -1757,11 +1764,11 @@ static void run_migraphx_program(
   bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 && 
                         original_batch_size < padded_batch_size);
 
-  LOGS_DEFAULT(WARNING) << "[run_migraphx_program] ==== ENTERING ====";
-  LOGS_DEFAULT(WARNING) << "[run_migraphx_program] original_batch_size=" << original_batch_size 
+  LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] ==== ENTERING ====";
+  LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] original_batch_size=" << original_batch_size 
                         << ", padded_batch_size=" << padded_batch_size 
                         << ", needs_slicing=" << needs_slicing;
-  LOGS_DEFAULT(WARNING) << "[run_migraphx_program] prog_output_indices.size()=" << prog_output_indices.size();
+  LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] prog_output_indices.size()=" << prog_output_indices.size();
   if (!prog_output_indices.empty()) {
     std::ostringstream ss;
     ss << "[";
@@ -1770,12 +1777,12 @@ static void run_migraphx_program(
       ss << prog_output_indices[i];
     }
     ss << "]";
-    LOGS_DEFAULT(WARNING) << "[run_migraphx_program] prog_output_indices=" << ss.str();
+    LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] prog_output_indices=" << ss.str();
   }
 
   // Process ALL outputs for proper slicing when needed
   auto output_num = prog_outputs->size();
-  LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Number of MIGraphX outputs: " << output_num;
+  LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Number of MIGraphX outputs: " << output_num;
   
   std::unordered_set<std::size_t> prog_output_indices_set(prog_output_indices.begin(), prog_output_indices.end());
   std::vector<std::size_t> outputs_to_copy;  // Outputs that need memcpy (not pre-allocated)
@@ -1786,9 +1793,9 @@ static void run_migraphx_program(
     }
   }
   
-  LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Pre-allocated outputs (in prog_output_indices): " 
+  LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Pre-allocated outputs (in prog_output_indices): " 
                         << prog_output_indices_set.size();
-  LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Outputs to copy (not pre-allocated): " 
+  LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Outputs to copy (not pre-allocated): " 
                         << outputs_to_copy.size();
   
   // First, handle pre-allocated outputs (need slicing but were already bound)
@@ -1796,10 +1803,10 @@ static void run_migraphx_program(
   // The proper solution is to use temp buffers in handle_program_input_outputs when needs_slicing=true.
   // This code handles the case defensively by copying sliced data to newly allocated ORT outputs.
   if (needs_slicing && !prog_output_indices_set.empty()) {
-    LOGS_DEFAULT(WARNING) << "[run_migraphx_program] ⚠️  WARNING: Handling " << prog_output_indices_set.size() 
+    LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] ⚠️  WARNING: Handling " << prog_output_indices_set.size() 
                          << " pre-allocated outputs with slicing";
-    LOGS_DEFAULT(WARNING) << "[run_migraphx_program] ⚠️  This indicates handle_program_input_outputs did NOT use temp buffers!";
-    LOGS_DEFAULT(WARNING) << "[run_migraphx_program] ⚠️  Pre-allocated outputs should be empty when slicing is needed.";
+    LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] ⚠️  This indicates handle_program_input_outputs did NOT use temp buffers!";
+    LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] ⚠️  Pre-allocated outputs should be empty when slicing is needed.";
     
     for (std::size_t i = 0; i < output_num; ++i) {
       if (prog_output_indices_set.count(i) > 0) {
@@ -1808,7 +1815,7 @@ static void run_migraphx_program(
         migraphx::shape res_shape = gpu_res.get_shape();
         auto res_lens = res_shape.lengths();
         
-        LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Pre-allocated output " << i 
+        LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Pre-allocated output " << i 
                              << " MIGraphX shape: [" << [&]() {
           std::ostringstream ss;
           for (size_t j = 0; j < res_lens.size(); ++j) {
@@ -1823,10 +1830,10 @@ static void run_migraphx_program(
         if (!ort_shape.empty() && static_cast<std::size_t>(ort_shape[0]) != original_batch_size) {
           ort_shape[0] = static_cast<int64_t>(original_batch_size);
           
-          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Slicing pre-allocated output " << i 
+          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Slicing pre-allocated output " << i 
                                << " from batch size " << padded_batch_size << " to " << original_batch_size;
           
-          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Output " << i << " ORT shape (after slicing): [" << [&]() {
+          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Output " << i << " ORT shape (after slicing): [" << [&]() {
             std::ostringstream ss;
             for (size_t j = 0; j < ort_shape.size(); ++j) {
               if (j > 0) ss << ", ";
@@ -1839,7 +1846,7 @@ static void run_migraphx_program(
           std::size_t bytes_per_batch = res_shape.bytes() / padded_batch_size;
           std::size_t bytes_to_copy = bytes_per_batch * original_batch_size;
           
-          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Bytes per batch: " << bytes_per_batch
+          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Bytes per batch: " << bytes_per_batch
                                << ", total bytes to copy: " << bytes_to_copy;
           
           // Allocate temp buffer for sliced data on GPU
@@ -1851,7 +1858,7 @@ static void run_migraphx_program(
           }
           
           // Copy sliced data from MIGraphX output to temp buffer
-          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Copying sliced data to temp buffer...";
+          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Copying sliced data to temp buffer...";
           HIP_CALL_THROW(hipMemcpyWithStream(temp_sliced_buffer,
                                              gpu_res.data(),
                                              bytes_to_copy,
@@ -1863,12 +1870,12 @@ static void run_migraphx_program(
           
           // Now allocate the ORT output tensor with the SLICED shape
           // This should work because we're allocating fresh (not re-using the padded buffer)
-          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Allocating ORT output with sliced shape...";
+          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Allocating ORT output with sliced shape...";
           auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
           void* output_data = output_tensor.GetTensorMutableRawData();
           
           // Copy from temp buffer to ORT output
-          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Copying from temp buffer to ORT output...";
+          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Copying from temp buffer to ORT output...";
           HIP_CALL_THROW(hipMemcpyWithStream(output_data,
                                              temp_sliced_buffer,
                                              bytes_to_copy,
@@ -1878,10 +1885,10 @@ static void run_migraphx_program(
           // Free temporary buffer
           hipFree(temp_sliced_buffer);
           
-          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] ✓ Successfully sliced pre-allocated output " << i;
+          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] ✓ Successfully sliced pre-allocated output " << i;
         } else {
           // No slicing needed for this output (batch dimension matches)
-          LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Output " << i << " batch dim already matches, no slicing needed";
+          LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Output " << i << " batch dim already matches, no slicing needed";
         }
       }
     }
@@ -1895,7 +1902,7 @@ static void run_migraphx_program(
       auto res_lens = res_shape.lengths();
       
       // Log the original MIGraphX output shape
-      LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Output " << i << " MIGraphX shape: [" << [&]() {
+      LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Output " << i << " MIGraphX shape: [" << [&]() {
         std::ostringstream ss;
         for (size_t j = 0; j < res_lens.size(); ++j) {
           if (j > 0) ss << ", ";
@@ -1908,11 +1915,11 @@ static void run_migraphx_program(
       std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
       if (needs_slicing && !ort_shape.empty()) {
         ort_shape[0] = original_batch_size;  // Slice batch dimension
-        LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Slicing output " << i << " from batch size " 
+        LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Slicing output " << i << " from batch size " 
                              << padded_batch_size << " to " << original_batch_size;
       }
       
-      LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Output " << i << " ORT shape (after slicing): [" << [&]() {
+      LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Output " << i << " ORT shape (after slicing): [" << [&]() {
         std::ostringstream ss;
         for (size_t j = 0; j < ort_shape.size(); ++j) {
           if (j > 0) ss << ", ";
@@ -1933,10 +1940,10 @@ static void run_migraphx_program(
           elements_per_batch *= res_lens[j];
         }
         bytes_to_copy = (res_shape.bytes() / padded_batch_size) * original_batch_size;
-        LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Copying " << bytes_to_copy 
+        LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Copying " << bytes_to_copy 
                              << " bytes (sliced from " << res_shape.bytes() << " bytes)";
       } else {
-        LOGS_DEFAULT(WARNING) << "[run_migraphx_program] Copying " << bytes_to_copy 
+        LOGS_DEFAULT(VERBOSE) << "[run_migraphx_program] Copying " << bytes_to_copy 
                              << " bytes (no slicing)";
       }
 
@@ -2077,10 +2084,10 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
     bool needs_slicing = false,
     std::vector<void*>* temp_output_buffers = nullptr)
 {
-  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] ==== ENTERING ====";
-  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] needs_slicing=" << needs_slicing 
+  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] ==== ENTERING ====";
+  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] needs_slicing=" << needs_slicing 
                         << ", temp_output_buffers=" << (temp_output_buffers != nullptr ? "valid" : "nullptr");
-  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] param_shapes.size()=" << param_shapes.size()
+  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] param_shapes.size()=" << param_shapes.size()
                         << ", output_shapes.size()=" << output_shapes.size();
   
   migraphx::program_parameters m;
@@ -2108,7 +2115,7 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
           output_count++;
           const auto& mgx_arg_shape = param_shapes[name];
           
-          LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] Processing output '" << name 
+          LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] Processing output '" << name 
                                 << "' (index=" << output_index << ")"
                                 << ", needs_slicing=" << needs_slicing 
                                 << ", temp_output_buffers=" << (temp_output_buffers != nullptr ? "valid" : "nullptr");
@@ -2125,12 +2132,12 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
             temp_output_buffers->push_back(temp_buffer);
             temp_buffer_count++;
             m.add(name, migraphx::argument(mgx_arg_shape, temp_buffer));
-            LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] ✓ Allocated TEMP BUFFER for output " 
+            LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] ✓ Allocated TEMP BUFFER for output " 
                                   << output_index << " '" << name << "' (" << output_size_bytes << " bytes)"
                                   << " - NOT adding to prog_output_indices";
           } else {
             // Normal path: bind directly to ORT output tensor
-            LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] Using NORMAL PATH for output " 
+            LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] Using NORMAL PATH for output " 
                                   << output_index << " '" << name << "'"
                                   << " - adding to prog_output_indices";
             prog_output_indices.push_back(static_cast<std::size_t>(output_index));
@@ -2144,12 +2151,12 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
     }
   }
   
-  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] ==== SUMMARY ====";
-  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] Processed " << input_count << " inputs, " 
+  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] ==== SUMMARY ====";
+  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] Processed " << input_count << " inputs, " 
                         << output_count << " outputs";
-  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] Temp buffers allocated: " << temp_buffer_count;
-  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] prog_output_indices.size()=" << prog_output_indices.size();
-  LOGS_DEFAULT(WARNING) << "[handle_program_input_outputs] ==== EXITING ====";
+  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] Temp buffers allocated: " << temp_buffer_count;
+  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] prog_output_indices.size()=" << prog_output_indices.size();
+  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] ==== EXITING ====";
   
   return {m, prog_output_indices};
 }
@@ -2220,8 +2227,8 @@ static std::vector<std::int64_t> build_input_shapes_in_cached_order(
   std::vector<std::int64_t> shapes;
   shapes.reserve(mgx_state->cached_inputs.size() * 4);  // Estimate average 4 dims per input
   
-  LOGS_DEFAULT(WARNING) << "[build_input_shapes_in_cached_order] Building shapes in cached_inputs order";
-  LOGS_DEFAULT(WARNING) << "[build_input_shapes_in_cached_order] cached_inputs.size()=" << mgx_state->cached_inputs.size()
+  LOGS_DEFAULT(VERBOSE) << "[build_input_shapes_in_cached_order] Building shapes in cached_inputs order";
+  LOGS_DEFAULT(VERBOSE) << "[build_input_shapes_in_cached_order] cached_inputs.size()=" << mgx_state->cached_inputs.size()
                         << ", padded_batch_size=" << padded_batch_size;
   
   // Log first few input names to verify ordering
@@ -2233,7 +2240,7 @@ static std::vector<std::int64_t> build_input_shapes_in_cached_order(
       input_order_ss << mgx_state->cached_inputs[i].name;
     }
     if (mgx_state->cached_inputs.size() > 5) input_order_ss << ", ...";
-    LOGS_DEFAULT(WARNING) << input_order_ss.str();
+    LOGS_DEFAULT(VERBOSE) << input_order_ss.str();
   }
   
   for (const auto& cached_inp : mgx_state->cached_inputs) {
@@ -2253,7 +2260,7 @@ static std::vector<std::int64_t> build_input_shapes_in_cached_order(
     }
   }
   
-  LOGS_DEFAULT(WARNING) << "[build_input_shapes_in_cached_order] Built " << shapes.size() << " shape dimensions";
+  LOGS_DEFAULT(VERBOSE) << "[build_input_shapes_in_cached_order] Built " << shapes.size() << " shape dimensions";
   return shapes;
 }
 
@@ -2269,27 +2276,27 @@ static bool execute_ultra_fast_path(
     OrtKernelContext* context,
     Ort::KernelContext& ctx)
 {
-  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Checking cache validity";
-  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] caches_valid = " << mgx_state->caches_valid;
-  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] last_input_shapes_raw.size() = " 
+  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Checking cache validity";
+  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] caches_valid = " << mgx_state->caches_valid;
+  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] last_input_shapes_raw.size() = " 
                         << mgx_state->last_input_shapes_raw.size();
-  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] cached_outputs.size() = " 
+  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] cached_outputs.size() = " 
                         << mgx_state->cached_outputs.size();
   
   if (!mgx_state->caches_valid || mgx_state->last_input_shapes_raw.empty()) {
-    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Caches not valid or empty - skipping";
+    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Caches not valid or empty - skipping";
     return false;
   }
   
   // Ultra-fast path not supported when outputs need dynamic slicing
   if (mgx_state->cached_outputs.empty()) {
-    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] No cached outputs (slicing mode) - skipping";
+    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] No cached outputs (slicing mode) - skipping";
     return false;
   }
 
   // Quick shape comparison
-  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Performing shape comparison";
-  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Number of cached inputs: " << mgx_state->cached_inputs.size();
+  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Performing shape comparison";
+  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Number of cached inputs: " << mgx_state->cached_inputs.size();
   
   // Log first few input names to verify ordering consistency
   if (mgx_state->cached_inputs.size() > 0) {
@@ -2300,7 +2307,7 @@ static bool execute_ultra_fast_path(
       input_order_ss << mgx_state->cached_inputs[i].name;
     }
     if (mgx_state->cached_inputs.size() > 5) input_order_ss << ", ...";
-    LOGS_DEFAULT(WARNING) << input_order_ss.str();
+    LOGS_DEFAULT(VERBOSE) << input_order_ss.str();
   }
   
   bool shapes_match = true;
@@ -2315,13 +2322,13 @@ static bool execute_ultra_fast_path(
   for (const auto& inp : mgx_state->cached_inputs) {
     const auto& shape = ctx.GetInput(inp.ort_index).GetTensorTypeAndShapeInfo().GetShape();
     
-    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Input " << input_idx << " '" << inp.name 
+    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Input " << input_idx << " '" << inp.name 
                           << "': current shape size=" << shape.size() 
                           << ", offset=" << offset 
                           << ", last_shapes.size()=" << last_shapes.size();
     
     if (offset + shape.size() > last_shapes.size()) {
-      LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Shape size mismatch - failing";
+      LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Shape size mismatch - failing";
       shapes_match = false;
       break;
     }
@@ -2342,8 +2349,8 @@ static bool execute_ultra_fast_path(
     }
     cached_ss << "]";
     
-    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH]   Current: " << current_ss.str();
-    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH]   Cached:  " << cached_ss.str();
+    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH]   Current: " << current_ss.str();
+    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH]   Cached:  " << cached_ss.str();
     
     // For dynamic batch, we check if the current batch needs padding
     if (mgx_state->has_dynamic_batch && !mgx_state->power_of_two_batch_sizes.empty()) {
@@ -2353,7 +2360,7 @@ static bool execute_ultra_fast_path(
         padded_batch_size = static_cast<std::size_t>(last_shapes[offset]);
         is_first = false;
         
-        LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Current batch: " << original_batch_size
+        LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Current batch: " << original_batch_size
                               << ", cached padded batch: " << padded_batch_size;
         
         // Check if the batch size matches (original or padded)
@@ -2362,10 +2369,10 @@ static bool execute_ultra_fast_path(
           std::size_t required_padded = find_nearest_power_of_two_batch(
               original_batch_size, mgx_state->power_of_two_batch_sizes);
           
-          LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Required padded: " << required_padded;
+          LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Required padded: " << required_padded;
           
           if (required_padded != padded_batch_size) {
-            LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Padded batch size mismatch - failing";
+            LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Padded batch size mismatch - failing";
             shapes_match = false;
             break;
           }
@@ -2373,11 +2380,11 @@ static bool execute_ultra_fast_path(
       }
       
       // For ALL inputs with dynamic batching: verify batch size consistency and check non-batch dims
-      LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Checking dimensions for input " << input_idx;
+      LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Checking dimensions for input " << input_idx;
       
       // All current inputs should have the same batch size (original_batch_size)
       if (shape[0] != original_batch_size) {
-        LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Batch dimension mismatch: current=" 
+        LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Batch dimension mismatch: current=" 
                               << shape[0] << ", expected original=" << original_batch_size;
         shapes_match = false;
         break;
@@ -2385,7 +2392,7 @@ static bool execute_ultra_fast_path(
       
       // Cached shape should have padded batch size in dimension 0
       if (last_shapes[offset] != static_cast<std::int64_t>(padded_batch_size)) {
-        LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Cached batch mismatch: cached=" 
+        LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Cached batch mismatch: cached=" 
                               << last_shapes[offset] << ", expected padded=" << padded_batch_size;
         shapes_match = false;
         break;
@@ -2395,7 +2402,7 @@ static bool execute_ultra_fast_path(
       bool rest_matches = true;
       for (std::size_t i = 1; i < shape.size(); ++i) {
         if (last_shapes[offset + i] != shape[i]) {
-          LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Dimension " << i 
+          LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Dimension " << i 
                                 << " mismatch: current=" << shape[i] 
                                 << ", cached=" << last_shapes[offset + i];
           rest_matches = false;
@@ -2406,12 +2413,12 @@ static bool execute_ultra_fast_path(
         shapes_match = false;
         break;
       }
-      LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH][DynamicBatch] Input " << input_idx << " dims match!";
+      LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH][DynamicBatch] Input " << input_idx << " dims match!";
     } else {
       // No dynamic batching - strict comparison
       for (std::size_t i = 0; i < shape.size(); ++i) {
         if (last_shapes[offset + i] != shape[i]) {
-          LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Dimension " << i 
+          LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Dimension " << i 
                                 << " mismatch at input " << input_idx 
                                 << ": current=" << shape[i] 
                                 << ", cached=" << last_shapes[offset + i];
@@ -2427,12 +2434,12 @@ static bool execute_ultra_fast_path(
   }
 
   if (!shapes_match || offset != last_shapes.size()) {
-    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Shapes don't match - failing";
+    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Shapes don't match - failing";
     return false;
   }
 
   // Shapes unchanged (or compatible with padding) - rebind pointers and run directly
-  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] ✓ Shapes match! Rebinding and executing";
+  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] ✓ Shapes match! Rebinding and executing";
   auto& m = mgx_state->cached_prog_params.value();
   auto& prog = mgx_state->prog;
   
@@ -2444,19 +2451,19 @@ static bool execute_ultra_fast_path(
     auto rocm_stream = static_cast<hipStream_t>(rocm_stream_ptr);
     using_padded_inputs = allocate_and_pad_inputs(mgx_state, ctx, original_batch_size, 
                                                   padded_batch_size, rocm_stream);
-    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Using padded inputs: " << using_padded_inputs;
+    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Using padded inputs: " << using_padded_inputs;
   }
 
   // Rebind inputs - use padded buffers if available, otherwise use original inputs
   if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
-    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Binding padded input buffers";
+    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Binding padded input buffers";
     for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
       const auto& inp = mgx_state->cached_inputs[i];
       const auto& padded_buf = mgx_state->padded_input_buffers[i];
       m.add(inp.name.c_str(), migraphx::argument(padded_buf.mgx_shape, padded_buf.data));
     }
   } else {
-    LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Binding original input buffers";
+    LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Binding original input buffers";
     for (const auto& inp : mgx_state->cached_inputs) {
       const auto& input_tensor = ctx.GetInput(inp.ort_index);
       m.add(inp.name.c_str(), migraphx::argument(inp.mgx_shape,
@@ -2474,7 +2481,7 @@ static bool execute_ultra_fast_path(
   }
 
   // Run directly - minimal overhead path (with slicing if needed)
-  LOGS_DEFAULT(WARNING) << "[ULTRA_FAST_PATH] Running (original_batch=" << original_batch_size 
+  LOGS_DEFAULT(VERBOSE) << "[ULTRA_FAST_PATH] Running (original_batch=" << original_batch_size 
                      << ", padded=" << padded_batch_size << ")";
   run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m,
                        mgx_state->cached_prog_output_indices,
@@ -2497,16 +2504,16 @@ static bool execute_fast_path(
     const std::string& current_hash,
     std::vector<std::int64_t>& all_input_shapes)
 {
-  LOGS_DEFAULT(WARNING) << "[FAST_PATH] Checking for cached program with hash: " << current_hash;
+  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Checking for cached program with hash: " << current_hash;
   
   if (mgx_state->defer_compilation || !mgx_state->cached_programs_ref.has_value()) {
-    LOGS_DEFAULT(WARNING) << "[FAST_PATH] Skipping - defer_compilation=" << mgx_state->defer_compilation
+    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Skipping - defer_compilation=" << mgx_state->defer_compilation
                           << ", has cache=" << mgx_state->cached_programs_ref.has_value();
     return false;
   }
 
   auto& cached_programs = mgx_state->cached_programs_ref.value().get();
-  LOGS_DEFAULT(WARNING) << "[FAST_PATH] Memory cache size: " << cached_programs.size();
+  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Memory cache size: " << cached_programs.size();
   auto prog_it = cached_programs.find(current_hash);
   
   // If not found directly, check if we need to use a padded batch size
@@ -2516,7 +2523,7 @@ static bool execute_fast_path(
   
   if (prog_it == cached_programs.end() && mgx_state->has_dynamic_batch && 
       !mgx_state->power_of_two_batch_sizes.empty()) {
-    LOGS_DEFAULT(WARNING) << "[FAST_PATH][DynamicBatch] Direct hash miss - checking for padded batch";
+    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Direct hash miss - checking for padded batch";
     // Try to find a padded batch size
     const auto& map_input_name_index = mgx_state->input_name_indexes;
     
@@ -2529,14 +2536,14 @@ static bool execute_fast_path(
         padded_batch_size = find_nearest_power_of_two_batch(original_batch_size, 
                                                             mgx_state->power_of_two_batch_sizes);
         needs_padding = (padded_batch_size > original_batch_size);
-        LOGS_DEFAULT(WARNING) << "[FAST_PATH][DynamicBatch] Original batch: " << original_batch_size
+        LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Original batch: " << original_batch_size
                               << ", padded: " << padded_batch_size << ", needs_padding: " << needs_padding;
         break;
       }
     }
     
     if (needs_padding && padded_batch_size > 0) {
-      LOGS_DEFAULT(WARNING) << "[FAST_PATH][DynamicBatch] Building padded shape key for hash lookup";
+      LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Building padded shape key for hash lookup";
       // Build padded shapes in alphabetical order (map order) for hash calculation
       // This matches the order used during compilation in compile_dynamic_batch_models
       std::vector<std::int64_t> padded_shapes_for_hash;
@@ -2554,17 +2561,17 @@ static bool execute_fast_path(
       }
       
       auto padded_hash = make_hash(padded_shapes_for_hash);
-      LOGS_DEFAULT(WARNING) << "[FAST_PATH][DynamicBatch] Padded hash (map order): " << padded_hash;
+      LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Padded hash (map order): " << padded_hash;
       prog_it = cached_programs.find(padded_hash);
       
       if (prog_it != cached_programs.end()) {
-        LOGS_DEFAULT(WARNING) << "[FAST_PATH][DynamicBatch] ✓✓✓ CACHE HIT using padded batch size " 
+        LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] ✓✓✓ CACHE HIT using padded batch size " 
                            << padded_batch_size << " for original batch " << original_batch_size;
         
         // Now rebuild padded_shapes in cached_inputs order for saving to last_input_shapes_raw
         // This ensures ultra-fast path shape comparison works correctly
         if (!mgx_state->cached_inputs.empty()) {
-          LOGS_DEFAULT(WARNING) << "[FAST_PATH][DynamicBatch] Rebuilding in cached_inputs order for saving";
+          LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Rebuilding in cached_inputs order for saving";
           std::vector<std::int64_t> padded_shapes_for_cache;
           padded_shapes_for_cache.reserve(mgx_state->cached_inputs.size() * 2);
           
@@ -2584,20 +2591,20 @@ static bool execute_fast_path(
           all_input_shapes = std::move(padded_shapes_for_hash);
         }
       } else {
-        LOGS_DEFAULT(WARNING) << "[FAST_PATH][DynamicBatch] Cache miss for padded hash too";
+        LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Cache miss for padded hash too";
       }
     }
   } else if (prog_it != cached_programs.end()) {
-    LOGS_DEFAULT(WARNING) << "[FAST_PATH] ✓ CACHE HIT for exact hash";
+    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] ✓ CACHE HIT for exact hash";
   }
   
   if (prog_it == cached_programs.end()) {
-    LOGS_DEFAULT(WARNING) << "[FAST_PATH] No cached program found";
+    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] No cached program found";
     return false;
   }
 
   // Found cached program - use it and populate caches
-  LOGS_DEFAULT(WARNING) << "[FAST_PATH] Using cached program, populating caches";
+  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Using cached program, populating caches";
   auto& prog = mgx_state->prog;
   prog = prog_it->second;
 
@@ -2625,16 +2632,16 @@ static bool execute_fast_path(
   }
 
   // Bind inputs/outputs (use temp buffers for outputs when slicing)
-  LOGS_DEFAULT(WARNING) << "[FAST_PATH] Calling handle_program_input_outputs with needs_slicing=" << needs_slicing;
+  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Calling handle_program_input_outputs with needs_slicing=" << needs_slicing;
   std::vector<void*> temp_output_buffers;
   auto [m, prog_output_indices] = handle_program_input_outputs(
       param_shapes, output_shapes, map_input_name_index, ctx, needs_slicing, &temp_output_buffers);
 
-  LOGS_DEFAULT(WARNING) << "[FAST_PATH] handle_program_input_outputs returned:";
-  LOGS_DEFAULT(WARNING) << "[FAST_PATH]   prog_output_indices.size()=" << prog_output_indices.size();
-  LOGS_DEFAULT(WARNING) << "[FAST_PATH]   temp_output_buffers.size()=" << temp_output_buffers.size();
+  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] handle_program_input_outputs returned:";
+  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH]   prog_output_indices.size()=" << prog_output_indices.size();
+  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH]   temp_output_buffers.size()=" << temp_output_buffers.size();
   if (needs_slicing && !prog_output_indices.empty()) {
-    LOGS_DEFAULT(WARNING) << "[FAST_PATH]   ⚠️  WARNING: prog_output_indices is NOT empty with slicing enabled!";
+    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH]   ⚠️  WARNING: prog_output_indices is NOT empty with slicing enabled!";
   }
 
   mgx_state->cached_prog_params = std::move(m);
@@ -2644,7 +2651,7 @@ static bool execute_fast_path(
   // This ensures ultra-fast path shape comparison uses consistent ordering
   mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(
       mgx_state, ctx, using_padded_inputs ? padded_batch_size : 0);
-  LOGS_DEFAULT(WARNING) << "[FAST_PATH] Built last_input_shapes_raw in cached_inputs order, size=" 
+  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Built last_input_shapes_raw in cached_inputs order, size=" 
                         << mgx_state->last_input_shapes_raw.size();
   
   mgx_state->last_input_shape_hash = current_hash;
@@ -2652,7 +2659,7 @@ static bool execute_fast_path(
 
   // Rebind padded inputs to program parameters
   if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
-    LOGS_DEFAULT(WARNING) << "[FAST_PATH] Rebinding padded input buffers";
+    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Rebinding padded input buffers";
     auto& prog_params = mgx_state->cached_prog_params.value();
     for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
       const auto& inp = mgx_state->cached_inputs[i];
@@ -2661,7 +2668,7 @@ static bool execute_fast_path(
     }
   }
 
-  LOGS_DEFAULT(WARNING) << "[FAST_PATH] Running program (original_batch=" << original_batch_size 
+  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Running program (original_batch=" << original_batch_size 
                      << ", padded=" << padded_batch_size << ")";
   run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog,
                        mgx_state->cached_prog_params.value(),
@@ -2678,6 +2685,7 @@ static bool execute_fast_path(
   // NOTE: Padded buffers are kept for reuse - they will be freed when batch size changes
   // or when the state is destroyed
   
+  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Complete";
   return true;
 }
 
@@ -2775,22 +2783,22 @@ static void compile_dynamic_batch_models(
     const std::string& mxr_filename_prefix,
     const Ort::KernelContext& ctx) {
   
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ==== ENTERING compile_dynamic_batch_models ====";
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] has_dynamic_batch = " << mgx_state->has_dynamic_batch;
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] power_of_two_batch_sizes.size() = " 
+  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ==== ENTERING compile_dynamic_batch_models ====";
+  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] has_dynamic_batch = " << mgx_state->has_dynamic_batch;
+  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] power_of_two_batch_sizes.size() = " 
                      << mgx_state->power_of_two_batch_sizes.size();
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] max_dynamic_batch = " << mgx_state->max_dynamic_batch;
+  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] max_dynamic_batch = " << mgx_state->max_dynamic_batch;
   
   if (!mgx_state->has_dynamic_batch || mgx_state->power_of_two_batch_sizes.empty()) {
-    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Skipping - dynamic batch disabled or no batch sizes";
+    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Skipping - dynamic batch disabled or no batch sizes";
     return;
   }
   
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Compiling models for " 
+  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Compiling models for " 
                      << mgx_state->power_of_two_batch_sizes.size() << " power-of-two batch sizes";
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Batch sizes: ";
+  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Batch sizes: ";
   for (const auto& bs : mgx_state->power_of_two_batch_sizes) {
-    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE]   - " << bs;
+    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE]   - " << bs;
   }
   
   // Get input names and base shapes (without batch dimension)
@@ -2798,14 +2806,14 @@ static void compile_dynamic_batch_models(
   std::vector<std::string> input_names;
   std::vector<std::vector<std::int64_t>> all_input_base_shapes;
   
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Processing " << map_input_name_index.size() << " input parameters";
+  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Processing " << map_input_name_index.size() << " input parameters";
   for (const auto& [name, index] : map_input_name_index) {
     input_names.push_back(name);
     auto input_tensor = ctx.GetInput(index);
     auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
     const auto tensor_shape = tensor_info.GetShape();
     
-    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Input '" << name << "' (index " << index 
+    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Input '" << name << "' (index " << index 
                        << ") runtime shape: [" << [&]() {
                          std::ostringstream ss;
                          for (size_t i = 0; i < tensor_shape.size(); ++i) {
@@ -2822,7 +2830,7 @@ static void compile_dynamic_batch_models(
     }
     all_input_base_shapes.push_back(base_shape);
     
-    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE]   Base shape (no batch): [" << [&]() {
+    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE]   Base shape (no batch): [" << [&]() {
                          std::ostringstream ss;
                          for (size_t i = 0; i < base_shape.size(); ++i) {
                            if (i > 0) ss << ", ";
@@ -2834,7 +2842,7 @@ static void compile_dynamic_batch_models(
   
   // Compile a model for each power-of-two batch size
   for (const auto& batch_size : mgx_state->power_of_two_batch_sizes) {
-    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ---- Processing batch size: " << batch_size << " ----";
+    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ---- Processing batch size: " << batch_size << " ----";
     
     // Build cache key for this batch size
     std::vector<std::int64_t> batch_shape_key;
@@ -2846,7 +2854,7 @@ static void compile_dynamic_batch_models(
     }
     auto cache_hash = make_hash(batch_shape_key);
     
-    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Shape key for batch " << batch_size << ": [" << [&]() {
+    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Shape key for batch " << batch_size << ": [" << [&]() {
                          std::ostringstream ss;
                          for (size_t i = 0; i < batch_shape_key.size(); ++i) {
                            if (i > 0) ss << ", ";
@@ -2854,32 +2862,32 @@ static void compile_dynamic_batch_models(
                          }
                          return ss.str();
                        }() << "]";
-    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Cache hash: " << cache_hash;
+    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Cache hash: " << cache_hash;
     
     // Check if already cached
     if (mgx_state->cached_programs_ref.has_value()) {
       auto& cached_progs = mgx_state->cached_programs_ref.value().get();
-      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Checking in-memory cache (size: " 
+      LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Checking in-memory cache (size: " 
                          << cached_progs.size() << ")";
       if (cached_progs.find(cache_hash) != cached_progs.end()) {
-        LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ✓ Batch size " << batch_size 
+        LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ✓ Batch size " << batch_size 
                           << " already in memory cache, skipping";
         continue;
       }
-      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Cache miss - need to compile/load";
+      LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Cache miss - need to compile/load";
     }
     
     // Build cache file path
     std::filesystem::path batch_cache_file;
     if (!model_cache_path.empty()) {
       batch_cache_file = model_cache_path / (mxr_filename_prefix + cache_hash + ".mxr");
-      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Disk cache file: " << batch_cache_file.string();
+      LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Disk cache file: " << batch_cache_file.string();
     } else {
-      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] No disk cache path configured";
+      LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] No disk cache path configured";
     }
     
     // Compile or load the model for this batch size
-    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Calling load_or_compile_model for batch " << batch_size;
+    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Calling load_or_compile_model for batch " << batch_size;
     migraphx::program batch_prog = load_or_compile_model(
         batch_cache_file,
         mgx_state->onnx_string,
@@ -2902,24 +2910,24 @@ static void compile_dynamic_batch_models(
     // Store in cache
     if (mgx_state->cached_programs_ref.has_value()) {
       mgx_state->cached_programs_ref.value().get()[cache_hash] = batch_prog;
-      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ✓ Stored program for batch size " << batch_size 
+      LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ✓ Stored program for batch size " << batch_size 
                          << " in memory cache with hash " << cache_hash;
-      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Memory cache now contains " 
+      LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Memory cache now contains " 
                          << mgx_state->cached_programs_ref.value().get().size() << " programs";
     }
   }
   
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ==== All power-of-two batch models compiled and cached ====";
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Setting max_dynamic_batch to 0 to disable future compilation";
+  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ==== All power-of-two batch models compiled and cached ====";
+  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Setting max_dynamic_batch to 0 to disable future compilation";
   
   // Disable dynamic batch compilation for subsequent runs (set max_dynamic_batch to 0)
   mgx_state->max_dynamic_batch = 0;
   
   // Also disable defer_compilation since we've now compiled
   mgx_state->defer_compilation = false;
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Set defer_compilation = false";
+  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Set defer_compilation = false";
   
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ==== EXITING compile_dynamic_batch_models ====";
+  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ==== EXITING compile_dynamic_batch_models ====";
 }
 
 // Standard path: Shape checking, potential recompilation, and execution
@@ -2934,10 +2942,10 @@ static void execute_standard_path(
     const std::filesystem::path& model_path,
     const std::string& mxr_filename_prefix)
 {
-  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] ==== ENTERING execute_standard_path ====";
-  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] current_hash = " << current_hash;
-  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] has_dynamic_batch = " << mgx_state->has_dynamic_batch;
-  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] max_dynamic_batch = " << mgx_state->max_dynamic_batch;
+  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] ==== ENTERING execute_standard_path ====";
+  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] current_hash = " << current_hash;
+  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] has_dynamic_batch = " << mgx_state->has_dynamic_batch;
+  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] max_dynamic_batch = " << mgx_state->max_dynamic_batch;
   
   auto& prog = mgx_state->prog;
   auto& cmp_options = mgx_state->options;
@@ -2945,19 +2953,19 @@ static void execute_standard_path(
 
   // Check if this is the first run with dynamic batch enabled
   if (mgx_state->has_dynamic_batch && mgx_state->max_dynamic_batch > 0) {
-    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] *** FIRST RUN DETECTED ***";
-    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] max_dynamic_batch=" 
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] *** FIRST RUN DETECTED ***";
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] max_dynamic_batch=" 
                        << mgx_state->max_dynamic_batch;
-    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Initiating compilation of all power-of-two batch models";
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Initiating compilation of all power-of-two batch models";
     
     // Compile all power-of-two batch models
     compile_dynamic_batch_models(mgx_state, model_cache_path, model_path, mxr_filename_prefix, ctx);
     
-    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Compilation complete, max_dynamic_batch now = " 
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Compilation complete, max_dynamic_batch now = " 
                        << mgx_state->max_dynamic_batch;
-    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Proceeding with normal execution using closest power-of-two batch";
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Proceeding with normal execution using closest power-of-two batch";
   } else if (mgx_state->has_dynamic_batch) {
-    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Dynamic batch enabled but max_dynamic_batch = 0 (already compiled)";
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Dynamic batch enabled but max_dynamic_batch = 0 (already compiled)";
   }
 
   // Extract current batch size from first input
@@ -2966,7 +2974,7 @@ static void execute_standard_path(
   bool needs_padding = false;
   
   if (mgx_state->has_dynamic_batch && !mgx_state->power_of_two_batch_sizes.empty()) {
-    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Checking for batch padding requirements";
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Checking for batch padding requirements";
     // Get the batch size from the first input
     for (const auto& [name, index] : map_input_name_index) {
       auto input_tensor = ctx.GetInput(index);
@@ -2978,9 +2986,9 @@ static void execute_standard_path(
                                                             mgx_state->power_of_two_batch_sizes);
         needs_padding = (padded_batch_size > original_batch_size);
         
-        LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Original batch size: " << original_batch_size;
-        LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Padded batch size: " << padded_batch_size;
-        LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Needs padding: " << (needs_padding ? "YES" : "NO");
+        LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Original batch size: " << original_batch_size;
+        LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Padded batch size: " << padded_batch_size;
+        LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Needs padding: " << (needs_padding ? "YES" : "NO");
         break;  // Only need batch size from first input
       }
     }
@@ -2989,9 +2997,9 @@ static void execute_standard_path(
     // Even when batch size matches exactly, we still use cached compiled programs
     if (padded_batch_size > 0) {
       if (needs_padding) {
-        LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Building padded shape key for cache lookup (needs padding)";
+        LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Building padded shape key for cache lookup (needs padding)";
       } else {
-        LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Building shape key for cache lookup (exact match, no padding)";
+        LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Building shape key for cache lookup (exact match, no padding)";
       }
       // Update the shape hash and all_input_shapes to use the padded batch size
       std::vector<std::int64_t> padded_shapes;
@@ -3012,15 +3020,15 @@ static void execute_standard_path(
       
       // Look up the cached program for the padded batch size
       auto padded_hash = make_hash(padded_shapes);
-      LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Padded shape hash: " << padded_hash;
+      LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Padded shape hash: " << padded_hash;
       
       if (mgx_state->cached_programs_ref.has_value()) {
         auto& cached_progs = mgx_state->cached_programs_ref.value().get();
-        LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Searching in memory cache (size: " 
+        LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Searching in memory cache (size: " 
                           << cached_progs.size() << ")";
         auto prog_it = cached_progs.find(padded_hash);
         if (prog_it != cached_progs.end()) {
-          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] ✓✓✓ CACHE HIT for batch size " 
+          LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] ✓✓✓ CACHE HIT for batch size " 
                              << padded_batch_size << (needs_padding ? " (will pad)" : " (exact match, no padding)");
           prog = prog_it->second;
           
@@ -3028,12 +3036,12 @@ static void execute_standard_path(
           auto param_shapes = prog.get_parameter_shapes();
           auto output_shapes = prog.get_output_shapes();
           
-          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Cached program param_shapes.size()=" 
+          LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Cached program param_shapes.size()=" 
                                << param_shapes.size() << ", output_shapes.size()=" << output_shapes.size();
           
           if (needs_padding) {
             // ============ PADDING PATH: Batch size needs to be padded ============
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Taking PADDING path";
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Taking PADDING path";
             
             // Populate caches (with slicing info so ultra-fast path is disabled)
             populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index,
@@ -3053,7 +3061,7 @@ static void execute_standard_path(
                 padded_shapes.insert(padded_shapes.end(), tensor_shape.begin() + 1, tensor_shape.end());
               }
             }
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Rebuilt padded_shapes in cached_inputs order";
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Rebuilt padded_shapes in cached_inputs order";
             
             // Allocate and pad inputs for dynamic batching
             void* rocm_stream_ptr;
@@ -3063,19 +3071,19 @@ static void execute_standard_path(
                                                                padded_batch_size, rocm_stream);
             
             // Bind inputs and outputs with temporary output buffers (for slicing)
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Calling handle_program_input_outputs with needs_slicing=true";
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] param_shapes.size()=" << param_shapes.size()
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Calling handle_program_input_outputs with needs_slicing=true";
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] param_shapes.size()=" << param_shapes.size()
                                  << ", output_shapes.size()=" << output_shapes.size();
             std::vector<void*> temp_output_buffers;
             auto [m, prog_output_indices] = handle_program_input_outputs(
                 param_shapes, output_shapes, map_input_name_index, ctx, true, &temp_output_buffers);
             
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] handle_program_input_outputs returned:";
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch]   prog_output_indices.size()=" << prog_output_indices.size();
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch]   temp_output_buffers.size()=" << temp_output_buffers.size();
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] handle_program_input_outputs returned:";
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch]   prog_output_indices.size()=" << prog_output_indices.size();
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch]   temp_output_buffers.size()=" << temp_output_buffers.size();
             if (!prog_output_indices.empty()) {
-              LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch]   ⚠️  WARNING: prog_output_indices is NOT empty!";
-              LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch]   ⚠️  This means outputs were pre-allocated instead of using temp buffers!";
+              LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch]   ⚠️  WARNING: prog_output_indices is NOT empty!";
+              LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch]   ⚠️  This means outputs were pre-allocated instead of using temp buffers!";
             }
             
             mgx_state->cached_prog_params = m;
@@ -3086,7 +3094,7 @@ static void execute_standard_path(
             
             // Rebind padded inputs to program parameters
             if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
-              LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Rebinding padded input buffers";
+              LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Rebinding padded input buffers";
               for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
                 const auto& inp = mgx_state->cached_inputs[i];
                 const auto& padded_buf = mgx_state->padded_input_buffers[i];
@@ -3094,7 +3102,7 @@ static void execute_standard_path(
               }
             }
             
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Running with output slicing enabled";
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Running with output slicing enabled";
             // Run with slicing enabled
             run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, 
                                 prog_output_indices, original_batch_size, padded_batch_size);
@@ -3108,10 +3116,12 @@ static void execute_standard_path(
             
             // NOTE: Padded buffers are kept for reuse - they will be freed when batch size changes
             // or when the state is destroyed
+            
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] ==== EXITING execute_standard_path (padded path) ====";
             return;
           } else {
             // ============ EXACT MATCH PATH: Batch size matches exactly, no padding needed ============
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Taking EXACT MATCH path (no padding/slicing)";
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Taking EXACT MATCH path (no padding/slicing)";
             
             // Populate caches for ultra-fast path (no slicing needed)
             populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
@@ -3120,8 +3130,8 @@ static void execute_standard_path(
             auto [m, prog_output_indices] = handle_program_input_outputs(
                 param_shapes, output_shapes, map_input_name_index, ctx);
             
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] handle_program_input_outputs returned:";
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch]   prog_output_indices.size()=" << prog_output_indices.size();
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] handle_program_input_outputs returned:";
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch]   prog_output_indices.size()=" << prog_output_indices.size();
             
             // Complete cache population
             mgx_state->cached_prog_params = m;
@@ -3130,37 +3140,37 @@ static void execute_standard_path(
             // IMPORTANT: Build last_input_shapes_raw in cached_inputs order (MIGraphX parameter order)
             // This ensures ultra-fast path shape comparison uses consistent ordering
             mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(mgx_state, ctx, 0);
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Built last_input_shapes_raw in cached_inputs order, size=" 
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Built last_input_shapes_raw in cached_inputs order, size=" 
                                   << mgx_state->last_input_shapes_raw.size();
             
             mgx_state->last_input_shape_hash = current_hash;
             mgx_state->caches_valid = true;
             
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] Running program (exact batch match, no padding/slicing)";
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Running program (exact batch match, no padding/slicing)";
             run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, prog_output_indices, 
                                 0, 0);  // Pass 0,0 for batch sizes to indicate no slicing needed
             
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] ==== EXITING execute_standard_path (exact match path) ====";
+            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] ==== EXITING execute_standard_path (exact match path) ====";
             return;
           }
         } else {
-          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] ✗✗✗ CACHE MISS for hash " 
+          LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] ✗✗✗ CACHE MISS for hash " 
                                 << padded_hash;
-          LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] This shouldn't happen - expected batch "
+          LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] This shouldn't happen - expected batch "
                                 << padded_batch_size << " to be pre-compiled";
         }
       }
     }
   }
 
-  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] Proceeding with normal shape checking";
+  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] Proceeding with normal shape checking";
   auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
       mgx_state->defer_compilation, map_input_name_index, ctx, cmp_options, prog);
 
-  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] input_shape_match = " << input_shape_match;
+  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] input_shape_match = " << input_shape_match;
   
   if (!input_shape_match) {
-    LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] Shape mismatch detected - recompiling";
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] Shape mismatch detected - recompiling";
     // Invalidate caches before recompilation
     mgx_state->caches_valid = false;
 
@@ -3194,16 +3204,16 @@ static void execute_standard_path(
   // IMPORTANT: Build last_input_shapes_raw in cached_inputs order (MIGraphX parameter order)
   // This ensures ultra-fast path shape comparison uses consistent ordering
   mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(mgx_state, ctx, 0);
-  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] Built last_input_shapes_raw in cached_inputs order, size=" 
+  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] Built last_input_shapes_raw in cached_inputs order, size=" 
                         << mgx_state->last_input_shapes_raw.size();
   
   mgx_state->last_input_shape_hash = current_hash;
   mgx_state->caches_valid = true;
 
-  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] Running program (no padding/slicing)";
+  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] Running program (no padding/slicing)";
   run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, prog_output_indices, 
                       original_batch_size, padded_batch_size);
-  LOGS_DEFAULT(WARNING) << "[STANDARD_PATH] ==== EXITING execute_standard_path (normal path) ====";
+  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] ==== EXITING execute_standard_path (normal path) ====";
 }
 
 // Build MIGraphX ONNX options with default shapes for symbolic dimensions
@@ -3372,18 +3382,18 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       Ort::KernelContext ctx(context);
       MIGraphXFuncState* mgx_state = reinterpret_cast<MIGraphXFuncState*>(state);
 
-      LOGS_DEFAULT(WARNING) << "======================================";
-      LOGS_DEFAULT(WARNING) << "[COMPUTE] Starting inference";
-      LOGS_DEFAULT(WARNING) << "[COMPUTE] has_dynamic_batch = " << mgx_state->has_dynamic_batch;
-      LOGS_DEFAULT(WARNING) << "[COMPUTE] max_dynamic_batch = " << mgx_state->max_dynamic_batch;
-      LOGS_DEFAULT(WARNING) << "[COMPUTE] caches_valid = " << mgx_state->caches_valid;
+      LOGS_DEFAULT(VERBOSE) << "======================================";
+      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Starting inference";
+      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] has_dynamic_batch = " << mgx_state->has_dynamic_batch;
+      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] max_dynamic_batch = " << mgx_state->max_dynamic_batch;
+      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] caches_valid = " << mgx_state->caches_valid;
       
       // Log incoming batch sizes
       const auto& map_input_name_index = mgx_state->input_name_indexes;
-      LOGS_DEFAULT(WARNING) << "[COMPUTE] Incoming input shapes:";
+      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Incoming input shapes:";
       for (const auto& [name, index] : map_input_name_index) {
         const auto& shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
-        LOGS_DEFAULT(WARNING) << "[COMPUTE]   '" << name << "': [" << [&]() {
+        LOGS_DEFAULT(VERBOSE) << "[COMPUTE]   '" << name << "': [" << [&]() {
           std::ostringstream ss;
           for (size_t i = 0; i < shape.size(); ++i) {
             if (i > 0) ss << ", ";
@@ -3396,18 +3406,18 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       // ═══════════════════════════════════════════════════════════════════════
       // ULTRA-FAST PATH: Shapes unchanged from last run
       // ═══════════════════════════════════════════════════════════════════════
-      LOGS_DEFAULT(WARNING) << "[COMPUTE] Trying ULTRA-FAST PATH...";
+      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Trying ULTRA-FAST PATH...";
       if (execute_ultra_fast_path(mgx_state, api, context, ctx)) {
-        LOGS_DEFAULT(WARNING) << "[COMPUTE] ✓ ULTRA-FAST PATH executed successfully";
-        LOGS_DEFAULT(WARNING) << "======================================";
+        LOGS_DEFAULT(VERBOSE) << "[COMPUTE] ✓ ULTRA-FAST PATH executed successfully";
+        LOGS_DEFAULT(VERBOSE) << "======================================";
         return Status::OK();
       }
-      LOGS_DEFAULT(WARNING) << "[COMPUTE] Ultra-fast path not taken";
+      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Ultra-fast path not taken";
 
       // ═══════════════════════════════════════════════════════════════════════
       // Build input shape hash - only computed when shapes change
       // ═══════════════════════════════════════════════════════════════════════
-      LOGS_DEFAULT(WARNING) << "[COMPUTE] Building input shape hash...";
+      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Building input shape hash...";
       std::vector<std::int64_t> all_input_shapes;
       all_input_shapes.reserve(map_input_name_index.size() * 4);
       for (const auto& [name, index] : map_input_name_index) {
@@ -3415,28 +3425,28 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         all_input_shapes.insert(all_input_shapes.end(), shape.begin(), shape.end());
       }
       const auto current_hash = make_hash(all_input_shapes);
-      LOGS_DEFAULT(WARNING) << "[COMPUTE] Current shape hash: " << current_hash;
+      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Current shape hash: " << current_hash;
 
       // ═══════════════════════════════════════════════════════════════════════
       // FAST PATH: Check cached programs for this shape hash
       // ═══════════════════════════════════════════════════════════════════════
-      LOGS_DEFAULT(WARNING) << "[COMPUTE] Trying FAST PATH...";
+      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Trying FAST PATH...";
       if (execute_fast_path(mgx_state, api, context, ctx, current_hash, all_input_shapes)) {
-        LOGS_DEFAULT(WARNING) << "[COMPUTE] ✓ FAST PATH executed successfully";
-        LOGS_DEFAULT(WARNING) << "======================================";
+        LOGS_DEFAULT(VERBOSE) << "[COMPUTE] ✓ FAST PATH executed successfully";
+        LOGS_DEFAULT(VERBOSE) << "======================================";
         return Status::OK();
       }
-      LOGS_DEFAULT(WARNING) << "[COMPUTE] Fast path not taken";
+      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Fast path not taken";
 
       // ═══════════════════════════════════════════════════════════════════════
       // STANDARD PATH: Shape checking and potential recompilation
       // ═══════════════════════════════════════════════════════════════════════
-      LOGS_DEFAULT(WARNING) << "[COMPUTE] Taking STANDARD PATH...";
+      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] Taking STANDARD PATH...";
       execute_standard_path(mgx_state, api, context, ctx, current_hash, std::move(all_input_shapes),
                             model_cache_path_, model_path_, mxr_filename_prefix);
 
-      LOGS_DEFAULT(WARNING) << "[COMPUTE] ✓ STANDARD PATH complete";
-      LOGS_DEFAULT(WARNING) << "======================================";
+      LOGS_DEFAULT(VERBOSE) << "[COMPUTE] ✓ STANDARD PATH complete";
+      LOGS_DEFAULT(VERBOSE) << "======================================";
       return Status::OK();
     };
     node_compute_funcs.push_back(compute_info);

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -2199,7 +2199,47 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       const SymbolicDimsMap& symbolic_dims = mgx_state->symbolic_dims;
       bool prog_has_dynamic_batch = mgx_state->prog_has_dynamic_batch;
 
-      // Process input shapes and determine if recompilation is needed
+      // Fast path: If program has dynamic batch and we have a cached program for the current batch size,
+      // use it directly without going through shape comparison and recompilation
+      if (prog_has_dynamic_batch && !defer_compilation && mgx_state->batched_programs_ref.has_value()) {
+        // Get current batch size from first input
+        std::size_t current_batch_size = 0;
+        if (!map_input_name_index.empty()) {
+          auto first_input = map_input_name_index.begin();
+          auto input_tensor = ctx.GetInput(first_input->second);
+          auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+          const auto tensor_shape = tensor_info.GetShape();
+          if (!tensor_shape.empty()) {
+            current_batch_size = static_cast<std::size_t>(tensor_shape[0]);
+          }
+        }
+
+        // Check if we have a cached program for this batch size
+        if (current_batch_size > 0) {
+          auto& batched_programs = mgx_state->batched_programs_ref.value().get();
+          auto it = batched_programs.find(current_batch_size);
+          if (it != batched_programs.end()) {
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Fast path: Found cached program for batch size " << current_batch_size;
+
+            // Use the cached program directly
+            migraphx::program& cached_prog = it->second;
+            auto param_shapes = cached_prog.get_parameter_shapes();
+
+            // Bind inputs and allocate outputs for the cached program
+            auto [m, prog_output_indices] = handle_program_input_outputs(param_shapes, map_input_name_index, ctx, cached_prog);
+
+            // Run the cached program
+            run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, cached_prog, m, prog_output_indices);
+
+            return Status::OK();
+          } else {
+            LOGS_DEFAULT(VERBOSE) << "[Compute] No cached program for batch size " << current_batch_size
+                                  << ", falling back to standard path";
+          }
+        }
+      }
+
+      // Standard path: Process input shapes and determine if recompilation is needed
       // Using fine-grained symbolic dimension tracking for more precise shape matching
       auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
           defer_compilation, symbolic_dims, prog_has_dynamic_batch, map_input_name_index, ctx, cmp_options, prog);

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1646,14 +1646,12 @@ static void handle_input_shape_mismatch(
     migraphx::program_parameter_shapes& param_shapes,
     std::vector<std::int64_t>& input_shapes)
 {
-  LOGS_DEFAULT(VERBOSE) << "[Compute] Input shape mismatch detected, initiating recompilation";
-
   // Extract references from mgx_state for convenience
   auto& prog = mgx_state->prog;
   auto& cmp_options = mgx_state->options;
   const auto& map_input_name_index = mgx_state->input_name_indexes;
 
-  // Build cache key from ALL inputs (not just symbolic ones)
+  // Build cache key from all inputs in map_input_name_index (already filtered to model inputs only)
   std::vector<std::int64_t> all_input_shapes;
   for (const auto& it : map_input_name_index) {
     auto input_tensor = ctx.GetInput(it.second);
@@ -1668,14 +1666,9 @@ static void handle_input_shape_mismatch(
     auto& cached_progs = mgx_state->cached_programs_ref.value().get();
     auto it = cached_progs.find(cache_hash);
     if (it != cached_progs.end()) {
-      LOGS_DEFAULT(VERBOSE) << "[Compute] Found hash " << cache_hash
-                         << " in in-memory cached_programs - using cached program";
       prog = it->second;
       param_shapes = prog.get_parameter_shapes();
       return;  // Early exit - no need to load from disk or compile
-    } else {
-      LOGS_DEFAULT(VERBOSE) << "[Compute] Hash " << cache_hash
-                         << " not in in-memory cache, checking disk cache";
     }
   }
 
@@ -1740,8 +1733,6 @@ static void handle_input_shape_mismatch(
   // Store the compiled/loaded program in the in-memory cached_programs cache
   if (mgx_state->cached_programs_ref.has_value()) {
     mgx_state->cached_programs_ref.value().get()[cache_hash] = prog;
-    LOGS_DEFAULT(VERBOSE) << "[Compute] Stored program for hash " << cache_hash
-                          << " in in-memory cached_programs cache";
   }
 
   param_shapes = prog.get_parameter_shapes();
@@ -1852,11 +1843,10 @@ static InputShapeResult handle_input_shape(
 
   if (defer_compilation) {
     LOGS_DEFAULT(VERBOSE) << "[Compute] No static input shapes available, setting from runtime inputs";
-    // NOTE: map_input_name_index only contains actual runtime inputs, not constants/initializers
+    // NOTE: map_input_name_index only contains actual model inputs, not constants/initializers
     // Constants and initializers are embedded in the graph and MIGraphX infers their shapes
     LOGS_DEFAULT(VERBOSE) << "[Compute] Setting shapes for " << map_input_name_index.size()
-                          << " runtime input parameters (excluding constants)";
-
+                          << " model input parameters (excluding constants)";
 
     for (const auto& it : map_input_name_index) {
       const auto& name = it.first;
@@ -1867,11 +1857,10 @@ static InputShapeResult handle_input_shape(
       std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
 
       // Override default batch size with incoming batch size and treat as static
-      // Only for actual input parameters - constants are handled by MIGraphX
       cmp_options.set_input_parameter_shape(name, ort_lens);
       input_shape_match = false;
 
-      // Include ALL inputs in cache key for hash calculation
+      // Include all inputs in cache key (map_input_name_index already filtered to model inputs only)
       input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
     }
     LOGS_DEFAULT(VERBOSE) << "[Compute] All runtime input shapes set as static parameters in MIGraphX options";
@@ -1907,7 +1896,7 @@ static InputShapeResult handle_input_shape(
             input_shape_match = false;
           }
 
-          // Include ALL inputs in cache key for hash calculation
+          // Include all inputs in cache key (map_input_name_index already filtered to model inputs only)
           input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
         }
       }
@@ -1965,13 +1954,21 @@ static migraphx::onnx_options get_program_parameter_options(
 }
 
 // Build a map from input parameter name to index
+// If model_input_names is provided, only includes inputs that are in that set (excludes weights/constants)
 template <typename Container>
-static std::unordered_map<std::string, std::size_t> get_input_name_map(const Container& input_defs) {
+static std::unordered_map<std::string, std::size_t> get_input_name_map(
+    const Container& input_defs,
+    const std::set<std::string>* model_input_names = nullptr) {
   std::unordered_map<std::string, std::size_t> input_name_index;
   input_name_index.reserve(input_defs.size());
   std::size_t i = 0;
   for (const auto& def : input_defs) {
-    input_name_index[def->Name()] = i++;
+    const auto& name = def->Name();
+    // Only include if it's a model input parameter (skip weights/constants)
+    if (model_input_names == nullptr || model_input_names->count(name) > 0) {
+      input_name_index[name] = i;
+    }
+    ++i;  // Always increment index to maintain correct ORT input indices
   }
   return input_name_index;
 }
@@ -1988,19 +1985,24 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     std::filesystem::path model_cache_file;
     auto mxr_filename_prefix = to_hex(MIGraphX_Version) + "-" + GenerateGraphId(graph_body_viewer) + "-" + make_hash(std::string_view(device_prop_.gcnArchName)) + "-";
 
-    // Get model input names (only first layer)
+    // Get model input names (only first layer) - these are actual model inputs, not weights/constants
     const Graph* cur_graph = &graph_body_viewer.GetGraph();
     while (cur_graph->IsSubgraph()) {
       cur_graph = cur_graph->ParentGraph();
     }
     const Graph& main_graph = *cur_graph;
     const auto& input_tensor = main_graph.GetInputs();
+    std::set<std::string>& node_session_input_names = map_session_input_names_[fused_node.Name()];
     for (auto i : input_tensor) {
-      session_input_names.insert(i->Name());
+      node_session_input_names.insert(i->Name());
     }
+    LOGS_DEFAULT(VERBOSE) << "[Compile] Node '" << fused_node.Name() << "' has "
+                          << node_session_input_names.size() << " model input parameters (excluding weights/constants)";
 
-
-    auto input_name_index = get_input_name_map(fused_node.InputDefs());
+    // Build input name to index map, only for model input parameters (excludes weights/constants)
+    auto input_name_index = get_input_name_map(fused_node.InputDefs(), &node_session_input_names);
+    LOGS_DEFAULT(VERBOSE) << "[Compile] input_name_index has " << input_name_index.size()
+                          << " entries (model inputs only)";
 
     auto model = graph_body_viewer.CreateModel(*GetLogger());
     auto model_proto = model->ToProto();
@@ -2066,7 +2068,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
       // Fast path: If compilation is not deferred and we have cached programs, check for a match
       if (!mgx_state->defer_compilation && mgx_state->cached_programs_ref.has_value()) {
-        // Build cache key from ALL inputs
+        // Build cache key from all inputs in map_input_name_index (already filtered to model inputs only)
         std::vector<std::int64_t> all_input_shapes;
         for (const auto& it : map_input_name_index) {
           auto input_tensor = ctx.GetInput(it.second);
@@ -2077,10 +2079,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
         auto cache_hash = make_hash(all_input_shapes);
         auto& cached_programs = mgx_state->cached_programs_ref.value().get();
+
         auto it = cached_programs.find(cache_hash);
         if (it != cached_programs.end()) {
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Fast path: Found cached program for hash " << cache_hash;
-
           // Use the cached program directly
           migraphx::program& cached_prog = it->second;
           auto param_shapes = cached_prog.get_parameter_shapes();
@@ -2092,14 +2093,10 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, cached_prog, m, prog_output_indices);
 
           return Status::OK();
-        } else {
-          LOGS_DEFAULT(VERBOSE) << "[Compute] No cached program for hash " << cache_hash
-                                << ", falling back to standard path";
         }
       }
 
       // Standard path: Process input shapes and determine if recompilation is needed
-      // Using fine-grained symbolic dimension tracking for more precise shape matching
       auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
           mgx_state->defer_compilation, map_input_name_index, ctx, cmp_options, prog);
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -2267,16 +2267,33 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
       // Fast path: If program has dynamic batch and we have a cached program for the current batch size,
       // use it directly without going through shape comparison and recompilation
-      /* if (prog_has_dynamic_batch && mgx_state->max_dynamic_batch > 0 && mgx_state->batched_programs_ref.has_value()) {
-        // Get current batch size from first input
+      if (prog_has_dynamic_batch && mgx_state->batched_programs_ref.has_value()) {
+        // Get current batch size from an input with symbolic batch dimension (dim 0)
+        // This ensures we use the actual dynamic batch input, not weight tensors
         std::size_t current_batch_size = 0;
-        if (!map_input_name_index.empty()) {
-          auto first_input = map_input_name_index.begin();
-          auto input_tensor = ctx.GetInput(first_input->second);
-          auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-          const auto tensor_shape = tensor_info.GetShape();
-          if (!tensor_shape.empty() && tensor_shape[0] == ) {
-            current_batch_size = static_cast<std::size_t>(tensor_shape[0]);
+        for (const auto& it : map_input_name_index) {
+          const auto& name = it.first;
+
+          // Check if this input has a symbolic batch dimension (dim 0)
+          auto sym_it = symbolic_dims.find(name);
+          if (sym_it != symbolic_dims.end()) {
+            bool has_dynamic_batch = false;
+            for (const auto& sym_dim : sym_it->second) {
+              if (sym_dim.dim_index == 0) {
+                has_dynamic_batch = true;
+                break;
+              }
+            }
+
+            if (has_dynamic_batch) {
+              auto input_tensor = ctx.GetInput(it.second);
+              auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+              const auto tensor_shape = tensor_info.GetShape();
+              if (!tensor_shape.empty()) {
+                current_batch_size = static_cast<std::size_t>(tensor_shape[0]);
+                break;  // Use first dynamic batch input found
+              }
+            }
           }
         }
 
@@ -2303,7 +2320,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
                                   << ", falling back to standard path";
           }
         }
-      } */
+      }
 
       // Standard path: Process input shapes and determine if recompilation is needed
       // Using fine-grained symbolic dimension tracking for more precise shape matching

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -751,7 +751,7 @@ std::unique_ptr<IndexedSubGraph> MIGraphXExecutionProvider::GetSubGraph(const st
 
         if (target_op_type == "If" || target_op_type == "Loop" || target_op_type == "Scan") {
           const auto& src_output_idx = it->GetSrcArgIndex();
-          if (src_output_idx < node->OutputDefs().size()) {
+          if (static_cast<std::size_t>(src_output_idx) < node->OutputDefs().size()) {
             const auto* output_def = node->OutputDefs()[src_output_idx];
             if (output_def && fused_outputs.find(output_def) == fused_outputs.end() && erased.find(output_def) == erased.end()) {
               fused_outputs_to_add[output_def] = output_order++;
@@ -2274,7 +2274,6 @@ static bool execute_ultra_fast_path(
   std::size_t original_batch_size = 0;
   std::size_t padded_batch_size = 0;
   bool is_first = true;
-  int input_idx = 0;
 
   for (const auto& inp : mgx_state->cached_inputs) {
     const auto& shape = ctx.GetInput(inp.ort_index).GetTensorTypeAndShapeInfo().GetShape();
@@ -2306,7 +2305,7 @@ static bool execute_ultra_fast_path(
       }
       
       // All current inputs should have the same batch size (original_batch_size)
-      if (shape[0] != original_batch_size) {
+      if (static_cast<std::size_t>(shape[0]) != original_batch_size) {
         shapes_match = false;
         break;
       }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1238,6 +1238,102 @@ InputOutputNamesResult get_input_output_names(const GraphViewer& graph,
   return {defer_compilation, prog_has_dynamic_batch, std::move(symbolic_dims)};
 }
 
+// Result structure for check_for_symbolic_dims
+struct SymbolicDimsCheckResult {
+  std::vector<std::int64_t> input_shapes;  // Shapes for cache key hash calculation
+  bool has_symbolic_dims;                   // True if any symbolic dimensions found
+  bool symbolic_batch_dim;                  // True if batch dimension (dim 0) is symbolic for any input
+};
+
+// Check input tensors for symbolic dimensions and build shape vector for cache key generation
+// Returns input shapes suitable for hash calculation and whether symbolic dims were found
+static SymbolicDimsCheckResult check_for_symbolic_dims(
+    const std::vector<const NodeArg*>& input_tensor,
+    const std::set<std::string>& session_input_names,
+    int64_t default_batch_size = 1)
+{
+  std::vector<std::int64_t> input_shapes;
+  bool has_symbolic_dims = false;
+  // Track if ALL inputs have symbolic batch dimension (starts true, set false if any concrete batch found)
+  bool all_batch_dims_symbolic = !session_input_names.empty();
+
+  for (std::size_t i = 0; i < session_input_names.size(); ++i) {
+    auto tensor_shape = input_tensor[i]->Shape();
+
+    // Check for symbolic dimensions and handle them
+    if (tensor_shape == nullptr || tensor_shape->dim_size() == 0) {
+      LOGS_DEFAULT(WARNING) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                            << ") has no shape information";
+      has_symbolic_dims = true;
+      // No shape info implies batch is also unknown - keeps all_batch_dims_symbolic as true for this input
+      continue;
+    }
+
+    // Handle batch dimension (first dimension) specially
+    if (tensor_shape->dim_size() > 0) {
+      const auto& batch_dim = tensor_shape->dim(0);
+      int64_t batch_size_to_use = default_batch_size;
+
+      if (batch_dim.has_dim_value()) {
+        batch_size_to_use = batch_dim.dim_value();
+        // Found a concrete batch dimension - not all batch dims are symbolic
+        all_batch_dims_symbolic = false;
+        LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                              << ") batch size: " << batch_size_to_use;
+      } else if (batch_dim.has_dim_param()) {
+        // Symbolic batch dimension - default to 1
+        has_symbolic_dims = true;
+        LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                              << ") batch size is symbolic: " << batch_dim.dim_param()
+                              << ", defaulting to " << default_batch_size;
+      } else {
+        // Unknown batch dimension - default to 1
+        has_symbolic_dims = true;
+        LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                              << ") batch size is unknown, defaulting to " << default_batch_size;
+      }
+
+      // Add batch size to input shapes for hash calculation
+      input_shapes.push_back(batch_size_to_use);
+    }
+
+    // Process all dimensions (skip batch dimension at j=0, start at j=1)
+    for (int j = 1; j < tensor_shape->dim_size(); ++j) {
+      const auto& dim = tensor_shape->dim(j);
+
+      // Handle symbolic dimensions
+      if (dim.has_dim_param()) {
+        LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                              << ") dimension " << j << " is symbolic: " << dim.dim_param();
+        has_symbolic_dims = true;
+        // Use -1 as placeholder for symbolic dimensions in hash calculation
+        input_shapes.push_back(-1);
+      } else if (dim.has_dim_value()) {
+        auto dim_val = dim.dim_value();
+        input_shapes.push_back(dim_val);
+        LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                              << ") dimension " << j << " value: " << dim_val;
+      } else {
+        LOGS_DEFAULT(WARNING) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
+                              << ") dimension " << j << " has no value or param";
+        has_symbolic_dims = true;
+      }
+    }
+  }
+
+  if (has_symbolic_dims) {
+    LOGS_DEFAULT(WARNING) << "[Compile] Model has symbolic dimensions, "
+                          << "dynamic batch dimensions defaulted to " << default_batch_size
+                          << " (will be overridden at runtime if needed)";
+  }
+
+  if (all_batch_dims_symbolic) {
+    LOGS_DEFAULT(VERBOSE) << "[Compile] All inputs have symbolic batch dimension";
+  }
+
+  return {std::move(input_shapes), has_symbolic_dims, all_batch_dims_symbolic};
+}
+
 // Attempt to load a model and catch any exceptions on load fail.
 // Useful to default to EP to trigger the compile if file doesn't exist or loading fails.
 bool load_precompiled_model(migraphx::program& prog, const std::filesystem::path& path) try {
@@ -1921,78 +2017,10 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       session_input_names.insert(i->Name());
     }
 
+    constexpr std::size_t default_batch_size = 1;
     // empty cache path means the MXR caching is disabled - always compile
     if (!model_cache_path_.empty() or first_start_) {
-      std::vector<std::int64_t> input_shapes;
-      bool has_symbolic_dims = false;
-      constexpr int64_t default_batch_size = 1;
-
-      for (std::size_t i = 0; i < session_input_names.size(); ++i) {
-        auto tensor_shape = input_tensor[i]->Shape();
-
-        // Check for symbolic dimensions and handle them
-        if (tensor_shape == nullptr || tensor_shape->dim_size() == 0) {
-          LOGS_DEFAULT(WARNING) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                                << ") has no shape information";
-          has_symbolic_dims = true;
-          continue;
-        }
-
-        // Handle batch dimension (first dimension) specially
-        if (tensor_shape->dim_size() > 0) {
-          const auto& batch_dim = tensor_shape->dim(0);
-          int64_t batch_size_to_use = default_batch_size;
-
-          if (batch_dim.has_dim_value()) {
-            batch_size_to_use = batch_dim.dim_value();
-            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                                  << ") batch size: " << batch_size_to_use;
-          } else if (batch_dim.has_dim_param()) {
-            // Symbolic batch dimension - default to 1
-            has_symbolic_dims = true;
-            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                                  << ") batch size is symbolic: " << batch_dim.dim_param()
-                                  << ", defaulting to " << default_batch_size;
-          } else {
-            // Unknown batch dimension - default to 1
-            has_symbolic_dims = true;
-            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                                  << ") batch size is unknown, defaulting to " << default_batch_size;
-          }
-
-          // Add batch size to input shapes for hash calculation
-          input_shapes.push_back(batch_size_to_use);
-        }
-
-        // Process all dimensions (skip batch dimension at j=0, start at j=1)
-        for (int j = 1; j < tensor_shape->dim_size(); ++j) {
-          const auto& dim = tensor_shape->dim(j);
-
-          // Handle symbolic dimensions
-          if (dim.has_dim_param()) {
-            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                                  << ") dimension " << j << " is symbolic: " << dim.dim_param();
-            has_symbolic_dims = true;
-            // Use -1 as placeholder for symbolic dimensions in hash calculation
-            input_shapes.push_back(-1);
-          } else if (dim.has_dim_value()) {
-            auto dim_val = dim.dim_value();
-            input_shapes.push_back(dim_val);
-            LOGS_DEFAULT(VERBOSE) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                                  << ") dimension " << j << " value: " << dim_val;
-          } else {
-            LOGS_DEFAULT(WARNING) << "[Compile] Input " << i << " (" << input_tensor[i]->Name()
-                                  << ") dimension " << j << " has no value or param";
-            has_symbolic_dims = true;
-          }
-        }
-      }
-
-      if (has_symbolic_dims) {
-        LOGS_DEFAULT(WARNING) << "[Compile] Model has symbolic dimensions, "
-                              << "dynamic batch dimensions defaulted to " << default_batch_size
-                              << " (will be overridden at runtime if needed)";
-      }
+      auto [input_shapes, has_symbolic_dims, symbolic_batch_dim] = check_for_symbolic_dims(input_tensor, session_input_names, default_batch_size);
 
       if (!input_shapes.empty()) {
         model_cache_file = model_cache_path_ / (mxr_filename_prefix + make_hash(input_shapes) + ".mxr");
@@ -2029,7 +2057,6 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     // Set default batch size for symbolic dimensions in onnx_options
     // NOTE: Only set shapes for actual model inputs, NOT for constants or initializers
     // MIGraphX will automatically infer shapes for constants and intermediate tensors
-    constexpr std::size_t default_batch_size = 1;
     if (defer_compilation) {
       LOGS_DEFAULT(VERBOSE) << "[Compile] Setting default batch size of " << default_batch_size
                             << " for model input parameters (excluding constants)";

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1622,7 +1622,7 @@ static void run_migraphx_program(
 
       // Log output batch size for tracking
       if (!ort_shape.empty()) {
-        LOGS_DEFAULT(INFO) << "[Compute] Output " << i << " batch size: " << ort_shape[0];
+        LOGS_DEFAULT(VERBOSE) << "[Compute] Output " << i << " batch size: " << ort_shape[0];
       }
 
       HIP_CALL_THROW(hipMemcpyWithStream(output_data,
@@ -1752,6 +1752,17 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
   std::vector<std::size_t> prog_output_indices;
   auto prog_output_shapes = prog.get_output_shapes();
 
+  auto compute_output_index = [](const std::string_view sv) -> int {
+    constexpr std::string_view out_name_prefix = "#output_";
+    const auto pos = sv.find(out_name_prefix);
+    if (pos == std::string_view::npos) {
+      return -1;
+    }
+
+    const auto index_str = sv.substr(pos + out_name_prefix.length());
+    return ToInteger(Trim(index_str, std::isdigit));
+  };
+
   if (param_shapes.size() > 0) {
     for (auto&& name : param_shapes.names()) {
       if (map_input_name_index.count(name) > 0) {
@@ -1775,17 +1786,6 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
       }
       // It is an output argument
       else {
-        auto compute_output_index = [](const std::string_view sv) -> int {
-          constexpr std::string_view out_name_prefix = "#output_";
-          const auto pos = sv.find(out_name_prefix);
-          if (pos == std::string_view::npos) {
-            return -1;
-          }
-
-          const auto index_str = sv.substr(pos + out_name_prefix.length());
-          return ToInteger(Trim(index_str, std::isdigit));
-        };
-
         int output_index = compute_output_index(name);
         if (output_index != -1) {
           prog_output_indices.push_back(static_cast<std::size_t>(output_index));

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -154,7 +154,8 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
       metadef_id_generator_{ModelMetadefIdGenerator::Create()},
       external_alloc_{info.external_alloc},
       external_free_{info.external_free},
-      external_empty_cache_{info.external_empty_cache} {
+      external_empty_cache_{info.external_empty_cache},
+      max_dynamic_batch_{info.max_dynamic_batch} {
   InitProviderOrtApi();
 
   // Set GPU device to be used and read device properties for feature usage.
@@ -237,7 +238,8 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
                         << "\n " << migraphx_provider_option::kInt8CalibTable << ": " << int8_calibration_table_name_
                         << "\n int8_calibration_cache_available: " << int8_calibration_cache_available_
                         << "\n " << migraphx_provider_option::kInt8UseNativeCalibTable << ": " << int8_use_native_calibration_table_
-                        << "\n " << migraphx_provider_option::kModelCacheDir << ": " << model_cache_path_;
+                        << "\n " << migraphx_provider_option::kModelCacheDir << ": " << model_cache_path_
+                        << "\n " << migraphx_provider_option::kModelMaxDynamicBatch << ": " << max_dynamic_batch_;
 }
 
 std::vector<AllocatorPtr> MIGraphXExecutionProvider::CreatePreferredAllocators() {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1513,11 +1513,23 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         LOGS_DEFAULT(VERBOSE) << "[Compile] Cache hit! Loaded precompiled model from: " << model_cache_file.string();
       }
 
+      // Log output shapes to verify they match the input batch size
       auto prog_output_shapes = prog.get_output_shapes();
+      LOGS_DEFAULT(VERBOSE) << "[Compile] Compiled model has " << prog_output_shapes.size() << " outputs:";
       for (std::size_t i = 0; i < prog_output_shapes.size(); ++i) {
-        auto out_len = prog_output_shapes[i].lengths();
-        options.set_input_parameter_shape(output_names[i], out_len);
+        auto out_lens = prog_output_shapes[i].lengths();
+        std::ostringstream ss;
+        ss << "[";
+        for (size_t j = 0; j < out_lens.size(); ++j) {
+          if (j > 0) ss << ", ";
+          ss << out_lens[j];
+        }
+        ss << "]";
+        LOGS_DEFAULT(VERBOSE) << "[Compile] Output " << i << " shape: " << ss.str()
+                              << (out_lens.size() > 0 ? " (batch=" + std::to_string(out_lens[0]) + ")" : "");
       }
+      // NOTE: DO NOT set output shapes as input parameters!
+      // Outputs are dynamically inferred by MIGraphX based on input shapes
     } else {
       LOGS_DEFAULT(VERBOSE) << "[Compile] Deferring compilation until runtime (no static input shapes available)";
       LOGS_DEFAULT(VERBOSE) << "[Compile] Will use default batch size of 1, then recompile with actual batch at runtime";
@@ -1814,6 +1826,21 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       migraphx::program_parameters m;
       auto prog_output_shapes = prog.get_output_shapes();
       std::vector<std::size_t> prog_output_indices;
+
+      // Log the output shapes from the compiled program to verify they match input batch
+      LOGS_DEFAULT(VERBOSE) << "[Compute] Program has " << prog_output_shapes.size() << " outputs:";
+      for (std::size_t i = 0; i < prog_output_shapes.size(); ++i) {
+        auto out_lens = prog_output_shapes[i].lengths();
+        std::ostringstream ss;
+        ss << "[";
+        for (size_t j = 0; j < out_lens.size(); ++j) {
+          if (j > 0) ss << ", ";
+          ss << out_lens[j];
+        }
+        ss << "]";
+        LOGS_DEFAULT(VERBOSE) << "[Compute] Program output " << i << " shape: " << ss.str();
+      }
+
       if (param_shapes.size() > 0) {
         for (auto&& name : param_shapes.names()) {
           if (map_input_name_index.count(name) > 0) {
@@ -1860,7 +1887,16 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
               // Log output batch size for tracking
               if (!ort_output_shape.empty()) {
                 LOGS_DEFAULT(VERBOSE) << "[Compute] Output " << output_index << " ('" << name
-                                      << "') batch size: " << ort_output_shape[0];
+                                      << "') allocated with shape: ["
+                                      << [&]() {
+                                          std::ostringstream ss;
+                                          for (size_t j = 0; j < ort_output_shape.size(); ++j) {
+                                            if (j > 0) ss << ", ";
+                                            ss << ort_output_shape[j];
+                                          }
+                                          return ss.str();
+                                        }() << "]";
+                LOGS_DEFAULT(VERBOSE) << "[Compute] Output " << output_index << " batch size: " << ort_output_shape[0];
               }
 
               // argument shape
@@ -1877,7 +1913,24 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
         void* rocm_stream;
         Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &rocm_stream));
+        LOGS_DEFAULT(VERBOSE) << "[Compute] Executing MIGraphX program...";
         auto prog_outputs = prog.run_async(m, static_cast<hipStream_t>(rocm_stream));
+        LOGS_DEFAULT(VERBOSE) << "[Compute] Execution complete, got " << prog_outputs.size() << " outputs";
+
+        // Verify actual output shapes match expectations
+        for (std::size_t i = 0; i < prog_outputs.size(); ++i) {
+          auto actual_shape = prog_outputs[i].get_shape();
+          auto actual_lens = actual_shape.lengths();
+          std::ostringstream ss;
+          ss << "[";
+          for (size_t j = 0; j < actual_lens.size(); ++j) {
+            if (j > 0) ss << ", ";
+            ss << actual_lens[j];
+          }
+          ss << "]";
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Actual output " << i << " shape after execution: " << ss.str()
+                                << (actual_lens.size() > 0 ? " (batch=" + std::to_string(actual_lens[0]) + ")" : "");
+        }
 
         // In case of input parameters are reused as output parameter call hipMemcpy
         auto output_num = prog_outputs.size();

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1419,27 +1419,9 @@ static void run_migraphx_program(
 
   // lock to avoid race condition
   std::lock_guard<std::mutex> lock(*mgx_mu_ptr);
-
   void* rocm_stream;
   Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &rocm_stream));
-  LOGS_DEFAULT(INFO) << "[Compute] Executing MIGraphX program...";
   auto prog_outputs = prog.run_async(m, static_cast<hipStream_t>(rocm_stream));
-  LOGS_DEFAULT(INFO) << "[Compute] Execution complete, got " << prog_outputs.size() << " outputs";
-
-  // Verify actual output shapes match expectations
-  for (std::size_t i = 0; i < prog_outputs.size(); ++i) {
-    auto actual_shape = prog_outputs[i].get_shape();
-    auto actual_lens = actual_shape.lengths();
-    std::ostringstream ss;
-    ss << "[";
-    for (size_t j = 0; j < actual_lens.size(); ++j) {
-      if (j > 0) ss << ", ";
-      ss << actual_lens[j];
-    }
-    ss << "]";
-    LOGS_DEFAULT(INFO) << "[Compute] Actual output " << i << " shape after execution: " << ss.str()
-                          << (actual_lens.size() > 0 ? " (batch=" + std::to_string(actual_lens[0]) + ")" : "");
-  }
 
   // In case of input parameters are reused as output parameter call hipMemcpy
   auto output_num = prog_outputs.size();
@@ -1480,7 +1462,7 @@ static void handle_input_shape_mismatch(
     migraphx::program_parameter_shapes& param_shapes,
     std::vector<std::int64_t>& input_shapes)
 {
-  LOGS_DEFAULT(INFO) << "[Compute] Input shape mismatch detected, initiating recompilation";
+  LOGS_DEFAULT(VERBOSE) << "[Compute] Input shape mismatch detected, initiating recompilation";
 
   // Extract references from mgx_state for convenience
   auto& prog = mgx_state->prog;
@@ -1504,13 +1486,13 @@ static void handle_input_shape_mismatch(
     auto& batched_progs = mgx_state->batched_programs_ref.value().get();
     auto it = batched_progs.find(current_batch_size);
     if (it != batched_progs.end()) {
-      LOGS_DEFAULT(INFO) << "[Compute] Found batch size " << current_batch_size
+      LOGS_DEFAULT(VERBOSE) << "[Compute] Found batch size " << current_batch_size
                          << " in in-memory batched_programs cache - using cached program";
       prog = it->second;
         param_shapes = prog.get_parameter_shapes();
       return;  // Early exit - no need to load from disk or compile
     } else {
-      LOGS_DEFAULT(INFO) << "[Compute] Batch size " << current_batch_size
+      LOGS_DEFAULT(VERBOSE) << "[Compute] Batch size " << current_batch_size
                          << " not in in-memory cache, checking disk cache";
     }
   }
@@ -1539,18 +1521,18 @@ static void handle_input_shape_mismatch(
       shapes_str << input_shapes[i];
     }
     shapes_str << "]";
-    LOGS_DEFAULT(INFO) << "[Compute] Cache key input shapes (including updated batch): " << shapes_str.str();
+    LOGS_DEFAULT(VERBOSE) << "[Compute] Cache key input shapes (including updated batch): " << shapes_str.str();
 
     auto cache_hash = make_hash(input_shapes);
     model_cache_file = mgx_state->model_cache_dir / (mxr_filename_prefix + cache_hash + ".mxr");
-    LOGS_DEFAULT(INFO) << "[Compute] Cache file with batch-aware hash: " << model_cache_file.string();
+    LOGS_DEFAULT(VERBOSE) << "[Compute] Cache file with batch-aware hash: " << model_cache_file.string();
   }
 
   if (!load_precompiled_model(prog, model_cache_file)) {
-    LOGS_DEFAULT(INFO) << "[Compute] Cache miss. Compiling model with updated batch size";
+    LOGS_DEFAULT(VERBOSE) << "[Compute] Cache miss. Compiling model with updated batch size";
 
     // Set input parameter shapes from runtime tensors before compilation
-    LOGS_DEFAULT(INFO) << "[Compute] Setting " << map_input_name_index.size()
+    LOGS_DEFAULT(VERBOSE) << "[Compute] Setting " << map_input_name_index.size()
                           << " input parameter shapes as static in MIGraphX options (excluding constants)";
 
     for (const auto& it : map_input_name_index) {
@@ -1562,7 +1544,7 @@ static void handle_input_shape_mismatch(
       std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
       cmp_options.set_input_parameter_shape(name, ort_lens);
 
-      LOGS_DEFAULT(INFO) << "[Compute] Set static shape for input parameter '" << name << "': ["
+      LOGS_DEFAULT(VERBOSE) << "[Compute] Set static shape for input parameter '" << name << "': ["
                             << [&]() {
                                 std::ostringstream ss;
                                 for (size_t i = 0; i < ort_lens.size(); ++i) {
@@ -1591,17 +1573,17 @@ static void handle_input_shape_mismatch(
         &map_input_name_index);
 
     // Save compiled model with batch-aware filename
-    LOGS_DEFAULT(INFO) << "[Compute] Saving compiled model with updated batch size to: "
+    LOGS_DEFAULT(VERBOSE) << "[Compute] Saving compiled model with updated batch size to: "
                           << model_cache_file.string();
     save_compiled_model(prog, model_cache_file);
   } else {
-    LOGS_DEFAULT(INFO) << "[Compute] Cache hit! Loaded precompiled model with matching batch size";
+    LOGS_DEFAULT(VERBOSE) << "[Compute] Cache hit! Loaded precompiled model with matching batch size";
   }
 
   // Store the compiled/loaded program in the in-memory batched_programs cache
   if (mgx_state->batched_programs_ref.has_value() && current_batch_size > 0) {
     mgx_state->batched_programs_ref.value().get()[current_batch_size] = prog;
-    LOGS_DEFAULT(INFO) << "[Compute] Stored program for batch size " << current_batch_size
+    LOGS_DEFAULT(VERBOSE) << "[Compute] Stored program for batch size " << current_batch_size
                        << " in in-memory batched_programs cache";
   }
 
@@ -1667,7 +1649,7 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
 
           // Log output batch size for tracking
           if (!ort_output_shape.empty()) {
-            LOGS_DEFAULT(INFO) << "[Compute] Output " << output_index << " ('" << name
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Output " << output_index << " ('" << name
                                   << "') allocated with shape: ["
                                   << [&]() {
                                       std::ostringstream ss;
@@ -1677,7 +1659,7 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
                                       }
                                       return ss.str();
                                     }() << "]";
-            LOGS_DEFAULT(INFO) << "[Compute] Output " << output_index << " batch size: " << ort_output_shape[0];
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Output " << output_index << " batch size: " << ort_output_shape[0];
           }
 
           // argument shape
@@ -1711,10 +1693,10 @@ static InputShapeResult handle_input_shape(
   std::vector<std::int64_t> input_shapes;
 
   if (no_input_shape) {
-    LOGS_DEFAULT(INFO) << "[Compute] No static input shapes available, setting from runtime inputs";
+    LOGS_DEFAULT(VERBOSE) << "[Compute] No static input shapes available, setting from runtime inputs";
     // NOTE: map_input_name_index only contains actual runtime inputs, not constants/initializers
     // Constants and initializers are embedded in the graph and MIGraphX infers their shapes
-    LOGS_DEFAULT(INFO) << "[Compute] Setting shapes for " << map_input_name_index.size()
+    LOGS_DEFAULT(VERBOSE) << "[Compute] Setting shapes for " << map_input_name_index.size()
                           << " runtime input parameters (excluding constants)";
 
     for (const auto& it : map_input_name_index) {
@@ -1735,7 +1717,7 @@ static InputShapeResult handle_input_shape(
 
       // Log batch size and full shape for tracking dynamic shapes
       if (!tensor_shape.empty()) {
-        LOGS_DEFAULT(INFO) << "[Compute] Input parameter '" << name
+        LOGS_DEFAULT(VERBOSE) << "[Compute] Input parameter '" << name
                               << "' batch size (runtime override): " << tensor_shape[0];
 
         std::ostringstream shape_str;
@@ -1745,11 +1727,11 @@ static InputShapeResult handle_input_shape(
           shape_str << tensor_shape[i];
         }
         shape_str << "]";
-        LOGS_DEFAULT(INFO) << "[Compute] Input parameter '" << name << "' set as static shape: " << shape_str.str();
+        LOGS_DEFAULT(VERBOSE) << "[Compute] Input parameter '" << name << "' set as static shape: " << shape_str.str();
       }
     }
-    LOGS_DEFAULT(INFO) << "[Compute] All runtime input shapes set as static parameters in MIGraphX options";
-    LOGS_DEFAULT(INFO) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
+    LOGS_DEFAULT(VERBOSE) << "[Compute] All runtime input shapes set as static parameters in MIGraphX options";
+    LOGS_DEFAULT(VERBOSE) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
   } else {
     LOGS_DEFAULT(VERBOSE) << "Assigning inputs, and parameters from compiled model";
     param_shapes = prog.get_parameter_shapes();
@@ -1776,13 +1758,13 @@ static InputShapeResult handle_input_shape(
 
           // Check if shapes match
           if (mgx_lens != ort_lens) {
-            LOGS_DEFAULT(INFO) << "[Compute] Shape mismatch for input '" << name
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Shape mismatch for input '" << name
                                   << "': MIGraphX expects [" << mgx_lens.size() << " dims], "
                                   << "got [" << ort_lens.size() << " dims]";
 
             // Check if it's specifically a batch size change
             if (mgx_lens.size() == ort_lens.size() && mgx_lens.size() > 0 && mgx_lens[0] != ort_lens[0]) {
-              LOGS_DEFAULT(INFO) << "[Compute] Batch size changed from " << mgx_lens[0]
+              LOGS_DEFAULT(VERBOSE) << "[Compute] Batch size changed from " << mgx_lens[0]
                                     << " to " << ort_lens[0] << " for input '" << name << "'";
             }
 
@@ -1793,7 +1775,7 @@ static InputShapeResult handle_input_shape(
 
           // Log batch size and full shape for tracking
           if (!tensor_shape.empty()) {
-            LOGS_DEFAULT(INFO) << "[Compute] Input '" << name << "' batch size: " << tensor_shape[0];
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' batch size: " << tensor_shape[0];
 
             // Log full shape for debugging symbolic dimensions
             std::ostringstream shape_str;
@@ -1803,7 +1785,7 @@ static InputShapeResult handle_input_shape(
               shape_str << tensor_shape[i];
             }
             shape_str << "]";
-            LOGS_DEFAULT(INFO) << "[Compute] Input '" << name << "' full shape: " << shape_str.str();
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' full shape: " << shape_str.str();
           }
         }
       }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1192,13 +1192,10 @@ static bool inputs_have_dynamic_dims(const GraphViewer& graph) {
 }
 
 // Get input and output names from the graph
-static void get_io_names(const GraphViewer& graph,
-                         std::vector<std::string>& input_names,
-                         std::vector<std::string>& output_names) {
-  input_names.clear();
-  output_names.clear();
-
+static std::pair<std::vector<std::string>, std::vector<std::string>> get_io_names(const GraphViewer& graph) {
   const auto& input_args = graph.GetInputs();
+  std::vector<std::string> input_names;
+  input_names.reserve(input_args.size());
   for (const auto& arg : input_args) {
     if (arg != nullptr) {
       input_names.push_back(arg->Name());
@@ -1206,17 +1203,15 @@ static void get_io_names(const GraphViewer& graph,
   }
 
   const auto& out_args = graph.GetOutputs();
-  std::vector<std::string> tmp_out_names;
-  std::transform(out_args.begin(),
-                 out_args.end(),
-                 std::back_inserter(tmp_out_names),
-                 [](auto& arg) { return arg->Name(); });
+  std::vector<std::string> output_names;
+  output_names.reserve(out_args.size());
+  for (const auto& arg : out_args) {
+    if (arg != nullptr) {
+      output_names.push_back(arg->Name());
+    }
+  }
 
-  std::copy_if(
-      tmp_out_names.begin(),
-      tmp_out_names.end(),
-      std::back_inserter(output_names),
-      [&](const auto& name) { return !name.empty(); });
+  return {std::move(input_names), std::move(output_names)};
 }
 
 // Check input tensors for symbolic dimensions and build shape vector for cache key generation
@@ -2016,8 +2011,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
     dump_model_as_onnx(onnx_string_buffer, std::string{fused_node.Name() + ".onnx"});
 
-    std::vector<std::string> input_names, output_names;
-    get_io_names(graph_body_viewer, input_names, output_names);
+    // map parameter input name to index
+    auto [input_names, output_names] = get_io_names(graph_body_viewer);
 
     // Get initializers and build ONNX options with default shapes for symbolic dimensions
     const auto& initializers = graph_body_viewer.GetAllInitializedTensors();

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1340,11 +1340,32 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     // empty cache path means the MXR caching is disabled - always compile
     if (!model_cache_path_.empty()) {
       std::vector<std::int64_t> input_shapes;
-      for (std::size_t i = 0; i < session_input_names.size(); ++i) {
+
+      // Use input_tensor directly, not session_input_names.size()
+      for (std::size_t i = 0; i < input_tensor.size(); ++i) {
         auto tensor_shape = input_tensor[i]->Shape();
-        for (int j = 1; j < tensor_shape->dim_size(); ++j) {
-          input_shapes.push_back(tensor_shape->dim(j).dim_value());
+
+        // Check if shape is valid
+        if (tensor_shape == nullptr || tensor_shape->dim_size() == 0) {
+          LOGS_DEFAULT(WARNING) << "Input " << i << " has no shape information";
+          input_shapes.clear();
+          break;
         }
+
+        // Include ALL dimensions (including batch), or skip only if dim_value is 0
+        for (int j = 0; j < tensor_shape->dim_size(); ++j) {
+          if (tensor_shape->dim(j).has_dim_value()) {
+            auto dim_val = tensor_shape->dim(j).dim_value();
+            if (dim_val > 0) {  // Only add valid dimensions
+              input_shapes.push_back(dim_val);
+            }
+          }
+        }
+      }
+
+      if(input_shapes.empty())
+      {
+        LOGS_DEFAULT(WARNING) << "Input shapes are empty, skipping model caching";
       }
       model_cache_file = model_cache_path_ / (mxr_filename_prefix + make_hash(input_shapes) + ".mxr");
     }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1271,6 +1271,7 @@ static void pad_input_tensor(const void* src_data, void* dst_data,
 
 // Allocate padded input buffers and pad the data for dynamic batching
 // Returns true if padding was applied, false otherwise
+// OPTIMIZATION: Reuses existing buffers if padded batch size matches
 static bool allocate_and_pad_inputs(
     MIGraphXFuncState* mgx_state,
     Ort::KernelContext& ctx,
@@ -1282,7 +1283,79 @@ static bool allocate_and_pad_inputs(
     return false;  // No padding needed
   }
   
-  LOGS_DEFAULT(WARNING) << "[allocate_and_pad_inputs] Allocating and padding inputs: original=" 
+  // ═══════════════════════════════════════════════════════════════════════════
+  // OPTIMIZATION: Check if we can reuse existing padded buffers
+  // ═══════════════════════════════════════════════════════════════════════════
+  bool can_reuse_buffers = (
+      mgx_state->last_padded_batch_size == padded_batch_size &&
+      !mgx_state->padded_input_buffers.empty() &&
+      mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()
+  );
+  
+  if (can_reuse_buffers) {
+    LOGS_DEFAULT(VERBOSE) << "[allocate_and_pad_inputs] ✓✓✓ REUSING existing padded buffers "
+                          << "(original=" << original_batch_size << ", padded=" << padded_batch_size << ")";
+    
+    // Just copy new data into existing buffers - skip allocation
+    for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
+      const auto& cached_inp = mgx_state->cached_inputs[i];
+      auto input_tensor = ctx.GetInput(cached_inp.ort_index);
+      auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+      const auto tensor_shape = tensor_info.GetShape();
+      
+      if (tensor_shape.empty()) continue;
+      
+      auto& padded_buf = mgx_state->padded_input_buffers[i];
+      
+      // Calculate elements per batch
+      std::size_t elements_per_batch = 1;
+      for (std::size_t j = 1; j < tensor_shape.size(); ++j) {
+        elements_per_batch *= tensor_shape[j];
+      }
+      
+      // Calculate element size from tensor type
+      std::size_t element_size_bytes;
+      switch (tensor_info.GetElementType()) {
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+          element_size_bytes = sizeof(float);
+          break;
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+          element_size_bytes = sizeof(uint16_t);
+          break;
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+          element_size_bytes = sizeof(int64_t);
+          break;
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
+          element_size_bytes = sizeof(int32_t);
+          break;
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
+          element_size_bytes = sizeof(int16_t);
+          break;
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:
+          element_size_bytes = sizeof(int8_t);
+          break;
+        default:
+          element_size_bytes = sizeof(float);  // Fallback to float
+          break;
+      }
+      
+      // Reuse existing buffer - just pad with new data
+      const void* original_data = input_tensor.GetTensorRawData();
+      pad_input_tensor(original_data, padded_buf.data, original_batch_size, padded_batch_size,
+                      element_size_bytes, elements_per_batch, stream);
+    }
+    
+    // Update original batch tracking (padded batch is already correct)
+    mgx_state->last_original_batch_size = original_batch_size;
+    
+    return true;
                         << original_batch_size << ", padded=" << padded_batch_size;
   
   // Free old buffers if they exist
@@ -1375,7 +1448,10 @@ static bool allocate_and_pad_inputs(
                          << "': " << padded_bytes << " bytes";
   }
   
-  LOGS_DEFAULT(WARNING) << "[allocate_and_pad_inputs] Allocated " 
+  // Update batch tracking
+  mgx_state->last_original_batch_size = original_batch_size;
+  mgx_state->last_padded_batch_size = padded_batch_size;
+  
                         << mgx_state->padded_input_buffers.size() << " padded buffers";
   return true;
 }
@@ -1389,6 +1465,10 @@ static void free_padded_inputs(MIGraphXFuncState* mgx_state) {
     }
   }
   mgx_state->padded_input_buffers.clear();
+  
+  // Clear batch tracking when freeing buffers
+  mgx_state->last_original_batch_size = 0;
+  mgx_state->last_padded_batch_size = 0;
 }
 
 // Order matters here especially if the program uses mixed quantization
@@ -2400,10 +2480,8 @@ static bool execute_ultra_fast_path(
                        mgx_state->cached_prog_output_indices,
                        original_batch_size, padded_batch_size);
   
-  // Free padded buffers after execution
-  if (using_padded_inputs) {
-    free_padded_inputs(mgx_state);
-  }
+  // NOTE: Padded buffers are kept for reuse - they will be freed when batch size changes
+  // or when the state is destroyed
   
   return true;
 }
@@ -2597,12 +2675,9 @@ static bool execute_fast_path(
     }
   }
   
-  // Free padded buffers after execution
-  if (using_padded_inputs) {
-    free_padded_inputs(mgx_state);
-  }
+  // NOTE: Padded buffers are kept for reuse - they will be freed when batch size changes
+  // or when the state is destroyed
   
-  LOGS_DEFAULT(WARNING) << "[FAST_PATH] Complete";
   return true;
 }
 
@@ -3031,12 +3106,8 @@ static void execute_standard_path(
               }
             }
             
-            // Free padded buffers after execution
-            if (using_padded_inputs) {
-              free_padded_inputs(mgx_state);
-            }
-            
-            LOGS_DEFAULT(WARNING) << "[STANDARD_PATH][DynamicBatch] ==== EXITING execute_standard_path (padded path) ====";
+            // NOTE: Padded buffers are kept for reuse - they will be freed when batch size changes
+            // or when the state is destroyed
             return;
           } else {
             // ============ EXACT MATCH PATH: Batch size matches exactly, no padding needed ============

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1440,11 +1440,23 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     no_input_shape = no_input_shape || get_input_output_names(graph_body_viewer, input_names, output_names);
 
     // Set default batch size for symbolic dimensions in onnx_options
+    // NOTE: Only set shapes for actual model inputs, NOT for constants or initializers
+    // MIGraphX will automatically infer shapes for constants and intermediate tensors
     constexpr std::size_t default_batch_size = 1;
     if (no_input_shape) {
       LOGS_DEFAULT(VERBOSE) << "[Compile] Setting default batch size of " << default_batch_size
-                            << " for inputs with symbolic dimensions";
+                            << " for model input parameters (excluding constants)";
+
+      // Get initializers to filter them out
+      const auto& initializers = graph_body_viewer.GetAllInitializedTensors();
+
       for (std::size_t i = 0; i < input_names.size(); ++i) {
+        // Skip if this is an initializer/constant - let MIGraphX infer its shape
+        if (initializers.count(input_names[i]) > 0) {
+          LOGS_DEFAULT(VERBOSE) << "[Compile] Skipping '" << input_names[i] << "' (initializer/constant)";
+          continue;
+        }
+
         if (i < input_tensor.size()) {
           auto tensor_shape = input_tensor[i]->Shape();
           if (tensor_shape != nullptr && tensor_shape->dim_size() > 0) {
@@ -1459,18 +1471,19 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
                 // Symbolic or unknown dimension - use default batch size for dim 0, 1 for others
                 has_symbolic = true;
                 default_shape.push_back(j == 0 ? default_batch_size : 1);
-                LOGS_DEFAULT(VERBOSE) << "[Compile] Input '" << input_names[i]
+                LOGS_DEFAULT(VERBOSE) << "[Compile] Input parameter '" << input_names[i]
                                       << "' dimension " << j << " is symbolic, using default";
               }
             }
 
             if (has_symbolic && !default_shape.empty()) {
               options.set_input_parameter_shape(input_names[i], default_shape);
-              LOGS_DEFAULT(VERBOSE) << "[Compile] Set default shape for '" << input_names[i] << "'";
+              LOGS_DEFAULT(VERBOSE) << "[Compile] Set default shape for input parameter '" << input_names[i] << "'";
             }
           }
         }
       }
+      LOGS_DEFAULT(VERBOSE) << "[Compile] Constants and initializers will have shapes inferred by MIGraphX";
     }
 
     // by parsing the model_proto, create a program corresponding to
@@ -1558,6 +1571,11 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
       if (no_input_shape) {
         LOGS_DEFAULT(VERBOSE) << "[Compute] No static input shapes available, setting from runtime inputs";
+        // NOTE: map_input_name_index only contains actual runtime inputs, not constants/initializers
+        // Constants and initializers are embedded in the graph and MIGraphX infers their shapes
+        LOGS_DEFAULT(VERBOSE) << "[Compute] Setting shapes for " << map_input_name_index.size()
+                              << " runtime input parameters (excluding constants)";
+
         for (auto& it : map_input_name_index) {
           auto& name = it.first;
           auto& index = it.second;
@@ -1567,6 +1585,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
 
           // Override default batch size with incoming batch size and treat as static
+          // Only for actual input parameters - constants are handled by MIGraphX
           cmp_options.set_input_parameter_shape(name, ort_lens);
           input_shape_match = false;
 
@@ -1575,7 +1594,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
           // Log batch size and full shape for tracking dynamic shapes
           if (!tensor_shape.empty()) {
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Input parameter '" << name
                                   << "' batch size (runtime override): " << tensor_shape[0];
 
             std::ostringstream shape_str;
@@ -1585,10 +1604,11 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
               shape_str << tensor_shape[i];
             }
             shape_str << "]";
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Input '" << name << "' set as static shape: " << shape_str.str();
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Input parameter '" << name << "' set as static shape: " << shape_str.str();
           }
         }
-        LOGS_DEFAULT(VERBOSE) << "[Compute] All runtime shapes set as static parameters in MIGraphX options";
+        LOGS_DEFAULT(VERBOSE) << "[Compute] All runtime input shapes set as static parameters in MIGraphX options";
+        LOGS_DEFAULT(VERBOSE) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
       } else {
         LOGS_DEFAULT(VERBOSE) << "Assigning inputs, and parameters from compiled model";
         param_shapes = prog.get_parameter_shapes();
@@ -1689,9 +1709,13 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         if (!load_precompiled_model(prog, model_cache_file)) {
           LOGS_DEFAULT(VERBOSE) << "[Compute] Cache miss. Compiling model with updated batch size";
 
-          // CRITICAL: Ensure ALL input shapes are explicitly set as static shapes in cmp_options
+          // CRITICAL: Ensure ALL input parameter shapes are explicitly set as static shapes in cmp_options
           // This must be done BEFORE parsing to treat dynamic shapes as static for compilation
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Setting all input shapes as static in MIGraphX options";
+          // NOTE: Only set shapes for actual runtime input parameters, NOT for constants/initializers
+          // MIGraphX will automatically infer shapes for constants and intermediate tensors
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Setting " << map_input_name_index.size()
+                                << " input parameter shapes as static in MIGraphX options (excluding constants)";
+
           for (auto& it : map_input_name_index) {
             auto& name = it.first;
             auto& index = it.second;
@@ -1701,9 +1725,10 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
 
             // Set shape as static parameter for MIGraphX compilation
+            // Only for actual input parameters - constants/initializers are handled by MIGraphX
             cmp_options.set_input_parameter_shape(name, ort_lens);
 
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Set static shape for '" << name << "': ["
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Set static shape for input parameter '" << name << "': ["
                                   << [&]() {
                                       std::ostringstream ss;
                                       for (size_t i = 0; i < ort_lens.size(); ++i) {
@@ -1713,20 +1738,22 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
                                       return ss.str();
                                     }() << "]";
           }
-          LOGS_DEFAULT(VERBOSE) << "[Compute] All input shapes set as static parameters";
+          LOGS_DEFAULT(VERBOSE) << "[Compute] All input parameter shapes set as static";
+          LOGS_DEFAULT(VERBOSE) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
 
 #ifndef ENABLE_TRAINING_CORE
 #ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
           cmp_options.set_external_data_path(model_path_.parent_path().string());
 #endif
 #endif
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Parsing ONNX buffer with static shapes";
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Parsing ONNX buffer with static input shapes";
           prog = migraphx::parse_onnx_buffer(onnx_string, cmp_options);
           LOGS_DEFAULT(VERBOSE) << "[Compute] ONNX parsing complete";
 
-          // Verify that MIGraphX parsed with correct shapes
+          // Verify that MIGraphX parsed with correct shapes for input parameters
           auto parsed_param_shapes = prog.get_parameter_shapes();
-          LOGS_DEFAULT(VERBOSE) << "[Compute] Verifying parsed parameter shapes:";
+          LOGS_DEFAULT(VERBOSE) << "[Compute] Verifying parsed parameter shapes ("
+                                << parsed_param_shapes.size() << " total parameters):";
           for (auto&& param_name : parsed_param_shapes.names()) {
             auto shape = parsed_param_shapes[param_name];
             auto lens = shape.lengths();
@@ -1737,7 +1764,11 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
               ss << lens[i];
             }
             ss << "]";
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Parameter '" << param_name << "' parsed shape: " << ss.str();
+
+            // Distinguish between input parameters we set and constants MIGraphX inferred
+            bool is_input_param = (map_input_name_index.count(param_name) > 0);
+            LOGS_DEFAULT(VERBOSE) << "[Compute] Parameter '" << param_name << "' parsed shape: " << ss.str()
+                                  << (is_input_param ? " (input parameter)" : " (constant/internal)");
           }
 
           migraphx::program_parameters quant_params;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1312,6 +1312,86 @@ std::string make_hash(const char* v) {
   return make_hash(std::string_view{v});
 }
 
+// Helper: Compile a single program with specific batch size for all inputs
+migraphx::program CompileProgramWithBatch(
+  const std::string& onnx_string,
+  const std::vector<std::string>& input_names,
+  const std::vector<std::vector<std::int64_t>>& all_input_base_shapes,
+  size_t batch_size,
+  migraphx::onnx_options options,
+  const migraphx::target& t,
+  bool fp16_enable,
+  bool bf16_enable,
+  bool int8_enable,
+  bool fp8_enable,
+  bool int8_calibration_cache_available,
+  std::unordered_map<std::string, float>& dynamic_range_map,
+  bool exhaustive_tune,
+  const std::filesystem::path& model_path)
+{
+
+  LOGS_DEFAULT(VERBOSE) << "[CompileBatch] Compiling for batch size: " << batch_size;
+
+  // Set input shapes with the specified batch size for ALL inputs
+  for (size_t i = 0; i < input_names.size() && i < all_input_base_shapes.size(); ++i) {
+    std::vector<std::size_t> shape_with_batch;
+    shape_with_batch.push_back(batch_size);
+    for (auto dim : all_input_base_shapes[i]) {
+      shape_with_batch.push_back(static_cast<std::size_t>(dim));
+    }
+    options.set_input_parameter_shape(input_names[i], shape_with_batch);
+
+    std::ostringstream ss;
+    ss << "[";
+    for (size_t j = 0; j < shape_with_batch.size(); ++j) {
+      if (j > 0) ss << ", ";
+      ss << shape_with_batch[j];
+    }
+    ss << "]";
+    LOGS_DEFAULT(VERBOSE) << "[CompileBatch] Input '" << input_names[i] << "' shape: " << ss.str();
+  }
+
+  #ifndef ENABLE_TRAINING_CORE
+  #ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
+  if (!model_path.empty()) {
+    options.set_external_data_path(model_path.parent_path().string());
+  }
+  #endif
+  #endif
+
+  migraphx::program prog = migraphx::parse_onnx_buffer(onnx_string, options);
+  migraphx::program_parameters quant_params;
+
+  if ((int8_enable ^ fp8_enable) && int8_calibration_cache_available) {
+    auto local_param_shapes = prog.get_parameter_shapes();
+    // Add input parameter data and the values they're set to
+    for (auto&& name : local_param_shapes.names()) {
+      if (map_input_name_index.count(name) > 0) {
+        auto input_tensor = ctx.GetInput(map_input_name_index[name]);
+        auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+        const auto tensor_shape = tensor_info.GetShape();
+        const auto tensor_type = tensor_info.GetElementType();
+
+        migraphx_shape_datatype_t mgx_type;
+        getMIGraphXType(tensor_type, mgx_type);
+        auto mgx_s = local_param_shapes[name];
+
+        if (mgx_type != mgx_s.type()) {
+          LOGS_DEFAULT(FATAL) << "MIGraphX: param type mismatch";
+        }
+        quant_params.add(name, migraphx::argument(local_param_shapes[name], const_cast<void*>(input_tensor.GetTensorRawData())));
+      }
+    }
+  }
+
+  calibrate_and_quantize(prog, t, quant_params, fp16_enable, bf16_enable, int8_enable,
+                        fp8_enable, int8_calibration_cache_available, dynamic_range_map);
+  compile_program(prog, t, exhaustive_tune);
+
+  LOGS_DEFAULT(VERBOSE) << "[CompileBatch] Compilation complete for batch size: " << batch_size;
+  return prog;
+}
+
 constexpr std::uint64_t MIGraphX_Version =
     ((MIGRAPHX_VERSION_MAJOR << 16) | (MIGRAPHX_VERSION_MINOR << 8) | MIGRAPHX_VERSION_PATCH);
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -38,6 +38,15 @@ constexpr auto kModelCachePath = "ORT_MIGRAPHX_MODEL_CACHE_PATH"sv;
 constexpr auto kModelMaxDynamicBatch = "ORT_MIGRAPHX_MAX_DYNAMIC_BATCH"sv;
 }  // namespace migraphx_env_vars
 
+// Tracks which dimensions are symbolic for a given input
+struct SymbolicDimInfo {
+  int dim_index;                // The dimension index (0 = batch, 1, 2, ...)
+  std::string dim_param;        // The symbolic parameter name (e.g., "batch", "sequence_length")
+};
+
+// Map from input name to its symbolic dimensions
+using SymbolicDimsMap = std::unordered_map<std::string, std::vector<SymbolicDimInfo>>;
+
 // Information to construct kernel function state.
 struct MIGraphXFuncState {
   AllocateFunc allocate_func = nullptr;
@@ -49,7 +58,7 @@ struct MIGraphXFuncState {
   migraphx::target t{};
   std::unordered_map<std::string, std::size_t> input_name_indexes;
   std::mutex* mgx_mu_ptr = nullptr;
-  bool no_input_shape = false;
+  bool defer_compilation = false;
   bool fp16_enable = false;
   bool bf16_enable = false;
   bool fp8_enable = false;
@@ -62,6 +71,10 @@ struct MIGraphXFuncState {
   size_t max_dynamic_batch;
   // Reference to the batched programs map for this node (keyed by batch size)
   std::optional<std::reference_wrapper<std::unordered_map<std::size_t, migraphx::program>>> batched_programs_ref = std::nullopt;
+  // Fine-grained tracking of which dimensions are symbolic per input
+  SymbolicDimsMap symbolic_dims;
+  // Flag indicating program has dynamic batch dimension (batch dim is symbolic for at least one input)
+  bool prog_has_dynamic_batch = false;
 };
 
 // Logical device representation.
@@ -142,9 +155,13 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   std::unordered_map<std::string, migraphx::program> map_progs_;
   std::unordered_map<std::string, std::string> map_onnx_string_;
   std::unordered_map<std::string, std::unordered_map<std::string, std::size_t>> map_input_index_;
-  std::unordered_map<std::string, bool> map_no_input_shape_;
+  std::unordered_map<std::string, bool> map_defer_compilation_;
   // Map of batched programs per node: node_name -> (batch_size -> program)
   std::unordered_map<std::string, std::unordered_map<std::size_t, migraphx::program>> batched_programs_;
+  // Fine-grained symbolic dimension tracking per node: node_name -> (input_name -> symbolic dims)
+  std::unordered_map<std::string, SymbolicDimsMap> map_symbolic_dims_;
+  // Flag indicating program has dynamic batch dimension per node
+  std::unordered_map<std::string, bool> map_prog_has_dynamic_batch_;
 
   AllocatorPtr allocator_;
   std::unique_ptr<ModelMetadefIdGenerator> metadef_id_generator_;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -68,6 +68,18 @@ struct MIGraphXFuncState {
   size_t max_dynamic_batch;
   // Reference to the cached programs map for this node (keyed by input shape hash)
   std::optional<std::reference_wrapper<std::unordered_map<std::string, migraphx::program>>> cached_programs_ref = std::nullopt;
+  
+  // Dynamic batch support
+  bool has_dynamic_batch = false;
+  std::vector<std::size_t> power_of_two_batch_sizes;
+  
+  // Padded input buffers for dynamic batching (allocated on GPU)
+  struct PaddedBuffer {
+    void* data = nullptr;          // GPU buffer pointer
+    std::size_t size_bytes = 0;    // Buffer size in bytes
+    migraphx::shape mgx_shape;     // Padded MIGraphX shape
+  };
+  std::vector<PaddedBuffer> padded_input_buffers;  // One per input when padding is active
 
   // ═══════════════════════════════════════════════════════════════════════════
   // PERFORMANCE CACHES - Avoid redundant MIGraphX API calls per inference

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -81,6 +81,10 @@ struct MIGraphXFuncState {
   };
   std::vector<PaddedBuffer> padded_input_buffers;  // One per input when padding is active
 
+  // Track last batch sizes to avoid re-allocation when batch size is unchanged
+  std::size_t last_original_batch_size = 0;  // Original batch size from last run
+  std::size_t last_padded_batch_size = 0;    // Padded batch size from last run
+
   // ═══════════════════════════════════════════════════════════════════════════
   // PERFORMANCE CACHES - Avoid redundant MIGraphX API calls per inference
   // ═══════════════════════════════════════════════════════════════════════════

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -110,7 +110,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
         {std::string{migraphx_provider_option::kGpuExternalEmptyCache}, MakeStringWithClassicLocale(external_empty_cache_)},
         {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_path_)}};
         {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(model_max_dynamic_batch_)}};
-  }
+
 
  private:
   OrtDevice::DeviceId device_id_{0};

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -33,6 +33,7 @@ constexpr auto kCachePath = "ORT_MIGRAPHX_CACHE_PATH"sv;
 constexpr auto kINT8UseNativeMIGraphXCalibrationTable = "ORT_MIGRAPHX_INT8_USE_NATIVE_CALIBRATION_TABLE"sv;
 constexpr auto kExhaustiveTune = "ORT_MIGRAPHX_EXHAUSTIVE_TUNE"sv;
 constexpr auto kModelCachePath = "ORT_MIGRAPHX_MODEL_CACHE_PATH"sv;
+constexpr auto kModelMaxDynamicBatch = "ORT_MIGRAPHX_MAX_DYNAMIC_BATCH"sv;
 }  // namespace migraphx_env_vars
 
 // Information to construct kernel function state.
@@ -56,6 +57,7 @@ struct MIGraphXFuncState {
   std::filesystem::path model_cache_dir;
   bool dump_model_ops = false;
   bool exhaustive_tune = false;
+  size_t max_dynamic_batch;
 };
 
 // Logical device representation.
@@ -107,6 +109,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
         {std::string{migraphx_provider_option::kGpuExternalFree}, MakeStringWithClassicLocale(external_free_)},
         {std::string{migraphx_provider_option::kGpuExternalEmptyCache}, MakeStringWithClassicLocale(external_empty_cache_)},
         {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_path_)}};
+        {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(model_max_dynamic_batch_)}};
   }
 
  private:

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -124,6 +124,37 @@ struct MIGraphXFuncState {
 
   // Flag indicating caches are valid
   bool caches_valid = false;
+  
+  // ═══════════════════════════════════════════════════════════════════════════
+  // OPTIMIZATION: Cached MIGraphX API results (avoid redundant API calls)
+  // ═══════════════════════════════════════════════════════════════════════════
+  
+  // Cached program parameter shapes (from prog.get_parameter_shapes())
+  std::optional<migraphx::program_parameter_shapes> cached_mgx_param_shapes;
+  
+  // Cached output shapes (from prog.get_output_shapes())
+  std::optional<migraphx::shapes> cached_mgx_output_shapes;
+  
+  // Flag indicating ultra-fast caches are populated (avoid redundant populate calls)
+  bool ultra_fast_caches_populated = false;
+  
+  // Track which program hash the cached shapes belong to (invalidate when program changes)
+  std::string cached_program_hash;
+  
+  // ═══════════════════════════════════════════════════════════════════════════
+  // OPTIMIZATION: Reusable temporary output buffers (for slicing mode)
+  // ═══════════════════════════════════════════════════════════════════════════
+  
+  // Temporary output buffers for slicing (allocated at padded size)
+  struct TempOutputBuffer {
+    void* data = nullptr;           // GPU buffer pointer
+    std::size_t size_bytes = 0;     // Buffer size in bytes
+    migraphx::shape mgx_shape;      // Padded MIGraphX shape
+  };
+  std::vector<TempOutputBuffer> temp_output_buffers;
+  
+  // Track padded batch size for temp output buffers
+  std::size_t temp_output_padded_batch_size = 0;
 };
 
 // Logical device representation.

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -68,6 +68,24 @@ struct MIGraphXFuncState {
   size_t max_dynamic_batch;
   // Reference to the cached programs map for this node (keyed by input shape hash)
   std::optional<std::reference_wrapper<std::unordered_map<std::string, migraphx::program>>> cached_programs_ref = std::nullopt;
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // PERFORMANCE CACHES - Avoid redundant MIGraphX API calls per inference
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Cached parameter shapes (invalidated on recompilation)
+  std::optional<migraphx::program_parameter_shapes> cached_param_shapes;
+  // Cached output shapes (invalidated on recompilation)
+  std::optional<migraphx::shapes> cached_output_shapes;
+  // Cached parameter names vector (avoid repeated .names() calls)
+  std::vector<std::string> cached_param_names;
+  // Cached program_parameters object for ultra-fast rebinding
+  std::optional<migraphx::program_parameters> cached_prog_params;
+  // Cached output indices for pre-allocated outputs
+  std::vector<std::size_t> cached_prog_output_indices;
+  // Last input shape hash for ultra-fast path detection
+  std::string last_input_shape_hash;
+  // Flag indicating caches are valid
+  bool caches_valid = false;
 };
 
 // Logical device representation.

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -44,9 +44,6 @@ struct SymbolicDimInfo {
   std::string dim_param;        // The symbolic parameter name (e.g., "batch", "sequence_length")
 };
 
-// Map from input name to its symbolic dimensions
-using SymbolicDimsMap = std::unordered_map<std::string, std::vector<SymbolicDimInfo>>;
-
 // Information to construct kernel function state.
 struct MIGraphXFuncState {
   AllocateFunc allocate_func = nullptr;
@@ -69,12 +66,8 @@ struct MIGraphXFuncState {
   bool dump_model_ops = false;
   bool exhaustive_tune = false;
   size_t max_dynamic_batch;
-  // Reference to the batched programs map for this node (keyed by batch size)
-  std::optional<std::reference_wrapper<std::unordered_map<std::size_t, migraphx::program>>> batched_programs_ref = std::nullopt;
-  // Fine-grained tracking of which dimensions are symbolic per input
-  SymbolicDimsMap symbolic_dims;
-  // Flag indicating program has dynamic batch dimension (batch dim is symbolic for at least one input)
-  bool prog_has_dynamic_batch = false;
+  // Reference to the cached programs map for this node (keyed by input shape hash)
+  std::optional<std::reference_wrapper<std::unordered_map<std::string, migraphx::program>>> cached_programs_ref = std::nullopt;
 };
 
 // Logical device representation.
@@ -156,12 +149,8 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   std::unordered_map<std::string, std::string> map_onnx_string_;
   std::unordered_map<std::string, std::unordered_map<std::string, std::size_t>> map_input_index_;
   std::unordered_map<std::string, bool> map_defer_compilation_;
-  // Map of batched programs per node: node_name -> (batch_size -> program)
-  std::unordered_map<std::string, std::unordered_map<std::size_t, migraphx::program>> batched_programs_;
-  // Fine-grained symbolic dimension tracking per node: node_name -> (input_name -> symbolic dims)
-  std::unordered_map<std::string, SymbolicDimsMap> map_symbolic_dims_;
-  // Flag indicating program has dynamic batch dimension per node
-  std::unordered_map<std::string, bool> map_prog_has_dynamic_batch_;
+  // Map of cached programs per node: node_name -> (input_shape_hash -> program)
+  std::unordered_map<std::string, std::unordered_map<std::string, migraphx::program>> cached_programs_;
 
   AllocatorPtr allocator_;
   std::unique_ptr<ModelMetadefIdGenerator> metadef_id_generator_;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -7,8 +7,8 @@
 #include <functional>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <optional>
+#include <semaphore>
 #include <set>
 #include <string>
 #include <string_view>
@@ -54,7 +54,7 @@ struct MIGraphXFuncState {
   migraphx::onnx_options options;
   migraphx::target t{};
   std::unordered_map<std::string, std::size_t> input_name_indexes;
-  std::mutex* mgx_mu_ptr = nullptr;
+  std::binary_semaphore* mgx_sem_ptr = nullptr;
   bool defer_compilation = false;
   bool fp16_enable = false;
   bool bf16_enable = false;
@@ -178,7 +178,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   std::unordered_map<std::string, std::set<std::string>> map_session_input_names_;
   bool dump_model_ops_ = false;
   migraphx::target t_;
-  std::mutex mgx_mu_;
+  std::binary_semaphore mgx_sem_{1};  // Initialize to 1 (available)
   hipStream_t stream_ = nullptr;
   hipDeviceProp_t device_prop_{};
   bool exhaustive_tune_ = false;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -72,18 +72,37 @@ struct MIGraphXFuncState {
   // ═══════════════════════════════════════════════════════════════════════════
   // PERFORMANCE CACHES - Avoid redundant MIGraphX API calls per inference
   // ═══════════════════════════════════════════════════════════════════════════
-  // Cached parameter shapes (invalidated on recompilation)
-  std::optional<migraphx::program_parameter_shapes> cached_param_shapes;
-  // Cached output shapes (invalidated on recompilation)
-  std::optional<migraphx::shapes> cached_output_shapes;
-  // Cached parameter names vector (avoid repeated .names() calls)
-  std::vector<std::string> cached_param_names;
+
+  // Cached input parameter info (name as const char*, ORT index, MIGraphX shape)
+  struct CachedInputParam {
+    std::string name;              // Parameter name (owns the string)
+    std::size_t ort_index;         // ORT input index
+    migraphx::shape mgx_shape;     // MIGraphX shape for this input
+  };
+
+  // Cached output parameter info (name as const char*, output index, MIGraphX shape)
+  struct CachedOutputParam {
+    std::string name;              // Parameter name (owns the string)
+    int output_index;              // ORT output index
+    migraphx::shape mgx_shape;     // MIGraphX shape for this output
+  };
+
+  // Separated input/output parameter lists for O(1) iteration without map lookups
+  std::vector<CachedInputParam> cached_inputs;
+  std::vector<CachedOutputParam> cached_outputs;
+
+  // Pre-allocated output shapes in ORT format (avoids vector allocation per inference)
+  std::vector<std::vector<int64_t>> cached_output_ort_shapes;
+
   // Cached program_parameters object for ultra-fast rebinding
   std::optional<migraphx::program_parameters> cached_prog_params;
-  // Cached output indices for pre-allocated outputs
+
+  // Cached output indices for pre-allocated outputs (used by run_migraphx_program)
   std::vector<std::size_t> cached_prog_output_indices;
+
   // Last input shape hash for ultra-fast path detection
   std::string last_input_shape_hash;
+
   // Flag indicating caches are valid
   bool caches_valid = false;
 };

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -134,7 +134,8 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   std::filesystem::path calibration_cache_path_{};
   std::unordered_map<std::string, float> dynamic_range_map_;
   std::filesystem::path model_cache_path_{};
-  std::set<std::string> session_input_names;
+  // Map of model input names per node (excludes weights/constants)
+  std::unordered_map<std::string, std::set<std::string>> map_session_input_names_;
   bool dump_model_ops_ = false;
   migraphx::target t_;
   std::mutex mgx_mu_;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -7,8 +7,8 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
-#include <semaphore>
 #include <set>
 #include <string>
 #include <string_view>
@@ -54,7 +54,7 @@ struct MIGraphXFuncState {
   migraphx::onnx_options options;
   migraphx::target t{};
   std::unordered_map<std::string, std::size_t> input_name_indexes;
-  std::binary_semaphore* mgx_sem_ptr = nullptr;
+  std::mutex* mgx_mu_ptr = nullptr;
   bool defer_compilation = false;
   bool fp16_enable = false;
   bool bf16_enable = false;
@@ -178,7 +178,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   std::unordered_map<std::string, std::set<std::string>> map_session_input_names_;
   bool dump_model_ops_ = false;
   migraphx::target t_;
-  std::binary_semaphore mgx_sem_{1};  // Initialize to 1 (available)
+  std::mutex mgx_mu_;
   hipStream_t stream_ = nullptr;
   hipDeviceProp_t device_prop_{};
   bool exhaustive_tune_ = false;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -100,7 +100,10 @@ struct MIGraphXFuncState {
   // Cached output indices for pre-allocated outputs (used by run_migraphx_program)
   std::vector<std::size_t> cached_prog_output_indices;
 
-  // Last input shape hash for ultra-fast path detection
+  // Last input shapes for quick comparison (avoids hash computation in ultra-fast path)
+  std::vector<std::int64_t> last_input_shapes_raw;
+
+  // Last input shape hash (only computed when shapes change, used for cache lookup)
   std::string last_input_shape_hash;
 
   // Flag indicating caches are valid

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -4,9 +4,11 @@
 #pragma once
 
 #include <filesystem>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <string>
 #include <string_view>
@@ -58,6 +60,8 @@ struct MIGraphXFuncState {
   bool dump_model_ops = false;
   bool exhaustive_tune = false;
   size_t max_dynamic_batch;
+  // Reference to the batched programs map for this node (keyed by batch size)
+  std::optional<std::reference_wrapper<std::unordered_map<std::size_t, migraphx::program>>> batched_programs_ref = std::nullopt;
 };
 
 // Logical device representation.
@@ -139,6 +143,8 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   std::unordered_map<std::string, std::string> map_onnx_string_;
   std::unordered_map<std::string, std::unordered_map<std::string, std::size_t>> map_input_index_;
   std::unordered_map<std::string, bool> map_no_input_shape_;
+  // Map of batched programs per node: node_name -> (batch_size -> program)
+  std::unordered_map<std::string, std::unordered_map<std::size_t, migraphx::program>> batched_programs_;
 
   AllocatorPtr allocator_;
   std::unique_ptr<ModelMetadefIdGenerator> metadef_id_generator_;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -108,9 +108,9 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
         {std::string{migraphx_provider_option::kGpuExternalAlloc}, MakeStringWithClassicLocale(external_alloc_)},
         {std::string{migraphx_provider_option::kGpuExternalFree}, MakeStringWithClassicLocale(external_free_)},
         {std::string{migraphx_provider_option::kGpuExternalEmptyCache}, MakeStringWithClassicLocale(external_empty_cache_)},
-        {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_path_)}};
-        {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(model_max_dynamic_batch_)}};
-
+        {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_path_)},
+        {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(max_dynamic_batch_)}};
+   }
 
  private:
   OrtDevice::DeviceId device_id_{0};
@@ -146,6 +146,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   void* external_free_{nullptr};
   void* external_empty_cache_{nullptr};
   bool first_start_ = true;
+  size_t max_dynamic_batch_{0};
 };
 
-}  // namespace onnxruntime
+}; // namespace onnxruntime

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -145,6 +145,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   void* external_alloc_{nullptr};
   void* external_free_{nullptr};
   void* external_empty_cache_{nullptr};
+  bool first_start_ = true;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
@@ -72,6 +72,7 @@ MIGraphXExecutionProviderInfo::MIGraphXExecutionProviderInfo(const ProviderOptio
           .AddAssignmentToReference(migraphx_provider_option::kExhaustiveTune, exhaustive_tune)
           .AddAssignmentToReference(migraphx_provider_option::kMemLimit, mem_limit)
           .AddAssignmentToEnumReference(migraphx_provider_option::kArenaExtendStrategy, arena_extend_strategy_mapping, arena_extend_strategy)
+          .AddAssignmentToReference(migraphx_provider_option::kModelMaxDynamicBatch, max_dynamic_batch)
           .Parse(options));
 }
 
@@ -84,7 +85,7 @@ MIGraphXExecutionProviderInfo::MIGraphXExecutionProviderInfo(const OrtMIGraphXPr
       exhaustive_tune{options.migraphx_exhaustive_tune != 0},
       mem_limit{options.migraphx_mem_limit},
       arena_extend_strategy{options.migraphx_arena_extend_strategy},
-      model_max_dynamic_batch{options.migraphx_max_dynamic_batch} {
+      max_dynamic_batch{options.migraphx_max_dynamic_batch} {
 }
 
 ProviderOptions MIGraphXExecutionProviderInfo::ToProviderOptions() const {
@@ -103,7 +104,7 @@ ProviderOptions MIGraphXExecutionProviderInfo::ToProviderOptions() const {
       {std::string{migraphx_provider_option::kGpuExternalFree}, MakeStringWithClassicLocale(external_free)},
       {std::string{migraphx_provider_option::kGpuExternalEmptyCache}, MakeStringWithClassicLocale(external_empty_cache)},
       {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_dir)},
-      {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(model_max_dynamic_batch)},
+      {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(max_dynamic_batch)},
   };
 }
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
@@ -83,7 +83,8 @@ MIGraphXExecutionProviderInfo::MIGraphXExecutionProviderInfo(const OrtMIGraphXPr
       int8_enable{options.migraphx_int8_enable != 0},
       exhaustive_tune{options.migraphx_exhaustive_tune != 0},
       mem_limit{options.migraphx_mem_limit},
-      arena_extend_strategy{options.migraphx_arena_extend_strategy} {
+      arena_extend_strategy{options.migraphx_arena_extend_strategy},
+      model_max_dynamic_batch{options.migraphx_max_dynamic_batch} {
 }
 
 ProviderOptions MIGraphXExecutionProviderInfo::ToProviderOptions() const {
@@ -102,6 +103,7 @@ ProviderOptions MIGraphXExecutionProviderInfo::ToProviderOptions() const {
       {std::string{migraphx_provider_option::kGpuExternalFree}, MakeStringWithClassicLocale(external_free)},
       {std::string{migraphx_provider_option::kGpuExternalEmptyCache}, MakeStringWithClassicLocale(external_empty_cache)},
       {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_dir)},
+      {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(model_max_dynamic_batch)},
   };
 }
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
@@ -51,7 +51,7 @@ struct MIGraphXExecutionProviderInfo {
   bool int8_use_native_calibration_table{false};
   std::filesystem::path model_cache_dir{};
   bool exhaustive_tune{false};
-  sizt_t max_dynamic_batch{0};
+  size_t max_dynamic_batch{0};
 
   size_t mem_limit{std::numeric_limits<size_t>::max()};
   ArenaExtendStrategy arena_extend_strategy{ArenaExtendStrategy::kNextPowerOfTwo};

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
@@ -51,12 +51,12 @@ struct MIGraphXExecutionProviderInfo {
   bool int8_use_native_calibration_table{false};
   std::filesystem::path model_cache_dir{};
   bool exhaustive_tune{false};
-  size_t max_dynamic_batch{0};
 
   size_t mem_limit{std::numeric_limits<size_t>::max()};
   ArenaExtendStrategy arena_extend_strategy{ArenaExtendStrategy::kNextPowerOfTwo};
 
   OrtArenaCfg* default_memory_arena_cfg{nullptr};
+  size_t max_dynamic_batch{static_cast<size_t>(0)};
 
   void* external_alloc{nullptr};
   void* external_free{nullptr};

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
@@ -34,6 +34,7 @@ constexpr auto kGpuExternalAlloc = "migraphx_external_alloc"sv;
 constexpr auto kGpuExternalFree = "migraphx_external_free"sv;
 constexpr auto kGpuExternalEmptyCache = "migraphx_external_empty_cache"sv;
 constexpr auto kModelCacheDir = "migraphx_model_cache_dir"sv;
+constexpr auto kModelMaxDynamicBatch = "migraphx_max_dynamic_batch"sv;
 }  // namespace migraphx_provider_option
 
 extern const EnumNameMapping<ArenaExtendStrategy> arena_extend_strategy_mapping;
@@ -50,6 +51,7 @@ struct MIGraphXExecutionProviderInfo {
   bool int8_use_native_calibration_table{false};
   std::filesystem::path model_cache_dir{};
   bool exhaustive_tune{false};
+  sizt_t max_dynamic_batch{0};
 
   size_t mem_limit{std::numeric_limits<size_t>::max()};
   ArenaExtendStrategy arena_extend_strategy{ArenaExtendStrategy::kNextPowerOfTwo};
@@ -100,6 +102,7 @@ struct std::hash<::onnxruntime::MIGraphXExecutionProviderInfo> {
     onnxruntime::HashCombine(reinterpret_cast<size_t>(info.external_free), value);
     onnxruntime::HashCombine(reinterpret_cast<size_t>(info.external_empty_cache), value);
 
+    onnxruntime::HashCombine(info.max_dynamic_batch, value);
     // The default memory arena cfg is not used in hashing right now.
     return value;
   }

--- a/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
@@ -146,6 +146,7 @@ struct MIGraphX_Provider final : Provider {
     migx_options->migraphx_cache_dir = internal_options.model_cache_dir.c_str();
     migx_options->migraphx_arena_extend_strategy = static_cast<int>(internal_options.arena_extend_strategy);
     migx_options->migraphx_mem_limit = internal_options.mem_limit;
+    migx_options->migraphx_max_dynamic_batch = internal_options.model_max_dynamic_batch;
   }
 
   ProviderOptions GetProviderOptions(const void* provider_options) override {

--- a/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
@@ -146,7 +146,7 @@ struct MIGraphX_Provider final : Provider {
     migx_options->migraphx_cache_dir = internal_options.model_cache_dir.c_str();
     migx_options->migraphx_arena_extend_strategy = static_cast<int>(internal_options.arena_extend_strategy);
     migx_options->migraphx_mem_limit = internal_options.mem_limit;
-    migx_options->migraphx_max_dynamic_batch = internal_options.model_max_dynamic_batch;
+    migx_options->migraphx_max_dynamic_batch = internal_options.max_dynamic_batch;
   }
 
   ProviderOptions GetProviderOptions(const void* provider_options) override {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Adds dynamic batch padding using max_dynamic_batch flag in EP API
- Better handling of dynamic symbolic shape inputs/detection
- Padded batch and slicing for models inbetween powers of two
- Adds caching of models for static input shapes
- Adds ultra fast, fast and standard path
- Performs threaded load or serialized precompile with input models.
- Reduces overhead of run with ultra/fast paths to make run close to MIGraphx driver

Using AI description for this to better summarize

Summary of Changes
1. Dynamic Batch Support with Power-of-Two Padding
The major feature addition is dynamic batch support where input batch sizes are padded to the nearest power-of-two (1, 2, 4, 8, 16, etc.) enabling model reuse across different batch sizes without recompilation.
2. Three-Tier Execution Path Architecture
The compute function was refactored into three distinct paths:
Ultra-fast path (execute_ultra_fast_path): When shapes are identical to the last run - just rebinds memory pointers and executes directly
Fast path (execute_fast_path): When a cached program exists for the shape hash - retrieves from cache and runs
Standard path (execute_standard_path): Full shape checking with potential recompilation
3. Precompilation at Compile Time
Moved model compilation from runtime to the Compile() phase:
precompile_all_dynamic_batch_models() - Precompiles all power-of-two batch sizes during initialization
precompile_static_model() - Precompiles static models during initialization
handle_precompilation_decision() - Logic to determine if precompilation is possible
4. Extensive Caching Infrastructure
Program cache: cached_programs map storing compiled programs by shape hash
Shape caching: cached_mgx_param_shapes and cached_mgx_output_shapes to avoid repeated MIGraphX API calls
Input/output caching: CachedInputParam and CachedOutputParam structures with pre-computed indices and shapes
Buffer reuse: Padded input buffers and temporary output buffers are kept for reuse
5. Input/Output Handling Refactoring
handle_program_input_outputs() - Centralized function to bind inputs and allocate outputs
populate_ultra_fast_caches() - Prepares optimized caches for ultra-fast path
build_input_shapes_in_cached_order() - Ensures consistent shape ordering for cache lookups
allocate_and_pad_inputs() - Handles GPU memory allocation and padding for dynamic batching
6. Output Slicing for Padded Batches
When running with a padded batch size larger than the original, outputs are stored in temporary buffers and sliced back to the original batch size.
7. Parallel Loading / Sequential Compilation
To improve load time while respecting MIGraphX thread safety:
Parallel loading from disk cache
Serialized compilation for cache misses (due to thread safety during MIGraphX compile)
8. New Helper Functions
has_only_dynamic_batch_dimension() - Checks if only the batch dimension is dynamic
extract_base_shapes_from_graph() - Extracts non-batch dimensions from graph definition
find_nearest_power_of_two_batch() - Finds the appropriate padded batch size
generate_power_of_two_batch_sizes() - Generates the list of batch sizes to precompile
get_input_name_map() / get_program_parameter_options() - Input processing utilities
Key Benefits
Reduced runtime compilation - Models are compiled at initialization instead of first inference
Better batch size handling - Arbitrary batch sizes reuse pre-compiled power-of-two models
Faster repeated inferences - Ultra-fast path skips shape checking when inputs are unchanged
Improved memory management - Buffer reuse reduces allocation overhead


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Customer ask since their models require us to add a dynamic batch mode
Offloads compile to leverage our MXR caching
has additional fixes and speedups as part of this body of work

Will cherry-pick to ROCm 7.2 once this is in 