### PR TITLE
Replace power-of-two batch sizes with max compiled model approach

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -827,6 +827,7 @@ typedef struct OrtMIGraphXProviderOptions {
    */
   int migraphx_arena_extend_strategy;
   size_t migraphx_max_dynamic_batch;                //Max Dynamic batch size. Default 0 = disabled, nonzero = enabled
+  size_t migraphx_max_compiled_models;              // 1 -> max only (default), 2 -> 1 and max, >=3 -> 1, mid, max
 
   // This is the legacy struct and don't add new fields here.
 } OrtMIGraphXProviderOptions;

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -827,7 +827,7 @@ typedef struct OrtMIGraphXProviderOptions {
    */
   int migraphx_arena_extend_strategy;
   size_t migraphx_max_dynamic_batch;                //Max Dynamic batch size. Default 0 = disabled, nonzero = enabled
-  size_t migraphx_max_compiled_models;              // 1 -> max only (default), 2 -> 1 and max, >=3 -> 1, mid, max
+  size_t migraphx_max_compiled_models;              // Number of evenly-spaced batch sizes to compile (1 -> max only, default)
 
   // This is the legacy struct and don't add new fields here.
 } OrtMIGraphXProviderOptions;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1237,38 +1237,28 @@ void save_compiled_model(const migraphx::program& prog, const std::filesystem::p
 }
 
 // Generate a vector of batch sizes to compile based on max_compiled_models setting
-// max_compiled_models == 1: only compile for max batch size
-// max_compiled_models == 2: compile for 1 and max batch size
-// max_compiled_models >= 3: compile for 1, max/2 (midpoint), and max batch size
+// Batch sizes are evenly spaced between 1 and max_batch_size.
+// max_compiled_models == 1: {max}
+// max_compiled_models == 2: {1, max}
+// max_compiled_models == 3: {1, max/2, max}
+// max_compiled_models == N: N evenly spaced values from 1 to max
 static std::vector<std::size_t> generate_compiled_batch_sizes(std::size_t max_batch_size, std::size_t max_compiled_models) {
   std::vector<std::size_t> batch_sizes;
   if (max_batch_size == 0) {
     return batch_sizes;
   }
-  
+
   if (max_compiled_models == 1) {
-    // Only compile the max batch size
     batch_sizes.push_back(max_batch_size);
-  } else if (max_compiled_models == 2) {
-    // Compile 1 and max batch size
-    batch_sizes.push_back(1);
-    if (max_batch_size > 1) {
-      batch_sizes.push_back(max_batch_size);
-    }
-  } else {
-    // max_compiled_models >= 3:
-    // Compile {1, mid, max}
-    batch_sizes.push_back(1);
-
-    if (max_batch_size > 2) {
-      std::size_t mid = max_batch_size / 2;
-      if (mid <= 1) mid = 2;
-      if (mid >= max_batch_size) mid = max_batch_size / 2;
-      batch_sizes.push_back(mid);
-    }
-
-    if (max_batch_size > 1) {
-      batch_sizes.push_back(max_batch_size);
+  } else if (max_compiled_models >= 2) {
+    // Evenly divide the range [1, max_batch_size] into max_compiled_models points
+    std::size_t n = max_compiled_models;
+    for (std::size_t i = 0; i < n; ++i) {
+      std::size_t bs = 1 + (max_batch_size - 1) * i / (n - 1);
+      // Avoid duplicates (can happen when max_batch_size is small relative to n)
+      if (batch_sizes.empty() || bs > batch_sizes.back()) {
+        batch_sizes.push_back(bs);
+      }
     }
   }
 
@@ -1286,11 +1276,9 @@ static std::vector<std::size_t> generate_compiled_batch_sizes(std::size_t max_ba
   return batch_sizes;
 }
 
-// Find the nearest compiled batch size for the given requested batch
-// max_compiled_models == 1: always use max batch size
-// max_compiled_models == 2: use 1 if requested <= 1, otherwise max batch size
-// max_compiled_models >= 3: use 1, max/2 (midpoint), or max batch size
-static std::size_t find_nearest_batch_for_compiled_models(std::size_t requested_batch,
+// Find the smallest compiled batch size >= requested_batch
+// Uses the same evenly-spaced scheme as generate_compiled_batch_sizes
+static std::size_t find_nearest_compiled_batch_size(std::size_t requested_batch,
                                                            std::size_t max_batch_size,
                                                            std::size_t max_compiled_models) {
   if (max_batch_size == 0) {
@@ -1299,21 +1287,17 @@ static std::size_t find_nearest_batch_for_compiled_models(std::size_t requested_
 
   if (max_compiled_models == 1) {
     return max_batch_size;
-  } else if (max_compiled_models == 2) {
-    return (requested_batch <= 1) ? 1 : max_batch_size;
-  } else {
-    // max_compiled_models >= 3: compiled sizes are {1, mid, max}
-    std::size_t mid = max_batch_size / 2;
-    if (mid <= 1) mid = 2;
-    if (mid >= max_batch_size) mid = max_batch_size / 2;
-
-    if (requested_batch <= 1) {
-      return 1;
-    } else if (requested_batch <= mid) {
-      return mid;
-    }
-    return max_batch_size;
   }
+
+  // Walk the evenly-spaced batch sizes and return the first one >= requested_batch
+  std::size_t n = max_compiled_models;
+  for (std::size_t i = 0; i < n; ++i) {
+    std::size_t bs = 1 + (max_batch_size - 1) * i / (n - 1);
+    if (bs >= requested_batch) {
+      return bs;
+    }
+  }
+  return max_batch_size;
 }
 
 // Pad input tensor data to a larger batch size
@@ -2367,7 +2351,7 @@ static bool execute_ultra_fast_path(
         // Check if the batch size matches (original or padded)
         if (shape[0] != last_shapes[offset]) {
           // Batch size changed - check if we can use padding
-          std::size_t required_padded = find_nearest_batch_for_compiled_models(
+          std::size_t required_padded = find_nearest_compiled_batch_size(
               original_batch_size, mgx_state->max_dynamic_batch, mgx_state->max_compiled_models);
           
           if (required_padded != padded_batch_size) {
@@ -2512,7 +2496,7 @@ static bool execute_fast_path(
       const auto tensor_shape = tensor_info.GetShape();
       if (!tensor_shape.empty()) {
         original_batch_size = static_cast<std::size_t>(tensor_shape[0]);
-        padded_batch_size = find_nearest_batch_for_compiled_models(original_batch_size,
+        padded_batch_size = find_nearest_compiled_batch_size(original_batch_size,
                                                                     mgx_state->max_dynamic_batch,
                                                                     mgx_state->max_compiled_models);
         needs_padding = (padded_batch_size > original_batch_size);
@@ -3015,7 +2999,7 @@ static void execute_standard_path(
       const auto tensor_shape = tensor_info.GetShape();
       if (!tensor_shape.empty()) {
         original_batch_size = static_cast<std::size_t>(tensor_shape[0]);
-        padded_batch_size = find_nearest_batch_for_compiled_models(original_batch_size,
+        padded_batch_size = find_nearest_compiled_batch_size(original_batch_size,
                                                                     mgx_state->max_dynamic_batch,
                                                                     mgx_state->max_compiled_models);
         needs_padding = (padded_batch_size > original_batch_size);

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1271,7 +1271,7 @@ static std::vector<std::size_t> generate_compiled_batch_sizes(std::size_t max_ba
     oss << batch_sizes[i];
   }
   oss << "] (count=" << batch_sizes.size() << ")";
-  LOGS_DEFAULT(WARNING) << oss.str();
+  LOGS_DEFAULT(VERBOSE) << oss.str();
 
   return batch_sizes;
 }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1248,6 +1248,16 @@ static std::vector<std::size_t> generate_compiled_batch_sizes(std::size_t max_ba
     return batch_sizes;
   }
 
+  if (max_compiled_models == 0) {
+    LOGS_DEFAULT(WARNING) << "max_compiled_models is 0. Defaulting to 1 (compile max batch size only).";
+    max_compiled_models = 1;
+  } else if (max_compiled_models > max_batch_size) {
+    LOGS_DEFAULT(WARNING) << "max_compiled_models (" << max_compiled_models
+                          << ") exceeds max_batch_size (" << max_batch_size
+                          << "). Setting max_compiled_models to " << max_batch_size << ".";
+    max_compiled_models = max_batch_size;
+  }
+
   if (max_compiled_models == 1) {
     batch_sizes.push_back(max_batch_size);
   } else if (max_compiled_models >= 2) {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -157,7 +157,8 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
       external_alloc_{info.external_alloc},
       external_free_{info.external_free},
       external_empty_cache_{info.external_empty_cache},
-      max_dynamic_batch_{info.max_dynamic_batch} {
+      max_dynamic_batch_{info.max_dynamic_batch},
+      max_compiled_models_{info.max_compiled_models} {
   InitProviderOrtApi();
 
   // Set GPU device to be used and read device properties for feature usage.
@@ -182,6 +183,7 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
   GET_ENV_STRING(migraphx_env_vars::kModelCachePath, model_cache_path_);
   GET_ENV_BOOL(migraphx_env_vars::kDumpModelOps, dump_model_ops_);
   GET_ENV_BOOL(migraphx_env_vars::kExhaustiveTune, exhaustive_tune_);
+  GET_ENV(migraphx_env_vars::kMaxCompiledModels, max_compiled_models_, max_compiled_models_ = std::stoul(max_compiled_models_env));
 
   // Verify configuration correctness and adjust accordingly.
 
@@ -1234,37 +1236,84 @@ void save_compiled_model(const migraphx::program& prog, const std::filesystem::p
   }
 }
 
-// Generate a vector of power-of-2 batch sizes from 1 up to the nearest power of 2 >= max_batch_size
-// E.g., max_batch_size=100 returns {1, 2, 4, 8, 16, 32, 64, 128}
-static std::vector<std::size_t> generate_power_of_two_batch_sizes(std::size_t max_batch_size) {
+// Generate a vector of batch sizes to compile based on max_compiled_models setting
+// max_compiled_models == 1: only compile for max batch size
+// max_compiled_models == 2: compile for 1 and max batch size
+// max_compiled_models >= 3: compile for 1, max/2 (midpoint), and max batch size
+static std::vector<std::size_t> generate_compiled_batch_sizes(std::size_t max_batch_size, std::size_t max_compiled_models) {
   std::vector<std::size_t> batch_sizes;
   if (max_batch_size == 0) {
     return batch_sizes;
   }
   
-  // Find the nearest power of 2 >= max_batch_size
-  std::size_t target = 1;
-  while (target < max_batch_size) {
-    target *= 2;
+  if (max_compiled_models == 1) {
+    // Only compile the max batch size
+    batch_sizes.push_back(max_batch_size);
+  } else if (max_compiled_models == 2) {
+    // Compile 1 and max batch size
+    batch_sizes.push_back(1);
+    if (max_batch_size > 1) {
+      batch_sizes.push_back(max_batch_size);
+    }
+  } else {
+    // max_compiled_models >= 3:
+    // Compile {1, mid, max}
+    batch_sizes.push_back(1);
+
+    if (max_batch_size > 2) {
+      std::size_t mid = max_batch_size / 2;
+      if (mid <= 1) mid = 2;
+      if (mid >= max_batch_size) mid = max_batch_size / 2;
+      batch_sizes.push_back(mid);
+    }
+
+    if (max_batch_size > 1) {
+      batch_sizes.push_back(max_batch_size);
+    }
   }
-  
-  // Generate all powers of 2 up to target
-  for (std::size_t bs = 1; bs <= target; bs *= 2) {
-    batch_sizes.push_back(bs);
+
+  std::ostringstream oss;
+  oss << "[MIGraphX] max_batch_size=" << max_batch_size
+      << ", max_compiled_models=" << max_compiled_models
+      << ", batch_sizes_to_compile=[";
+  for (std::size_t i = 0; i < batch_sizes.size(); ++i) {
+    if (i > 0) oss << ", ";
+    oss << batch_sizes[i];
   }
+  oss << "] (count=" << batch_sizes.size() << ")";
+  LOGS_DEFAULT(WARNING) << oss.str();
+
   return batch_sizes;
 }
 
-// Find the smallest power-of-two batch size that is >= the requested batch size
-// Returns 0 if no suitable batch size found in the list
-static std::size_t find_nearest_power_of_two_batch(std::size_t requested_batch, 
-                                                    const std::vector<std::size_t>& power_of_two_batches) {
-  for (const auto& bs : power_of_two_batches) {
-    if (bs >= requested_batch) {
-      return bs;
-    }
+// Find the nearest compiled batch size for the given requested batch
+// max_compiled_models == 1: always use max batch size
+// max_compiled_models == 2: use 1 if requested <= 1, otherwise max batch size
+// max_compiled_models >= 3: use 1, max/2 (midpoint), or max batch size
+static std::size_t find_nearest_batch_for_compiled_models(std::size_t requested_batch,
+                                                           std::size_t max_batch_size,
+                                                           std::size_t max_compiled_models) {
+  if (max_batch_size == 0) {
+    return 0;
   }
-  return 0;  // Not found - should not happen if list is properly generated
+
+  if (max_compiled_models == 1) {
+    return max_batch_size;
+  } else if (max_compiled_models == 2) {
+    return (requested_batch <= 1) ? 1 : max_batch_size;
+  } else {
+    // max_compiled_models >= 3: compiled sizes are {1, mid, max}
+    std::size_t mid = max_batch_size / 2;
+    if (mid <= 1) mid = 2;
+    if (mid >= max_batch_size) mid = max_batch_size / 2;
+
+    if (requested_batch <= 1) {
+      return 1;
+    } else if (requested_batch <= mid) {
+      return mid;
+    }
+    return max_batch_size;
+  }
 }
 
 // Pad input tensor data to a larger batch size
@@ -2308,7 +2357,7 @@ static bool execute_ultra_fast_path(
     }
     
     // For dynamic batch, we check if the current batch needs padding
-    if (mgx_state->has_dynamic_batch && !mgx_state->power_of_two_batch_sizes.empty()) {
+    if (mgx_state->has_dynamic_batch && !mgx_state->compiled_batch_sizes.empty()) {
       // Get batch sizes from first input
       if (is_first) {
         original_batch_size = static_cast<std::size_t>(shape[0]);
@@ -2318,8 +2367,8 @@ static bool execute_ultra_fast_path(
         // Check if the batch size matches (original or padded)
         if (shape[0] != last_shapes[offset]) {
           // Batch size changed - check if we can use padding
-          std::size_t required_padded = find_nearest_power_of_two_batch(
-              original_batch_size, mgx_state->power_of_two_batch_sizes);
+          std::size_t required_padded = find_nearest_batch_for_compiled_models(
+              original_batch_size, mgx_state->max_dynamic_batch, mgx_state->max_compiled_models);
           
           if (required_padded != padded_batch_size) {
             shapes_match = false;
@@ -2452,7 +2501,7 @@ static bool execute_fast_path(
   bool needs_padding = false;
   
   if (prog_it == cached_programs.end() && mgx_state->has_dynamic_batch && 
-      !mgx_state->power_of_two_batch_sizes.empty()) {
+      !mgx_state->compiled_batch_sizes.empty()) {
     LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Direct hash miss - checking for padded batch";
     // Try to find a padded batch size
     const auto& map_input_name_index = mgx_state->input_name_indexes;
@@ -2463,8 +2512,9 @@ static bool execute_fast_path(
       const auto tensor_shape = tensor_info.GetShape();
       if (!tensor_shape.empty()) {
         original_batch_size = static_cast<std::size_t>(tensor_shape[0]);
-        padded_batch_size = find_nearest_power_of_two_batch(original_batch_size, 
-                                                            mgx_state->power_of_two_batch_sizes);
+        padded_batch_size = find_nearest_batch_for_compiled_models(original_batch_size,
+                                                                    mgx_state->max_dynamic_batch,
+                                                                    mgx_state->max_compiled_models);
         needs_padding = (padded_batch_size > original_batch_size);
         LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Original batch: " << original_batch_size
                               << ", padded: " << padded_batch_size << ", needs_padding: " << needs_padding;
@@ -2754,7 +2804,7 @@ static InputShapeResult handle_input_shape(
   return {input_shape_match, param_shapes, input_shapes};
 }
 
-// Helper: Compile models for all power-of-two batch sizes and cache them
+// Helper: Compile models for all configured batch sizes and cache them
 static void compile_dynamic_batch_models(
     MIGraphXFuncState* mgx_state,
     const std::filesystem::path& model_cache_path,
@@ -2764,19 +2814,19 @@ static void compile_dynamic_batch_models(
   
   LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ==== ENTERING compile_dynamic_batch_models ====";
   LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] has_dynamic_batch = " << mgx_state->has_dynamic_batch;
-  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] power_of_two_batch_sizes.size() = " 
-                     << mgx_state->power_of_two_batch_sizes.size();
+  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] compiled_batch_sizes.size() = "
+                     << mgx_state->compiled_batch_sizes.size();
   LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] max_dynamic_batch = " << mgx_state->max_dynamic_batch;
   
-  if (!mgx_state->has_dynamic_batch || mgx_state->power_of_two_batch_sizes.empty()) {
+  if (!mgx_state->has_dynamic_batch || mgx_state->compiled_batch_sizes.empty()) {
     LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Skipping - dynamic batch disabled or no batch sizes";
     return;
   }
   
   LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Compiling models for " 
-                     << mgx_state->power_of_two_batch_sizes.size() << " power-of-two batch sizes";
+                     << mgx_state->compiled_batch_sizes.size() << " batch sizes";
   LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Batch sizes: ";
-  for (const auto& bs : mgx_state->power_of_two_batch_sizes) {
+  for (const auto& bs : mgx_state->compiled_batch_sizes) {
     LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE]   - " << bs;
   }
   
@@ -2819,8 +2869,8 @@ static void compile_dynamic_batch_models(
                        }() << "]";
   }
   
-  // Compile a model for each power-of-two batch size
-  for (const auto& batch_size : mgx_state->power_of_two_batch_sizes) {
+  // Compile a model for each configured batch size
+  for (const auto& batch_size : mgx_state->compiled_batch_sizes) {
     LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ---- Processing batch size: " << batch_size << " ----";
     
     // Build cache key for this batch size
@@ -2896,7 +2946,7 @@ static void compile_dynamic_batch_models(
     }
   }
   
-  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ==== All power-of-two batch models compiled and cached ====";
+  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ==== All batch models compiled and cached ====";
   LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Setting max_dynamic_batch to 0 to disable future compilation";
   
   // Disable dynamic batch compilation for subsequent runs (set max_dynamic_batch to 0)
@@ -2939,14 +2989,14 @@ static void execute_standard_path(
     LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] *** RUNTIME COMPILATION REQUIRED ***";
     LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] max_dynamic_batch=" 
                        << mgx_state->max_dynamic_batch;
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Initiating runtime compilation of power-of-two batch models";
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Initiating runtime compilation of batch models";
     
-    // Compile all power-of-two batch models at runtime
+    // Compile all batch models at runtime
     compile_dynamic_batch_models(mgx_state, model_cache_path, model_path, mxr_filename_prefix, ctx);
     
     LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Runtime compilation complete, max_dynamic_batch now = " 
                        << mgx_state->max_dynamic_batch;
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Proceeding with execution using closest power-of-two batch";
+    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Proceeding with execution using closest compiled batch";
   } else if (mgx_state->has_dynamic_batch) {
     LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Dynamic batch enabled, models already precompiled";
   }
@@ -2956,7 +3006,7 @@ static void execute_standard_path(
   std::size_t padded_batch_size = 0;
   bool needs_padding = false;
   
-  if (mgx_state->has_dynamic_batch && !mgx_state->power_of_two_batch_sizes.empty()) {
+  if (mgx_state->has_dynamic_batch && !mgx_state->compiled_batch_sizes.empty()) {
     LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Checking for batch padding requirements";
     // Get the batch size from the first input
     for (const auto& [name, index] : map_input_name_index) {
@@ -2965,8 +3015,9 @@ static void execute_standard_path(
       const auto tensor_shape = tensor_info.GetShape();
       if (!tensor_shape.empty()) {
         original_batch_size = static_cast<std::size_t>(tensor_shape[0]);
-        padded_batch_size = find_nearest_power_of_two_batch(original_batch_size, 
-                                                            mgx_state->power_of_two_batch_sizes);
+        padded_batch_size = find_nearest_batch_for_compiled_models(original_batch_size,
+                                                                    mgx_state->max_dynamic_batch,
+                                                                    mgx_state->max_compiled_models);
         needs_padding = (padded_batch_size > original_batch_size);
         
         LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Original batch size: " << original_batch_size;
@@ -3493,12 +3544,12 @@ static inline std::string precompile_model_for_batch(
   return cache_hash;
 }
 
-// Precompile all power-of-two batch models during Compile() phase
+// Precompile all batch models during Compile() phase
 // This moves compilation from compute_func() to initialization time
 // Uses parallel loading to speed up cache loading, but serializes compilation
 // to avoid thread-safety issues in MIGraphX compile()
 static inline void precompile_all_dynamic_batch_models(
-    const std::vector<std::size_t>& power_of_two_batch_sizes,
+    const std::vector<std::size_t>& compiled_batch_sizes,
     const std::vector<std::string>& input_names,
     const std::vector<std::vector<std::int64_t>>& all_input_base_shapes,
     const std::string& onnx_string,
@@ -3517,7 +3568,7 @@ static inline void precompile_all_dynamic_batch_models(
     std::unordered_map<std::string, migraphx::program>& cached_programs)
 {
   LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] Processing " 
-                     << power_of_two_batch_sizes.size() << " power-of-two batch models...";
+                     << compiled_batch_sizes.size() << " batch models...";
   
   // Structure to hold batch info for loading/compiling
   struct BatchInfo {
@@ -3528,7 +3579,7 @@ static inline void precompile_all_dynamic_batch_models(
   
   // Build batch info for all batch sizes
   std::vector<BatchInfo> batch_infos;
-  for (const auto& batch_size : power_of_two_batch_sizes) {
+  for (const auto& batch_size : compiled_batch_sizes) {
     BatchInfo info;
     info.batch_size = batch_size;
     
@@ -3826,7 +3877,8 @@ static inline bool handle_precompilation_decision(
     const std::filesystem::path& model_cache_path,
     const std::string& mxr_filename_prefix,
     std::unordered_map<std::string, migraphx::program>& cached_programs,
-    std::size_t max_dynamic_batch)
+    std::size_t max_dynamic_batch,
+    std::size_t max_compiled_models)
 {
   // ═══════════════════════════════════════════════════════════════════════════
   // PRECOMPILATION: Compile models during Compile() phase instead of compute_func()
@@ -3834,7 +3886,7 @@ static inline bool handle_precompilation_decision(
   // 
   // Precompilation rules:
   // 1. max_dynamic_batch > 0 AND all non-batch dims are concrete:
-  //    -> Precompile all power-of-two batch models (symbolic batch dim is OK)
+  //    -> Precompile all batch models (symbolic batch dim is OK)
   // 2. max_dynamic_batch > 0 AND some non-batch dims are symbolic:
   //    -> Defer to runtime (cannot precompile without concrete non-batch shapes)
   // 3. max_dynamic_batch == 0 AND all dims are concrete:
@@ -3873,21 +3925,21 @@ static inline bool handle_precompilation_decision(
       
       if (shapes_valid) {
         
-        // All non-batch dimensions are concrete - precompile all power-of-two batch models
-        auto power_of_two_batch_sizes = generate_power_of_two_batch_sizes(max_dynamic_batch);
+        // All non-batch dimensions are concrete - precompile all batch models
+        auto compiled_batch_sizes = generate_compiled_batch_sizes(max_dynamic_batch, max_compiled_models);
         
         std::ostringstream batch_ss;
         batch_ss << "[";
-        for (std::size_t i = 0; i < power_of_two_batch_sizes.size(); ++i) {
+        for (std::size_t i = 0; i < compiled_batch_sizes.size(); ++i) {
           if (i > 0) batch_ss << ", ";
-          batch_ss << power_of_two_batch_sizes[i];
+          batch_ss << compiled_batch_sizes[i];
         }
         batch_ss << "]";
-        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Power-of-two batch sizes to compile: " << batch_ss.str();
+        LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] Batch sizes to compile: " << batch_ss.str();
         LOGS_DEFAULT(VERBOSE) << "[Compile][PRECOMPILE] >>> STARTING DYNAMIC BATCH PRECOMPILATION <<<";
         
         precompile_all_dynamic_batch_models(
-            power_of_two_batch_sizes,
+            compiled_batch_sizes,
             ordered_names,
             base_shapes,
             onnx_string_buffer,
@@ -4072,7 +4124,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         model_cache_path_,
         mxr_filename_prefix,
         cached_programs_[fused_node.Name()],
-        max_dynamic_batch_);
+        max_dynamic_batch_,
+        max_compiled_models_);
 
     // Create program object (may be empty if precompiled programs are in cache)
     migraphx::program prog;
@@ -4091,15 +4144,16 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             map_defer_compilation_[context->node_name], fp16_enable_, bf16_enable_, fp8_enable_, int8_enable_,
             int8_calibration_cache_available_, dynamic_range_map_,
             model_cache_path_.string(), dump_model_ops_, exhaustive_tune_, max_dynamic_batch_,
-            std::ref(cached_programs_[context->node_name])};
+            max_compiled_models_, std::ref(cached_programs_[context->node_name])};
       
       // Initialize dynamic batch support if max_dynamic_batch > 0
       if (max_dynamic_batch_ > 0) {
         p->has_dynamic_batch = true;
-        p->power_of_two_batch_sizes = generate_power_of_two_batch_sizes(max_dynamic_batch_);
+        p->compiled_batch_sizes = generate_compiled_batch_sizes(max_dynamic_batch_, max_compiled_models_);
         LOGS_DEFAULT(VERBOSE) << "[Compile][CREATE_STATE] Dynamic batch enabled for node '" << context->node_name 
                               << "' with max_dynamic_batch=" << max_dynamic_batch_
-                              << ", generated " << p->power_of_two_batch_sizes.size() << " power-of-two batch sizes";
+                              << ", max_compiled_models=" << max_compiled_models_
+                              << ", generated " << p->compiled_batch_sizes.size() << " batch sizes to compile";
         LOGS_DEFAULT(VERBOSE) << "[Compile][CREATE_STATE] defer_compilation=" << p->defer_compilation;
       } else {
         LOGS_DEFAULT(VERBOSE) << "[Compile][CREATE_STATE] Static model mode for node '" << context->node_name << "'";

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -67,7 +67,7 @@ struct MIGraphXFuncState {
   bool dump_model_ops = false;
   bool exhaustive_tune = false;
   size_t max_dynamic_batch;
-  size_t max_compiled_models = 1;  // 1 -> max only (default), 2 -> 1 and max, >=3 -> 1, mid, max
+  size_t max_compiled_models = 1;  // Number of evenly-spaced batch sizes to compile (1 -> max only)
   // Reference to the cached programs map for this node (keyed by input shape hash)
   std::optional<std::reference_wrapper<std::unordered_map<std::string, migraphx::program>>> cached_programs_ref = std::nullopt;
   
@@ -250,7 +250,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   void* external_empty_cache_{nullptr};
   bool first_start_ = true;
   size_t max_dynamic_batch_{0};
-  size_t max_compiled_models_{1};  // 1 -> max only (default), 2 -> 1 and max, >=3 -> 1, mid, max
+  size_t max_compiled_models_{1};  // Number of evenly-spaced batch sizes to compile (1 -> max only)
 };
 
 }; // namespace onnxruntime

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -36,6 +36,7 @@ constexpr auto kINT8UseNativeMIGraphXCalibrationTable = "ORT_MIGRAPHX_INT8_USE_N
 constexpr auto kExhaustiveTune = "ORT_MIGRAPHX_EXHAUSTIVE_TUNE"sv;
 constexpr auto kModelCachePath = "ORT_MIGRAPHX_MODEL_CACHE_PATH"sv;
 constexpr auto kModelMaxDynamicBatch = "ORT_MIGRAPHX_MAX_DYNAMIC_BATCH"sv;
+constexpr auto kMaxCompiledModels = "ORT_MIGRAPHX_MAX_COMPILED_MODELS"sv;
 }  // namespace migraphx_env_vars
 
 // Tracks which dimensions are symbolic for a given input
@@ -66,12 +67,13 @@ struct MIGraphXFuncState {
   bool dump_model_ops = false;
   bool exhaustive_tune = false;
   size_t max_dynamic_batch;
+  size_t max_compiled_models = 1;  // 1 -> max only (default), 2 -> 1 and max, >=3 -> 1, mid, max
   // Reference to the cached programs map for this node (keyed by input shape hash)
   std::optional<std::reference_wrapper<std::unordered_map<std::string, migraphx::program>>> cached_programs_ref = std::nullopt;
   
   // Dynamic batch support
   bool has_dynamic_batch = false;
-  std::vector<std::size_t> power_of_two_batch_sizes;
+  std::vector<std::size_t> compiled_batch_sizes;
   
   // Padded input buffers for dynamic batching (allocated on GPU)
   struct PaddedBuffer {
@@ -206,7 +208,8 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
         {std::string{migraphx_provider_option::kGpuExternalFree}, MakeStringWithClassicLocale(external_free_)},
         {std::string{migraphx_provider_option::kGpuExternalEmptyCache}, MakeStringWithClassicLocale(external_empty_cache_)},
         {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_path_)},
-        {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(max_dynamic_batch_)}};
+        {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(max_dynamic_batch_)},
+        {std::string{migraphx_provider_option::kMaxCompiledModels}, MakeStringWithClassicLocale(max_compiled_models_)}};
    }
 
  private:
@@ -247,6 +250,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   void* external_empty_cache_{nullptr};
   bool first_start_ = true;
   size_t max_dynamic_batch_{0};
+  size_t max_compiled_models_{1};  // 1 -> max only (default), 2 -> 1 and max, >=3 -> 1, mid, max
 };
 
 }; // namespace onnxruntime

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
@@ -73,6 +73,7 @@ MIGraphXExecutionProviderInfo::MIGraphXExecutionProviderInfo(const ProviderOptio
           .AddAssignmentToReference(migraphx_provider_option::kMemLimit, mem_limit)
           .AddAssignmentToEnumReference(migraphx_provider_option::kArenaExtendStrategy, arena_extend_strategy_mapping, arena_extend_strategy)
           .AddAssignmentToReference(migraphx_provider_option::kModelMaxDynamicBatch, max_dynamic_batch)
+          .AddAssignmentToReference(migraphx_provider_option::kMaxCompiledModels, max_compiled_models)
           .Parse(options));
 }
 
@@ -85,7 +86,8 @@ MIGraphXExecutionProviderInfo::MIGraphXExecutionProviderInfo(const OrtMIGraphXPr
       exhaustive_tune{options.migraphx_exhaustive_tune != 0},
       mem_limit{options.migraphx_mem_limit},
       arena_extend_strategy{options.migraphx_arena_extend_strategy},
-      max_dynamic_batch{options.migraphx_max_dynamic_batch} {
+      max_dynamic_batch{options.migraphx_max_dynamic_batch},
+      max_compiled_models{options.migraphx_max_compiled_models == 0 ? 1 : options.migraphx_max_compiled_models} {
 }
 
 ProviderOptions MIGraphXExecutionProviderInfo::ToProviderOptions() const {
@@ -105,6 +107,7 @@ ProviderOptions MIGraphXExecutionProviderInfo::ToProviderOptions() const {
       {std::string{migraphx_provider_option::kGpuExternalEmptyCache}, MakeStringWithClassicLocale(external_empty_cache)},
       {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_dir)},
       {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(max_dynamic_batch)},
+      {std::string{migraphx_provider_option::kMaxCompiledModels}, MakeStringWithClassicLocale(max_compiled_models)},
   };
 }
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
@@ -58,7 +58,7 @@ struct MIGraphXExecutionProviderInfo {
 
   OrtArenaCfg* default_memory_arena_cfg{nullptr};
   size_t max_dynamic_batch{static_cast<size_t>(0)};
-  size_t max_compiled_models{static_cast<size_t>(1)};  // 1 -> max only (default), 2 -> 1 and max, >=3 -> 1, mid, max
+  size_t max_compiled_models{static_cast<size_t>(1)};  // Number of evenly-spaced batch sizes to compile (1 -> max only)
 
   void* external_alloc{nullptr};
   void* external_free{nullptr};

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
@@ -35,6 +35,7 @@ constexpr auto kGpuExternalFree = "migraphx_external_free"sv;
 constexpr auto kGpuExternalEmptyCache = "migraphx_external_empty_cache"sv;
 constexpr auto kModelCacheDir = "migraphx_model_cache_dir"sv;
 constexpr auto kModelMaxDynamicBatch = "migraphx_max_dynamic_batch"sv;
+constexpr auto kMaxCompiledModels = "migraphx_max_compiled_models"sv;
 }  // namespace migraphx_provider_option
 
 extern const EnumNameMapping<ArenaExtendStrategy> arena_extend_strategy_mapping;
@@ -57,6 +58,7 @@ struct MIGraphXExecutionProviderInfo {
 
   OrtArenaCfg* default_memory_arena_cfg{nullptr};
   size_t max_dynamic_batch{static_cast<size_t>(0)};
+  size_t max_compiled_models{static_cast<size_t>(1)};  // 1 -> max only (default), 2 -> 1 and max, >=3 -> 1, mid, max
 
   void* external_alloc{nullptr};
   void* external_free{nullptr};
@@ -103,6 +105,7 @@ struct std::hash<::onnxruntime::MIGraphXExecutionProviderInfo> {
     onnxruntime::HashCombine(reinterpret_cast<size_t>(info.external_empty_cache), value);
 
     onnxruntime::HashCombine(info.max_dynamic_batch, value);
+    onnxruntime::HashCombine(info.max_compiled_models, value);
     // The default memory arena cfg is not used in hashing right now.
     return value;
   }

--- a/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
@@ -147,6 +147,7 @@ struct MIGraphX_Provider final : Provider {
     migx_options->migraphx_arena_extend_strategy = static_cast<int>(internal_options.arena_extend_strategy);
     migx_options->migraphx_mem_limit = internal_options.mem_limit;
     migx_options->migraphx_max_dynamic_batch = internal_options.max_dynamic_batch;
+    migx_options->migraphx_max_compiled_models = internal_options.max_compiled_models;
   }
 
   ProviderOptions GetProviderOptions(const void* provider_options) override {


### PR DESCRIPTION
### Description
Replace power-of-two batch sizes with max compiled model approach.

ORT_MIGRAPHX_MAX_COMPILED_MODELS=N, such that

max_compiled_models == 1 -> compile the max batch size.
max_compiled_models == 2 -> compile batch size 1 and max batch size.
max_compiled_models >= 3   -> compile batch sizes of 1, some mid values, max.

max_compiled_models == 0 -> set max_compiled_models to 1.
max_compiled_models > max batch size -> set max_compiled_models to max batch size.


This helps to reduce memory usage for higher batch sizes.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


