### PR TITLE
Fix trim functions for output/input naming lookups using string view …

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
@@ -332,15 +332,13 @@ inline std::string GenerateGraphId(const GraphViewer& graph_viewer) {
 }
 
 inline std::string_view TrimLeft(std::string_view sv, int (*fn)(int) = std::isspace) {
-  return sv.substr(0, sv.end() - std::find_if(sv.begin(), sv.end(), [fn](int ch) {
-                        return fn(ch);
-                      }));
+  auto it = std::find_if(sv.begin(), sv.end(), fn);
+  return sv.substr(it - sv.begin());
 }
 
 inline std::string_view TrimRight(std::string_view sv, int (*fn)(int) = std::isspace) {
-  return sv.substr(sv.end() - std::find_if(sv.rbegin(), sv.rend(), [fn](int ch) {
-                                return fn(ch);
-                              }).base());
+  auto rit = std::find_if(sv.rbegin(), sv.rend(), fn);
+  return sv.substr(0, rit.base() - sv.begin());
 }
 
 inline std::string_view Trim(std::string_view sv, int (*fn)(int) = std::isspace) {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Fixes error we were seeing with indicies for outputs. Output names are index via a lookup leveraging string_view. We're supposed to trim out non digits to perform the lookup, and in some cases with models using a lot of lookups, we use an encoded output name to represent the output instead. This solves an error we were seeing with output names that weren't trimming an extra colon in the output case

```
main:#output_:00010  -> :00010 (wrong causes failure in ToInteger call)
main:#output_:00010  -> 00010 (correct)
```


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fixes a bug when we have inputs using an encoded output number as matching for string view doesn't account for this colon and causes a conversion error to integer when performing a lookup
