### PR TITLE
Guard save_compiled_model with try-catch to handle serialization failures

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1405,7 +1405,13 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         calibrate_and_quantize(prog, t_, quant_params, fp16_enable_, bf16_enable_, int8_enable_,
                                fp8_enable_, int8_calibration_cache_available_, dynamic_range_map_);
         compile_program(prog, t_, exhaustive_tune_);
-        save_compiled_model(prog, model_cache_file);
+        try {
+          save_compiled_model(prog, model_cache_file);
+        } catch (const std::exception& e) {
+          LOGS_DEFAULT(WARNING) << ">>>>>> exception caught at Compile::save_compiled_model: " << e.what();
+        } catch (...) {
+          LOGS_DEFAULT(WARNING) << ">>>>>> unknown exception caught at Compile::save_compiled_model";
+        }
       }
 
       auto prog_output_shapes = prog.get_output_shapes();
@@ -1548,7 +1554,13 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           calibrate_and_quantize(prog, t, quant_params, fp16_enable, bf16_enable, int8_enable,
                                  fp8_enable, int8_calibration_cache_available, map_dynamic_range);
           compile_program(prog, t, exhaustive_tune_);
-          save_compiled_model(prog, model_cache_file);
+          try {
+            save_compiled_model(prog, model_cache_file);
+          } catch (const std::exception& e) {
+            LOGS_DEFAULT(WARNING) << ">>>>>> exception caught at recompile::save_compiled_model: " << e.what();
+          } catch (...) {
+            LOGS_DEFAULT(WARNING) << ">>>>>> unknown exception caught at recompile::save_compiled_model";
+          }
         }
 
         mgx_state->prog = prog;


### PR DESCRIPTION
### Description
Wrap only the `save_compiled_model` call (in both the initial compile and recompile paths) with a try-catch that logs a warning instead of propagating the exception. All other operations (`SerializeToString`, `parse_onnx_buffer`, `compile_program`) are confirmed to succeed and are left unwrapped.

### Motivation and Context
`save_compiled_model` can throw `std::bad_alloc` during MXR cache serialization when the compiled model is large. This crashes the entire inference session even though the model compiled and runs correctly; the cache file is purely an optimization for subsequent loads. Inference should not fail because of a cache write failure.

