### PR TITLE
Cherry-pick Double memory microsoft fix (#223)

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -890,10 +890,18 @@ std::unique_ptr<IndexedSubGraph> MIGraphXExecutionProvider::GetSubGraph(const st
   const std::string graph_type = graph.IsSubgraph() ? "subgraph" : "graph";
   meta_def->name() = "MGXKernel_" + graph_type + "_" + graph.Name() + "_" + subgraph_id;
 
-  // Assign inputs and outputs to subgraph's meta_def
+  // Assign inputs and outputs to subgraph's meta_def.
+  // Drop constant initializers from inputs: MIGraphX loads them internally via
+  // the serialized ONNX model passed to parse_onnx_buffer(), so ORT does not
+  // need to allocate them on the device. Keeping them as inputs would cause
+  // double allocation of weights on the GPU.
   for (const auto& input : inputs) {
     if (input.second->Exists()) {
-      meta_def->inputs().push_back(input.second->Name());
+      const std::string& input_name = input.second->Name();
+      if (graph.IsConstantInitializer(input_name, /*check_outer_scope=*/true)) {
+        continue;
+      }
+      meta_def->inputs().push_back(input_name);
     }
   }
 


### PR DESCRIPTION
* Revert "Merge branch 'reduce_migx_gpu_mem_alloc' into wml-main"

This reverts commit 88b617716d9ef84634cad8ab9735bacb3bacc5ee, reversing changes made to 6e2fde9366a41878596a7a906f933f2cb51972da.

* Reverting old + adding microsoft fix for double allocation

* Workaround for reducing GPU  memory allocation

* completely remove the workaround

---------

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


