### PR TITLE
Force to use legacy TorchScript exporter to fix invalid dimensions error

### DIFF
--- a/onnxruntime/python/tools/transformers/torch_onnx_export_helper.py
+++ b/onnxruntime/python/tools/transformers/torch_onnx_export_helper.py
@@ -31,6 +31,7 @@ def torch_onnx_export(
     enable_onnx_checker=None,
     use_external_data_format=None,
     export_modules_as_functions=False,
+    dynamo=False,
 ):
     if Version(torch.__version__) >= Version("1.11.0"):
         torch.onnx.export(
@@ -49,6 +50,7 @@ def torch_onnx_export(
             keep_initializers_as_inputs=keep_initializers_as_inputs,
             custom_opsets=custom_opsets,
             export_modules_as_functions=export_modules_as_functions,
+            dynamo=dynamo,
         )
     else:
         torch.onnx.export(


### PR DESCRIPTION
### Description
Pass dynamo=False to torch.onnx.export() in torch_onnx_export_helper.py,
forcing the legacy TorchScript exporter.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


