### PR TITLE
Fix GPU device discovery failed error

### DIFF
--- a/onnxruntime/core/platform/linux/device_discovery.cc
+++ b/onnxruntime/core/platform/linux/device_discovery.cc
@@ -73,6 +73,14 @@ Status DetectGpuSysfsPaths(std::vector<GpuSysfsPathInfo>& gpu_sysfs_paths_out) {
     const auto& dir_item_path = dir_item.path();
 
     if (size_t card_idx{}; detect_card_path(dir_item_path, card_idx)) {
+      // Skip non-PCI DRM cards. On systems with AMD GPU compute partitioning
+      // (XCP), the amdgpu driver creates virtual platform sub-devices
+      // (e.g., amdgpu_xcp_*) that lack standard PCI sysfs attributes.
+      if (!fs::exists(dir_item_path / "device" / "vendor")) {
+        LOGS_DEFAULT(VERBOSE) << "Skipping non-PCI DRM card: " << dir_item_path;
+        continue;
+      }
+
       GpuSysfsPathInfo path_info{};
       path_info.card_idx = card_idx;
       path_info.path = dir_item_path;


### PR DESCRIPTION
### Description
Skip non-PCI DRM card entries in DetectGpuSysfsPaths by checking
for the existence of device/vendor in sysfs before including a card
in the discovery results.
This fixes errors similar to the following error:
GPU device discovery failed:
Failed to open file: "/sys/class/drm/card26/device/vendor"



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


