### PR TITLE
Three operator conditional blocks removed to get migraphx ep working for certain models

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -443,10 +443,6 @@ static bool IsUnsupportedOpMode(const GraphViewer& graph_viewer, const Node* nod
         (input_type->tensor_type().elem_type() != ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT8)) {
       return true;
     }
-  } else if (optype == "NonZero") {
-    if (!canEvalNodeArgument(graph_viewer, node, {0}, input_nodes)) {
-      return true;
-    }
   } else if (optype == "OneHot") {
     if (!canEvalNodeArgument(graph_viewer, node, {1}, input_nodes)) {
       return true;
@@ -472,13 +468,6 @@ static bool IsUnsupportedOpMode(const GraphViewer& graph_viewer, const Node* nod
       return true;
     }
 
-  } else if (optype == "Range") {
-    auto arg_num = node->InputDefs().size();
-    std::vector<std::size_t> vec(arg_num);
-    std::iota(vec.begin(), vec.end(), 0);
-    if (!canEvalNodeArgument(graph_viewer, node, vec, input_nodes)) {
-      return true;
-    }
   } else if (optype == "Reshape") {
     const auto& args = node->InputDefs();
     if (args.size() == 2) {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -399,39 +399,6 @@ static bool IsUnsupportedOpMode(const GraphViewer& graph_viewer, const Node* nod
     if (!canEvalNodeArgument(graph_viewer, node, {1}, input_nodes)) {
       return true;
     }
-  } else if (optype == "MaxPool") {
-    // MaxPool "indices" output is not currently supported.
-    if (node->OutputDefs().size() > 1) {
-      return true;
-    }
-
-    // ceil_mode and dilations attrs are not supported in MIGraphX
-    const auto& attributes = node->GetAttributes();
-    auto dila_attr = attributes.find("dilations");
-    if (dila_attr != attributes.end()) {
-      auto dilas = toVector((*dila_attr).second.ints());
-      bool ret = std::all_of(dilas.begin(), dilas.end(), [](auto i) { return i == 1; });
-      if (ret == false) {
-        return true;
-      }
-    }
-
-    // storage order 1 (column major format) is not supported
-    auto storage_order_attr = attributes.find("storage_order");
-    if (storage_order_attr != attributes.end() && (*storage_order_attr).second.i() != 0) {
-      return true;
-    }
-
-    // do not support int8 and uint8 type
-    const auto& input_type = node->InputDefs().at(0)->TypeAsProto();
-    if (input_type == nullptr) {
-      return true;
-    }
-    auto data_type = input_type->tensor_type().elem_type();
-    if (data_type == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT8 ||
-        data_type == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT8) {
-      return true;
-    }
   } else if (optype == "MatMulInteger") {
     // only support int8 and uint8 type
     const auto& input_type = node->InputDefs().at(0)->TypeAsProto();


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
In migraphx_execution_provider.cc, within IsUnsupportedOpMode the conditional blocks for optype NonZero, Range and MaxPool were removed.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

For some models (MeloTTS and SIE:SmolVLM2-500M-Video-Instruct:vision_*  models) these three operators were being reported unsupported by migraphx ep but they are in the supported list.  These conditionals were removed because when stepping through their code path they enter canEvalShapeGeneral and then eventually to IsGraphInput(graph, input_name) where it returns false from. After removing the conditional the two operators were no longer an issue.

A new issue stemmed later on for MeloTTS:
 Error: C:/w/src/include\migraphx/op/multibroadcast.hpp:87: compute_shape: MULTIBROADCAST: input shape {0} cannot be broadcasted to {1, 1}!
        Error: Non-zero status code returned while running MGXKernel_graph_main_graph_15922752454231187159_0 node. Name:'MIGraphXExecutionProvider_MGXKernel_graph_main_graph_15922752454231187159_0_0' Status Message: Failed to call function

Ticket related to it: https://amd-hub.atlassian.net/browse/AIRADSW-61
 
for some SmolVLM2-500M-Video-Instruct:vision_ models:
Error simplify_reshapes: C:/w/src/include\migraphx/check_shapes.hpp:220: same_dims: equal: Dimensions do not match
Dump: "C:\\Users\\tamahedi\\AppData\\Local\\Temp\\migraphx\\simplify_reshapes1552374039121400.mxr"
: Error: C:/w/src/include\migraphx/check_shapes.hpp:220: same_dims: equal: Dimensions do not match
        Error: Non-zero status code returned while running MGXKernel_graph_main_graph_6827965760175395044_0 node. Name:'MIGraphXExecutionProvider_MGXKernel_graph_main_graph_6827965760175395044_0_0' Status Message: Failed to call function

Ticket related to it: https://amd-hub.atlassian.net/browse/AIRADSW-59

MaxPool Conditional removal fixed ResNet50_int8 and Squeezenet_int8 errors.

MaskRCNN-12 had nonzero unsupported errors but these changes only led to another error:
: Error: C:/Users/taccuser/Documents/AMDMIGraphX/src/targets/gpu/include\migraphx/gpu/context.hpp:341: wait_for: Failed to record: context is destroyed
2026-02-27 10:19:20.9204205 [E:onnxruntime:, sequential_executor.cc:572 onnxruntime::ExecuteKernel] Non-zero status code returned while running MGXKernel_graph_torch-jit-export_15747441500071067602_0 node. Name:'MIGraphXExecutionProvider_MGXKernel_graph_torch-jit-export_15747441500071067602_0_0' Status Message: Failed to call function
Run failed:PerformanceRunner::RunOneIteration caught exception: Non-zero status code returned while running MGXKernel_graph_torch-jit-export_15747441500071067602_0 node. Name:'MIGraphXExecutionProvider_MGXKernel_graph_torch-jit-export_15747441500071067602_0_0' Status Message: Failed to call function

MaskRCNN-12-int8 originally had issues with maxpool and nonzero being unsupported. Now:
Error simplify_qdq: C:/w/src/include\migraphx/check_shapes.hpp:220: same_dims: quantizelinear: Dimensions do not match
Dump: "C:\\Users\\tamahedi\\AppData\\Local\\Temp\\migraphx\\simplify_qdq1712991398399200.mxr"
: Error: C:/w/src/include\migraphx/check_shapes.hpp:220: same_dims: quantizelinear: Dimensions do not match
        Error: Exception during initialization: Failed to call function

Originally the mentioned models here had a problem reporting MaxPool, NonZero or Range as unsupported. These are their later results.
All the models mentioned here work with cpu and dml ep.

