### PR TITLE
Target batch compile

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 // See docs\c_cxx\README.md on generating the Doxygen documentation from this file
@@ -827,7 +827,6 @@ typedef struct OrtMIGraphXProviderOptions {
    */
   int migraphx_arena_extend_strategy;
   size_t migraphx_max_dynamic_batch;                //Max Dynamic batch size. Default 0 = disabled, nonzero = enabled
-  size_t migraphx_max_compiled_models;              // Number of evenly-spaced batch sizes to compile (1 -> max only, default)
 
   // This is the legacy struct and don't add new fields here.
 } OrtMIGraphXProviderOptions;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -250,7 +250,6 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
   int8_calibration_cache_available_ =
     (int8_enable_ || fp8_enable_) && !int8_calibration_table_name_.empty();
 
-
   // Load INT8 calibration table
   if (int8_calibration_cache_available_) {
     std::unordered_map<std::string, float> dynamic_range_map;
@@ -1425,8 +1424,6 @@ static bool allocate_and_pad_inputs(
   );
   
   if (can_reuse_buffers) {
-    LOGS_DEFAULT(VERBOSE) << "[allocate_and_pad_inputs] ✓✓✓ REUSING existing padded buffers "
-                          << "(original=" << original_batch_size << ", padded=" << padded_batch_size << ")";
     
     // Just copy new data into existing buffers - skip allocation
     for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
@@ -1493,8 +1490,6 @@ static bool allocate_and_pad_inputs(
   // ═══════════════════════════════════════════════════════════════════════════
   // Normal path: Allocate new buffers (batch size changed or first run)
   // ═══════════════════════════════════════════════════════════════════════════
-  LOGS_DEFAULT(VERBOSE) << "[allocate_and_pad_inputs] Allocating NEW padded buffers: original=" 
-                        << original_batch_size << ", padded=" << padded_batch_size;
   
   // Free old buffers if they exist
   for (auto& buf : mgx_state->padded_input_buffers) {
@@ -1514,7 +1509,6 @@ static bool allocate_and_pad_inputs(
     const auto tensor_shape = tensor_info.GetShape();
     
     if (tensor_shape.empty()) {
-      LOGS_DEFAULT(VERBOSE) << "[allocate_and_pad_inputs] Skipping empty shape input";
       continue;
     }
     
@@ -1566,7 +1560,6 @@ static bool allocate_and_pad_inputs(
         break;
       default:
         element_size_bytes = sizeof(float);  // Fallback to float
-        LOGS_DEFAULT(VERBOSE) << "[allocate_and_pad_inputs] Unknown element type, assuming float";
         break;
     }
     
@@ -1582,16 +1575,12 @@ static bool allocate_and_pad_inputs(
     buf.mgx_shape = padded_mgx_shape;
     mgx_state->padded_input_buffers.push_back(buf);
     
-    LOGS_DEFAULT(VERBOSE) << "[allocate_and_pad_inputs] Padded input '" << cached_inp.name 
-                         << "': " << padded_bytes << " bytes";
   }
   
   // Update batch tracking
   mgx_state->last_original_batch_size = original_batch_size;
   mgx_state->last_padded_batch_size = padded_batch_size;
   
-  LOGS_DEFAULT(VERBOSE) << "[allocate_and_pad_inputs] Allocated " 
-                        << mgx_state->padded_input_buffers.size() << " padded buffers";
   return true;
 }
 
@@ -1643,8 +1632,6 @@ static std::vector<void*> get_or_allocate_temp_output_buffers(
   );
   
   if (can_reuse) {
-    LOGS_DEFAULT(VERBOSE) << "[get_or_allocate_temp_output_buffers] ✓✓✓ REUSING " 
-                          << mgx_state->temp_output_buffers.size() << " temp output buffers";
     // Return raw pointers from existing buffers
     std::vector<void*> ptrs;
     ptrs.reserve(mgx_state->temp_output_buffers.size());
@@ -1656,8 +1643,6 @@ static std::vector<void*> get_or_allocate_temp_output_buffers(
   
   // Free old buffers if they exist
   free_temp_output_buffers(mgx_state);
-  
-  LOGS_DEFAULT(VERBOSE) << "[get_or_allocate_temp_output_buffers] Allocating NEW temp output buffers";
   
   // Count outputs and allocate
   std::vector<void*> ptrs;
@@ -1691,14 +1676,10 @@ static std::vector<void*> get_or_allocate_temp_output_buffers(
       mgx_state->temp_output_buffers.push_back(temp_buf);
       ptrs.push_back(buffer);
       
-      LOGS_DEFAULT(VERBOSE) << "[get_or_allocate_temp_output_buffers] Allocated output " 
-                            << output_index << ": " << size_bytes << " bytes";
     }
   }
   
   mgx_state->temp_output_padded_batch_size = padded_batch_size;
-  LOGS_DEFAULT(VERBOSE) << "[get_or_allocate_temp_output_buffers] Allocated " 
-                        << mgx_state->temp_output_buffers.size() << " temp output buffers";
   
   return ptrs;
 }
@@ -1716,7 +1697,6 @@ void calibrate_and_quantize(migraphx::program& prog,
                             std::unordered_map<std::string, float>& dynamic_range_map) {
   // Read in the calibration data and map it to an migraphx paramater map for the calibration ops
   if ((int8_enable ^ fp8_enable) && int8_calibration_cache_available) {
-    LOGS_DEFAULT(VERBOSE) << "Quantizing input program";
 
     auto param_shapes = prog.get_parameter_shapes();
 
@@ -1728,36 +1708,28 @@ void calibrate_and_quantize(migraphx::program& prog,
 
     // perform static quantization on the programs
     if (int8_enable) {
-      LOGS_DEFAULT(VERBOSE) << "Quantizing input program to int8";
       migraphx::quantize_int8_options quant_opts;
       quant_opts.add_calibration_data(quant_params);
       // specify thing we want to int8 quantize
       quant_opts.add_op_name("convolution");
       quant_opts.add_op_name("dot");
       migraphx::quantize_int8(prog, t, quant_opts);
-      LOGS_DEFAULT(VERBOSE) << "Quantizing int8: Complete";
     } else if (fp8_enable) {
 #if HIP_VERSION_MAJOR > 6 || (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 4)
-      LOGS_DEFAULT(VERBOSE) << "Quantizing input program to fp8";
       migraphx::quantize_fp8_options quant_opts;
       quant_opts.add_calibration_data(quant_params);
       migraphx::quantize_fp8(prog, t, quant_opts);
-      LOGS_DEFAULT(VERBOSE) << "Quantizing fp8: Complete";
 #endif
     }
   }
 
   if (fp16_enable) {
-    LOGS_DEFAULT(VERBOSE) << "Quantizing input program to fp16";
     migraphx::quantize_fp16(prog);
-    LOGS_DEFAULT(VERBOSE) << "Quantizing fp16: Complete";
   }
 
 #if HIP_VERSION_MAJOR > 6 || (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 4 && HIP_VERSION_PATCH >= 2)
   if (bf16_enable) {
-    LOGS_DEFAULT(VERBOSE) << "Quantizing input program to bf16";
     migraphx::quantize_bf16(prog);
-    LOGS_DEFAULT(VERBOSE) << "Quantizing bf16: Complete";
   }
 #endif
 }
@@ -1765,7 +1737,6 @@ void calibrate_and_quantize(migraphx::program& prog,
 void compile_program(migraphx::program& prog,
                      const migraphx::target& t,
                      bool exhaustive_tune) {
-  LOGS_DEFAULT(VERBOSE) << "Model Compile: Begin";
   migraphx::compile_options co;
   co.set_fast_math(false);
   co.set_exhaustive_tune_flag(exhaustive_tune);
@@ -2131,8 +2102,6 @@ static void handle_input_shape_mismatch(
   }
 
   // Set input parameter shapes from runtime tensors before compilation
-  LOGS_DEFAULT(VERBOSE) << "[Compute] Setting " << map_input_name_index.size()
-                        << " input parameter shapes as static in MIGraphX options (excluding constants)";
 
   for (const auto& it : map_input_name_index) {
     const auto& name = it.first;
@@ -2143,9 +2112,6 @@ static void handle_input_shape_mismatch(
     std::vector<std::size_t> ort_lens(tensor_shape.begin(), tensor_shape.end());
     cmp_options.set_input_parameter_shape(name, ort_lens);
 
-    LOGS_DEFAULT(VERBOSE) << "[Compute] Set static shape for input parameter '" << name << "': ["
-                          << [&]() {
-                              std::ostringstream ss;
                               for (size_t i = 0; i < ort_lens.size(); ++i) {
                                 if (i > 0) ss << ", ";
                                 ss << ort_lens[i];
@@ -2190,8 +2156,6 @@ static void handle_input_shape_mismatch(
   mgx_state->defer_compilation = false;
 }
 
-
-
 // Overload: Handle program inputs and outputs binding with pre-cached output shapes
 // This avoids calling prog.get_output_shapes() when shapes are already cached
 // When needs_slicing is true, allocates temporary GPU buffers for outputs instead of binding directly
@@ -2204,11 +2168,6 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
     bool needs_slicing = false,
     std::vector<void*>* temp_output_buffers = nullptr)
 {
-  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] ==== ENTERING ====";
-  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] needs_slicing=" << needs_slicing 
-                        << ", temp_output_buffers=" << (temp_output_buffers != nullptr ? "valid" : "nullptr");
-  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] param_shapes.size()=" << param_shapes.size()
-                        << ", output_shapes.size()=" << output_shapes.size();
   
   migraphx::program_parameters m;
   std::vector<std::size_t> prog_output_indices;
@@ -2235,11 +2194,6 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
           output_count++;
           const auto& mgx_arg_shape = param_shapes[name];
           
-          LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] Processing output '" << name 
-                                << "' (index=" << output_index << ")"
-                                << ", needs_slicing=" << needs_slicing 
-                                << ", temp_output_buffers=" << (temp_output_buffers != nullptr ? "valid" : "nullptr");
-          
           if (needs_slicing && temp_output_buffers != nullptr) {
             // When slicing, use pre-allocated temp buffer or allocate new one
             // Don't add to prog_output_indices since these aren't pre-allocated ORT outputs
@@ -2250,8 +2204,6 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
             if (temp_buffer_count < temp_output_buffers->size()) {
               // Use pre-allocated buffer from previous run
               temp_buffer = (*temp_output_buffers)[temp_buffer_count];
-              LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] ✓ REUSING pre-allocated TEMP BUFFER for output " 
-                                    << output_index << " '" << name << "' (" << output_size_bytes << " bytes)";
             } else {
               // Allocate new buffer (first run or buffer list is empty)
               auto hip_status = hipMalloc(&temp_buffer, output_size_bytes);
@@ -2259,17 +2211,11 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
                 ORT_THROW("hipMalloc failed for temporary output buffer");
               }
               temp_output_buffers->push_back(temp_buffer);
-              LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] ✓ Allocated NEW TEMP BUFFER for output " 
-                                    << output_index << " '" << name << "' (" << output_size_bytes << " bytes)";
             }
             temp_buffer_count++;
             m.add(name, migraphx::argument(mgx_arg_shape, temp_buffer));
-            LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] - NOT adding to prog_output_indices";
           } else {
             // Normal path: bind directly to ORT output tensor
-            LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] Using NORMAL PATH for output " 
-                                  << output_index << " '" << name << "'"
-                                  << " - adding to prog_output_indices";
             prog_output_indices.push_back(static_cast<std::size_t>(output_index));
             const auto& lens = output_shapes[output_index].lengths();
             const std::vector<int64_t> ort_output_shape(lens.begin(), lens.end());
@@ -2280,13 +2226,6 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
       }
     }
   }
-  
-  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] ==== SUMMARY ====";
-  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] Processed " << input_count << " inputs, " 
-                        << output_count << " outputs";
-  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] Temp buffers allocated: " << temp_buffer_count;
-  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] prog_output_indices.size()=" << prog_output_indices.size();
-  LOGS_DEFAULT(VERBOSE) << "[handle_program_input_outputs] ==== EXITING ====";
   
   return {m, prog_output_indices};
 }
@@ -2542,16 +2481,12 @@ static bool execute_fast_path(
     const std::string& current_hash,
     std::vector<std::int64_t>& all_input_shapes)
 {
-  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Checking for cached program with hash: " << current_hash;
   
   if (mgx_state->defer_compilation || !mgx_state->cached_programs_ref.has_value()) {
-    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Skipping - defer_compilation=" << mgx_state->defer_compilation
-                          << ", has cache=" << mgx_state->cached_programs_ref.has_value();
     return false;
   }
 
   auto& cached_programs = mgx_state->cached_programs_ref.value().get();
-  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Memory cache size: " << cached_programs.size();
   auto prog_it = cached_programs.find(current_hash);
   
   // If not found directly, check if we need to use a padded batch size
@@ -2561,7 +2496,6 @@ static bool execute_fast_path(
   
   if (prog_it == cached_programs.end() && mgx_state->has_dynamic_batch && 
       !mgx_state->compiled_batch_sizes.empty()) {
-    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Direct hash miss - checking for padded batch";
     // Try to find a padded batch size
     const auto& map_input_name_index = mgx_state->input_name_indexes;
     
@@ -2574,14 +2508,11 @@ static bool execute_fast_path(
         padded_batch_size = find_nearest_compiled_batch_size(original_batch_size,
                                                                     mgx_state->compiled_batch_sizes);
         needs_padding = (padded_batch_size > original_batch_size);
-        LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Original batch: " << original_batch_size
-                              << ", padded: " << padded_batch_size << ", needs_padding: " << needs_padding;
         break;
       }
     }
     
     if (needs_padding && padded_batch_size > 0) {
-      LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Building padded shape key for hash lookup";
       // Build padded shapes in alphabetical order (map order) for hash calculation
       // This matches the order used during compilation in compile_dynamic_batch_models
       std::vector<std::int64_t> padded_shapes_for_hash;
@@ -2599,17 +2530,13 @@ static bool execute_fast_path(
       }
       
       auto padded_hash = make_hash(padded_shapes_for_hash);
-      LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Padded hash (map order): " << padded_hash;
       prog_it = cached_programs.find(padded_hash);
       
       if (prog_it != cached_programs.end()) {
-        LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] ✓✓✓ CACHE HIT using padded batch size " 
-                           << padded_batch_size << " for original batch " << original_batch_size;
         
         // Now rebuild padded_shapes in cached_inputs order for saving to last_input_shapes_raw
         // This ensures ultra-fast path shape comparison works correctly
         if (!mgx_state->cached_inputs.empty()) {
-          LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Rebuilding in cached_inputs order for saving";
           std::vector<std::int64_t> padded_shapes_for_cache;
           padded_shapes_for_cache.reserve(mgx_state->cached_inputs.size() * 2);
           
@@ -2628,16 +2555,11 @@ static bool execute_fast_path(
           // Fallback: use map order (shouldn't happen if caches are populated)
           all_input_shapes = std::move(padded_shapes_for_hash);
         }
-      } else {
-        LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Cache miss for padded hash too";
       }
     }
-  } else if (prog_it != cached_programs.end()) {
-    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] ✓ CACHE HIT for exact hash";
   }
   
   if (prog_it == cached_programs.end()) {
-    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] No cached program found";
     return false;
   }
 
@@ -2661,7 +2583,6 @@ static bool execute_fast_path(
   }
 
   // Found cached program - use it and populate caches
-  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Using cached program (hash: " << effective_program_hash << ")";
   auto& prog = mgx_state->prog;
   prog = prog_it->second;
 
@@ -2674,19 +2595,14 @@ static bool execute_fast_path(
   bool program_changed = (mgx_state->cached_program_hash != effective_program_hash);
   
   if (program_changed) {
-    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Program changed (old: " << mgx_state->cached_program_hash 
-                          << ", new: " << effective_program_hash << ") - clearing caches";
     clear_cached_mgx_shapes(mgx_state);
     free_temp_output_buffers(mgx_state);
     mgx_state->cached_program_hash = effective_program_hash;
   }
   
   if (!mgx_state->cached_mgx_param_shapes.has_value()) {
-    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Caching MIGraphX shapes (first time or after program change)";
     mgx_state->cached_mgx_param_shapes = prog.get_parameter_shapes();
     mgx_state->cached_mgx_output_shapes = prog.get_output_shapes();
-  } else {
-    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] ✓ Using cached MIGraphX shapes";
   }
   const auto& param_shapes = mgx_state->cached_mgx_param_shapes.value();
   const auto& output_shapes = mgx_state->cached_mgx_output_shapes.value();
@@ -2698,12 +2614,9 @@ static bool execute_fast_path(
   // OPTIMIZATION 2: Skip populate_ultra_fast_caches when already populated
   // ═══════════════════════════════════════════════════════════════════════════
   if (!mgx_state->ultra_fast_caches_populated) {
-    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Populating ultra-fast caches (first time)";
     populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index,
                               original_batch_size, padded_batch_size);
     mgx_state->ultra_fast_caches_populated = true;
-  } else {
-    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] ✓ Ultra-fast caches already populated";
   }
 
   // Allocate and pad inputs if needed for dynamic batching
@@ -2726,17 +2639,9 @@ static bool execute_fast_path(
   }
 
   // Bind inputs/outputs (use temp buffers for outputs when slicing)
-  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Calling handle_program_input_outputs with needs_slicing=" << needs_slicing;
   auto [m, prog_output_indices] = handle_program_input_outputs(
       param_shapes, output_shapes, map_input_name_index, ctx, needs_slicing, 
       needs_slicing ? &temp_output_buffer_ptrs : nullptr);
-
-  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] handle_program_input_outputs returned:";
-  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH]   prog_output_indices.size()=" << prog_output_indices.size();
-  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH]   temp_output_buffer_ptrs.size()=" << temp_output_buffer_ptrs.size();
-  if (needs_slicing && !prog_output_indices.empty()) {
-    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH]   ⚠️  WARNING: prog_output_indices is NOT empty with slicing enabled!";
-  }
 
   mgx_state->cached_prog_params = std::move(m);
   mgx_state->cached_prog_output_indices = std::move(prog_output_indices);
@@ -2745,15 +2650,12 @@ static bool execute_fast_path(
   // This ensures ultra-fast path shape comparison uses consistent ordering
   mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(
       mgx_state, ctx, using_padded_inputs ? padded_batch_size : 0);
-  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Built last_input_shapes_raw in cached_inputs order, size=" 
-                        << mgx_state->last_input_shapes_raw.size();
   
   mgx_state->last_input_shape_hash = current_hash;
   mgx_state->caches_valid = true;
 
   // Rebind padded inputs to program parameters
   if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
-    LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Rebinding padded input buffers";
     auto& prog_params = mgx_state->cached_prog_params.value();
     for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
       const auto& inp = mgx_state->cached_inputs[i];
@@ -2762,8 +2664,6 @@ static bool execute_fast_path(
     }
   }
 
-  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Running program (original_batch=" << original_batch_size 
-                     << ", padded=" << padded_batch_size << ")";
   run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog,
                        mgx_state->cached_prog_params.value(),
                        mgx_state->cached_prog_output_indices,
@@ -2772,7 +2672,6 @@ static bool execute_fast_path(
   // NOTE: Temp output buffers are kept for reuse - they will be freed when batch size changes
   // NOTE: Padded input buffers are also kept for reuse
   
-  LOGS_DEFAULT(VERBOSE) << "[FAST_PATH] Complete";
   return true;
 }
 
@@ -2798,11 +2697,8 @@ static InputShapeResult handle_input_shape(
   std::vector<std::int64_t> input_shapes;
 
   if (defer_compilation) {
-    LOGS_DEFAULT(VERBOSE) << "[Compute] No static input shapes available, setting from runtime inputs";
     // NOTE: map_input_name_index only contains actual model inputs, not constants/initializers
     // Constants and initializers are embedded in the graph and MIGraphX infers their shapes
-    LOGS_DEFAULT(VERBOSE) << "[Compute] Setting shapes for " << map_input_name_index.size()
-                          << " model input parameters (excluding constants)";
 
     for (const auto& it : map_input_name_index) {
       const auto& name = it.first;
@@ -2819,10 +2715,7 @@ static InputShapeResult handle_input_shape(
       // Include all inputs in cache key (map_input_name_index already filtered to model inputs only)
       input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
     }
-    LOGS_DEFAULT(VERBOSE) << "[Compute] All runtime input shapes set as static parameters in MIGraphX options";
-    LOGS_DEFAULT(VERBOSE) << "[Compute] MIGraphX will infer shapes for constants and intermediate tensors";
   } else {
-    LOGS_DEFAULT(VERBOSE) << "[Compute] Checking if compiled program shapes match runtime inputs";
     param_shapes = prog.get_parameter_shapes();
 
     // Check if all input shapes match the compiled program's shapes
@@ -2846,8 +2739,6 @@ static InputShapeResult handle_input_shape(
 
           // Check if shapes match
           if (mgx_lens != ort_lens) {
-            LOGS_DEFAULT(VERBOSE) << "[Compute] Shape mismatch for input '" << name << "': "
-                                  << "compiled shape vs runtime shape differ";
             cmp_options.set_input_parameter_shape(name, ort_lens);
             input_shape_match = false;
           }
@@ -3029,10 +2920,6 @@ static void execute_standard_path(
     const std::filesystem::path& model_path,
     const std::string& mxr_filename_prefix)
 {
-  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] ==== ENTERING execute_standard_path ====";
-  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] current_hash = " << current_hash;
-  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] has_dynamic_batch = " << mgx_state->has_dynamic_batch;
-  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] max_dynamic_batch = " << mgx_state->max_dynamic_batch;
   
   auto& prog = mgx_state->prog;
   auto& cmp_options = mgx_state->options;
@@ -3044,19 +2931,11 @@ static void execute_standard_path(
   // In that case, the programs are already in cache and we can skip runtime compilation
   if (mgx_state->has_dynamic_batch && mgx_state->max_dynamic_batch > 0 && mgx_state->defer_compilation) {
     // Runtime compilation path - used when precompilation was not possible (e.g., non-pure dynamic batch)
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] *** RUNTIME COMPILATION REQUIRED ***";
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] max_dynamic_batch=" 
-                       << mgx_state->max_dynamic_batch;
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Initiating runtime compilation of batch models";
     
     // Compile all batch models at runtime
     compile_dynamic_batch_models(mgx_state, model_cache_path, model_path, mxr_filename_prefix, ctx);
     
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Runtime compilation complete, max_dynamic_batch now = " 
-                       << mgx_state->max_dynamic_batch;
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Proceeding with execution using closest compiled batch";
   } else if (mgx_state->has_dynamic_batch) {
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Dynamic batch enabled, models already precompiled";
   }
 
   // Extract current batch size from first input
@@ -3065,7 +2944,6 @@ static void execute_standard_path(
   bool needs_padding = false;
   
   if (mgx_state->has_dynamic_batch && !mgx_state->compiled_batch_sizes.empty()) {
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Checking for batch padding requirements";
     // Get the batch size from the first input
     for (const auto& [name, index] : map_input_name_index) {
       auto input_tensor = ctx.GetInput(index);
@@ -3077,9 +2955,6 @@ static void execute_standard_path(
                                                                     mgx_state->compiled_batch_sizes);
         needs_padding = (padded_batch_size > original_batch_size);
         
-        LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Original batch size: " << original_batch_size;
-        LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Padded batch size: " << padded_batch_size;
-        LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Needs padding: " << (needs_padding ? "YES" : "NO");
         break;  // Only need batch size from first input
       }
     }
@@ -3087,11 +2962,6 @@ static void execute_standard_path(
     // We need to fetch from cache whether padding is needed or not
     // Even when batch size matches exactly, we still use cached compiled programs
     if (padded_batch_size > 0) {
-      if (needs_padding) {
-        LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Building padded shape key for cache lookup (needs padding)";
-      } else {
-        LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Building shape key for cache lookup (exact match, no padding)";
-      }
       // Update the shape hash and all_input_shapes to use the padded batch size
       std::vector<std::int64_t> padded_shapes;
       padded_shapes.reserve(all_input_shapes.size());
@@ -3110,28 +2980,19 @@ static void execute_standard_path(
       
       // Look up the cached program for the padded batch size
       auto padded_hash = make_hash(padded_shapes);
-      LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Padded shape hash: " << padded_hash;
       
       if (mgx_state->cached_programs_ref.has_value()) {
         auto& cached_progs = mgx_state->cached_programs_ref.value().get();
-        LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Searching in memory cache (size: " 
-                          << cached_progs.size() << ")";
         auto prog_it = cached_progs.find(padded_hash);
         if (prog_it != cached_progs.end()) {
-          LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] ✓✓✓ CACHE HIT for batch size " 
-                             << padded_batch_size << (needs_padding ? " (will pad)" : " (exact match, no padding)");
           prog = prog_it->second;
           
           // Get shapes for the cached program
           auto param_shapes = prog.get_parameter_shapes();
           auto output_shapes = prog.get_output_shapes();
           
-          LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Cached program param_shapes.size()=" 
-                               << param_shapes.size() << ", output_shapes.size()=" << output_shapes.size();
-          
           if (needs_padding) {
             // ============ PADDING PATH: Batch size needs to be padded ============
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Taking PADDING path";
             
             // Populate caches (with slicing info so ultra-fast path is disabled)
             populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index,
@@ -3151,7 +3012,6 @@ static void execute_standard_path(
                 padded_shapes.insert(padded_shapes.end(), tensor_shape.begin() + 1, tensor_shape.end());
               }
             }
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Rebuilt padded_shapes in cached_inputs order";
             
             // Allocate and pad inputs for dynamic batching
             void* rocm_stream_ptr;
@@ -3161,20 +3021,9 @@ static void execute_standard_path(
                                                                padded_batch_size, rocm_stream);
             
             // Bind inputs and outputs with temporary output buffers (for slicing)
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Calling handle_program_input_outputs with needs_slicing=true";
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] param_shapes.size()=" << param_shapes.size()
-                                 << ", output_shapes.size()=" << output_shapes.size();
             std::vector<void*> temp_output_buffers;
             auto [m, prog_output_indices] = handle_program_input_outputs(
                 param_shapes, output_shapes, map_input_name_index, ctx, true, &temp_output_buffers);
-            
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] handle_program_input_outputs returned:";
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch]   prog_output_indices.size()=" << prog_output_indices.size();
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch]   temp_output_buffers.size()=" << temp_output_buffers.size();
-            if (!prog_output_indices.empty()) {
-              LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch]   ⚠️  WARNING: prog_output_indices is NOT empty!";
-              LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch]   ⚠️  This means outputs were pre-allocated instead of using temp buffers!";
-            }
             
             mgx_state->cached_prog_params = m;
             mgx_state->cached_prog_output_indices = prog_output_indices;
@@ -3184,7 +3033,6 @@ static void execute_standard_path(
             
             // Rebind padded inputs to program parameters
             if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
-              LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Rebinding padded input buffers";
               for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
                 const auto& inp = mgx_state->cached_inputs[i];
                 const auto& padded_buf = mgx_state->padded_input_buffers[i];
@@ -3192,7 +3040,6 @@ static void execute_standard_path(
               }
             }
             
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Running with output slicing enabled";
             // Run with slicing enabled
             run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, 
                                 prog_output_indices, original_batch_size, padded_batch_size);
@@ -3207,11 +3054,9 @@ static void execute_standard_path(
             // NOTE: Padded buffers are kept for reuse - they will be freed when batch size changes
             // or when the state is destroyed
             
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] ==== EXITING execute_standard_path (padded path) ====";
             return;
           } else {
             // ============ EXACT MATCH PATH: Batch size matches exactly, no padding needed ============
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Taking EXACT MATCH path (no padding/slicing)";
             
             // Populate caches for ultra-fast path (no slicing needed)
             populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
@@ -3220,9 +3065,6 @@ static void execute_standard_path(
             auto [m, prog_output_indices] = handle_program_input_outputs(
                 param_shapes, output_shapes, map_input_name_index, ctx);
             
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] handle_program_input_outputs returned:";
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch]   prog_output_indices.size()=" << prog_output_indices.size();
-            
             // Complete cache population
             mgx_state->cached_prog_params = m;
             mgx_state->cached_prog_output_indices = prog_output_indices;
@@ -3230,37 +3072,24 @@ static void execute_standard_path(
             // IMPORTANT: Build last_input_shapes_raw in cached_inputs order (MIGraphX parameter order)
             // This ensures ultra-fast path shape comparison uses consistent ordering
             mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(mgx_state, ctx, 0);
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Built last_input_shapes_raw in cached_inputs order, size=" 
-                                  << mgx_state->last_input_shapes_raw.size();
             
             mgx_state->last_input_shape_hash = current_hash;
             mgx_state->caches_valid = true;
             
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Running program (exact batch match, no padding/slicing)";
             run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, prog_output_indices, 
                                 0, 0);  // Pass 0,0 for batch sizes to indicate no slicing needed
             
-            LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] ==== EXITING execute_standard_path (exact match path) ====";
             return;
           }
-        } else {
-          LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] ✗✗✗ CACHE MISS for hash " 
-                                << padded_hash;
-          LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] This shouldn't happen - expected batch "
-                                << padded_batch_size << " to be pre-compiled";
         }
       }
     }
   }
 
-  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] Proceeding with normal shape checking";
   auto [input_shape_match, param_shapes, input_shapes] = handle_input_shape(
       mgx_state->defer_compilation, map_input_name_index, ctx, cmp_options, prog);
 
-  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] input_shape_match = " << input_shape_match;
-  
   if (!input_shape_match) {
-    LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] Shape mismatch detected - recompiling";
     // Invalidate caches before recompilation
     mgx_state->caches_valid = false;
 
@@ -3294,16 +3123,12 @@ static void execute_standard_path(
   // IMPORTANT: Build last_input_shapes_raw in cached_inputs order (MIGraphX parameter order)
   // This ensures ultra-fast path shape comparison uses consistent ordering
   mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(mgx_state, ctx, 0);
-  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] Built last_input_shapes_raw in cached_inputs order, size=" 
-                        << mgx_state->last_input_shapes_raw.size();
   
   mgx_state->last_input_shape_hash = current_hash;
   mgx_state->caches_valid = true;
 
-  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] Running program (no padding/slicing)";
   run_migraphx_program(mgx_state->mgx_mu_ptr, api, context, ctx, prog, m, prog_output_indices, 
                       original_batch_size, padded_batch_size);
-  LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH] ==== EXITING execute_standard_path (normal path) ====";
 }
 
 // Build MIGraphX ONNX options with default shapes for symbolic dimensions
@@ -3318,7 +3143,6 @@ static migraphx::onnx_options get_program_parameter_options(
   for (std::size_t i = 0; i < input_names.size(); ++i) {
     // Skip if this is an initializer/constant - let MIGraphX infer its shape
     if (initializers.count(input_names[i]) > 0) {
-      LOGS_DEFAULT(VERBOSE) << "[Compile] Skipping '" << input_names[i] << "' (initializer/constant)";
       continue;
     }
 
@@ -3336,14 +3160,11 @@ static migraphx::onnx_options get_program_parameter_options(
             // Symbolic or unknown dimension - use default batch size for dim 0, 1 for others
             has_symbolic = true;
             default_shape.push_back(j == 0 ? default_batch_size : 1);
-            LOGS_DEFAULT(VERBOSE) << "[Compile] Input parameter '" << input_names[i]
-                                  << "' dimension " << j << " is symbolic, using default";
           }
         }
 
         if (has_symbolic && !default_shape.empty()) {
           options.set_input_parameter_shape(input_names[i], default_shape);
-          LOGS_DEFAULT(VERBOSE) << "[Compile] Set default shape for input parameter '" << input_names[i] << "'";
         }
       }
     }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -13,6 +13,7 @@
 #include <memory>
 #include <mutex>
 #include <set>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -139,6 +140,8 @@ static std::string_view GetArenaExtendStrategyName(ArenaExtendStrategy strategy)
 #define GET_ENV_STRING(variable, value) \
   GET_ENV(variable, value, value = value##env)
 
+static std::vector<std::size_t> parse_compile_batches(const std::string& spec);
+
 MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProviderInfo& info)
     : IExecutionProvider{kMIGraphXExecutionProvider, OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, OrtDevice::VendorIds::AMD, info.device_id)},
       device_id_{info.device_id},
@@ -158,7 +161,8 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
       external_free_{info.external_free},
       external_empty_cache_{info.external_empty_cache},
       max_dynamic_batch_{info.max_dynamic_batch},
-      max_compiled_models_{info.max_compiled_models} {
+      max_compiled_models_{info.max_compiled_models},
+      compile_batches_{info.compile_batches} {
   InitProviderOrtApi();
 
   // Set GPU device to be used and read device properties for feature usage.
@@ -194,6 +198,27 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
   GET_ENV_BOOL(migraphx_env_vars::kDumpModelOps, dump_model_ops_);
   GET_ENV_BOOL(migraphx_env_vars::kExhaustiveTune, exhaustive_tune_);
   GET_ENV(migraphx_env_vars::kMaxCompiledModels, max_compiled_models_, max_compiled_models_ = std::stoul(max_compiled_models_env));
+  GET_ENV_STRING(migraphx_env_vars::kCompileBatches, compile_batches_);
+
+  // If compile_batches is set, auto-derive max_dynamic_batch from the spec's max value
+  if (!compile_batches_.empty()) {
+    auto explicit_sizes = parse_compile_batches(compile_batches_);
+    if (!explicit_sizes.empty()) {
+      std::size_t derived_max = explicit_sizes.back();
+      if (max_dynamic_batch_ == 0) {
+        max_dynamic_batch_ = derived_max;
+        LOGS_DEFAULT(INFO) << "[MIGraphX] compile_batches set: auto-derived max_dynamic_batch=" << derived_max;
+      } else if (max_dynamic_batch_ < derived_max) {
+        LOGS_DEFAULT(WARNING) << "[MIGraphX] compile_batches max (" << derived_max
+                              << ") exceeds max_dynamic_batch (" << max_dynamic_batch_
+                              << "). Updating max_dynamic_batch to " << derived_max;
+        max_dynamic_batch_ = derived_max;
+      }
+      LOGS_DEFAULT(INFO) << "[MIGraphX] compile_batches='" << compile_batches_
+                         << "', effective max_dynamic_batch=" << max_dynamic_batch_
+                         << ", batch count=" << explicit_sizes.size();
+    }
+  }
 
   // Verify configuration correctness and adjust accordingly.
 
@@ -253,7 +278,8 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
                         << "\n int8_calibration_cache_available: " << int8_calibration_cache_available_
                         << "\n " << migraphx_provider_option::kInt8UseNativeCalibTable << ": " << int8_use_native_calibration_table_
                         << "\n " << migraphx_provider_option::kModelCacheDir << ": " << model_cache_path_
-                        << "\n " << migraphx_provider_option::kModelMaxDynamicBatch << ": " << max_dynamic_batch_;
+                        << "\n " << migraphx_provider_option::kModelMaxDynamicBatch << ": " << max_dynamic_batch_
+                        << "\n " << migraphx_provider_option::kCompileBatches << ": " << (compile_batches_.empty() ? "(not set)" : compile_batches_);
 }
 
 std::vector<AllocatorPtr> MIGraphXExecutionProvider::CreatePreferredAllocators() {
@@ -1218,32 +1244,87 @@ static std::pair<std::vector<std::string>, std::vector<std::string>> get_io_name
 // Useful to default to EP to trigger the compile if file doesn't exist or loading fails.
 bool load_precompiled_model(migraphx::program& prog, const std::filesystem::path& path) try {
   if (!path.empty() && exists(path)) {
-    LOGS_DEFAULT(VERBOSE) << "[load_precompiled_model] Attempting to load model from disk: " << path.string();
+    auto file_sz = std::filesystem::file_size(path);
+    LOGS_DEFAULT(INFO) << "[load_precompiled_model] Loading model from disk: " << path.string()
+                       << " (file size: " << file_sz << " bytes, "
+                       << (file_sz / (1024.0 * 1024.0)) << " MB)";
     migraphx::file_options fo;
     fo.set_file_format("msgpack");
     prog = migraphx::load(path.string().c_str(), fo);
-    LOGS_DEFAULT(VERBOSE) << "[load_precompiled_model] ✓ Successfully loaded model from disk";
+    LOGS_DEFAULT(INFO) << "[load_precompiled_model] Loaded model from disk: " << path.string()
+                       << " (file size: " << file_sz << " bytes, "
+                       << (file_sz / (1024.0 * 1024.0)) << " MB)";
     return true;
   }
   LOGS_DEFAULT(VERBOSE) << "[load_precompiled_model] Cache file does not exist: " 
                         << (path.empty() ? "(no path specified)" : path.string());
   return false;
 } catch (const std::exception& e) {
-  LOGS_DEFAULT(VERBOSE) << "[load_precompiled_model] ✗ Failed to load model from disk: " << e.what();
+  LOGS_DEFAULT(WARNING) << "[load_precompiled_model] Failed to load model from disk: " << e.what();
   return false;
   } catch (...) {
-  LOGS_DEFAULT(VERBOSE) << "[load_precompiled_model] ✗ Failed to load model from disk (unknown exception)";
+  LOGS_DEFAULT(WARNING) << "[load_precompiled_model] Failed to load model from disk (unknown exception)";
   return false;
 }
 
 void save_compiled_model(const migraphx::program& prog, const std::filesystem::path& path) {
   if (!path.empty()) {
-    LOGS_DEFAULT(VERBOSE) << "[save_compiled_model] Saving compiled model to disk: " << path.string();
+    LOGS_DEFAULT(INFO) << "[save_compiled_model] Saving compiled model to disk: " << path.string();
     migraphx::file_options fo;
     fo.set_file_format("msgpack");
     save(prog, path.string().c_str(), fo);
-    LOGS_DEFAULT(VERBOSE) << "[save_compiled_model] ✓ Model saved successfully";
+    if (std::filesystem::exists(path)) {
+      auto file_sz = std::filesystem::file_size(path);
+      LOGS_DEFAULT(INFO) << "[save_compiled_model] Saved: " << path.string()
+                         << " (file size: " << file_sz << " bytes, "
+                         << (file_sz / (1024.0 * 1024.0)) << " MB)";
+    }
   }
+}
+
+// Parse compile_batches specification: a comma-separated list of explicit batch sizes.
+// Example: "1,4,8,16,32" compiles exactly those five batch sizes.
+// Values are deduplicated and sorted in ascending order.
+// At runtime the existing pad logic selects the smallest compiled batch >= the request.
+static std::vector<std::size_t> parse_compile_batches(const std::string& spec) {
+  std::vector<std::size_t> batch_sizes;
+  if (spec.empty()) return batch_sizes;
+
+  std::istringstream iss(spec);
+  std::string token;
+  while (std::getline(iss, token, ',')) {
+    if (token.empty()) continue;
+    try {
+      auto val = std::stoull(token);
+      if (val == 0) {
+        LOGS_DEFAULT(WARNING) << "[MIGraphX] compile_batches: skipping zero-valued entry";
+        continue;
+      }
+      batch_sizes.push_back(static_cast<std::size_t>(val));
+    } catch (const std::exception& e) {
+      LOGS_DEFAULT(WARNING) << "[MIGraphX] compile_batches: could not parse '" << token
+                            << "' as an integer (" << e.what() << "). Skipping.";
+    }
+  }
+
+  if (batch_sizes.empty()) {
+    LOGS_DEFAULT(WARNING) << "[MIGraphX] compile_batches: no valid batch sizes in '" << spec << "'. Ignoring.";
+    return batch_sizes;
+  }
+
+  std::sort(batch_sizes.begin(), batch_sizes.end());
+  batch_sizes.erase(std::unique(batch_sizes.begin(), batch_sizes.end()), batch_sizes.end());
+
+  std::ostringstream oss;
+  oss << "[MIGraphX] compile_batches '" << spec << "' -> [";
+  for (std::size_t i = 0; i < batch_sizes.size(); ++i) {
+    if (i > 0) oss << ", ";
+    oss << batch_sizes[i];
+  }
+  oss << "] (count=" << batch_sizes.size() << ")";
+  LOGS_DEFAULT(INFO) << oss.str();
+
+  return batch_sizes;
 }
 
 // Generate a vector of batch sizes to compile based on max_compiled_models setting
@@ -1296,28 +1377,36 @@ static std::vector<std::size_t> generate_compiled_batch_sizes(std::size_t max_ba
   return batch_sizes;
 }
 
-// Find the smallest compiled batch size >= requested_batch
-// Uses the same evenly-spaced scheme as generate_compiled_batch_sizes
-static std::size_t find_nearest_compiled_batch_size(std::size_t requested_batch,
-                                                           std::size_t max_batch_size,
-                                                           std::size_t max_compiled_models) {
-  if (max_batch_size == 0) {
-    return 0;
+// Overload: if compile_batches spec is given, use it; otherwise fall back to evenly-spaced scheme.
+static std::vector<std::size_t> generate_compiled_batch_sizes(
+    std::size_t max_batch_size, std::size_t max_compiled_models,
+    const std::string& compile_batches_spec) {
+  if (!compile_batches_spec.empty()) {
+    auto batch_sizes = parse_compile_batches(compile_batches_spec);
+    if (!batch_sizes.empty()) {
+      LOGS_DEFAULT(INFO) << "[MIGraphX] Using compile_batches specification '" << compile_batches_spec
+                         << "' (overrides max_compiled_models=" << max_compiled_models << ")";
+      return batch_sizes;
+    }
+    LOGS_DEFAULT(WARNING) << "[MIGraphX] compile_batches parse failed, falling back to evenly-spaced scheme";
   }
+  return generate_compiled_batch_sizes(max_batch_size, max_compiled_models);
+}
 
-  if (max_compiled_models == 1) {
-    return max_batch_size;
+// Find the smallest compiled batch size >= requested_batch from pre-computed vector.
+// The vector must be sorted in ascending order.
+static std::size_t find_nearest_compiled_batch_size(
+    std::size_t requested_batch,
+    const std::vector<std::size_t>& compiled_batch_sizes) {
+  if (compiled_batch_sizes.empty()) {
+    return requested_batch;
   }
-
-  // Walk the evenly-spaced batch sizes and return the first one >= requested_batch
-  std::size_t n = max_compiled_models;
-  for (std::size_t i = 0; i < n; ++i) {
-    std::size_t bs = 1 + (max_batch_size - 1) * i / (n - 1);
+  for (const auto& bs : compiled_batch_sizes) {
     if (bs >= requested_batch) {
       return bs;
     }
   }
-  return max_batch_size;
+  return compiled_batch_sizes.back();
 }
 
 // Pad input tensor data to a larger batch size
@@ -2372,7 +2461,7 @@ static bool execute_ultra_fast_path(
         if (shape[0] != last_shapes[offset]) {
           // Batch size changed - check if we can use padding
           std::size_t required_padded = find_nearest_compiled_batch_size(
-              original_batch_size, mgx_state->max_dynamic_batch, mgx_state->max_compiled_models);
+              original_batch_size, mgx_state->compiled_batch_sizes);
           
           if (required_padded != padded_batch_size) {
             shapes_match = false;
@@ -2517,8 +2606,7 @@ static bool execute_fast_path(
       if (!tensor_shape.empty()) {
         original_batch_size = static_cast<std::size_t>(tensor_shape[0]);
         padded_batch_size = find_nearest_compiled_batch_size(original_batch_size,
-                                                                    mgx_state->max_dynamic_batch,
-                                                                    mgx_state->max_compiled_models);
+                                                                    mgx_state->compiled_batch_sizes);
         needs_padding = (padded_batch_size > original_batch_size);
         LOGS_DEFAULT(VERBOSE) << "[FAST_PATH][DynamicBatch] Original batch: " << original_batch_size
                               << ", padded: " << padded_batch_size << ", needs_padding: " << needs_padding;
@@ -3020,8 +3108,7 @@ static void execute_standard_path(
       if (!tensor_shape.empty()) {
         original_batch_size = static_cast<std::size_t>(tensor_shape[0]);
         padded_batch_size = find_nearest_compiled_batch_size(original_batch_size,
-                                                                    mgx_state->max_dynamic_batch,
-                                                                    mgx_state->max_compiled_models);
+                                                                    mgx_state->compiled_batch_sizes);
         needs_padding = (padded_batch_size > original_batch_size);
         
         LOGS_DEFAULT(VERBOSE) << "[STANDARD_PATH][DynamicBatch] Original batch size: " << original_batch_size;
@@ -3720,7 +3807,32 @@ static inline void precompile_all_dynamic_batch_models(
                        << needs_compilation.size() << " models compiled";
   }
   
-  LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] ✓ All " 
+  // Summary: report total disk and in-memory cache sizes
+  {
+    std::size_t total_disk_bytes = 0;
+    std::size_t disk_file_count = 0;
+    for (const auto& batch_size : compiled_batch_sizes) {
+      std::vector<std::int64_t> bsk;
+      for (std::size_t i = 0; i < input_names.size(); ++i) {
+        bsk.push_back(static_cast<std::int64_t>(batch_size));
+        bsk.insert(bsk.end(), all_input_base_shapes[i].begin(), all_input_base_shapes[i].end());
+      }
+      auto hash = make_hash(bsk);
+      if (!model_cache_path.empty()) {
+        auto fpath = model_cache_path / (mxr_filename_prefix + hash + ".mxr");
+        if (std::filesystem::exists(fpath)) {
+          total_disk_bytes += std::filesystem::file_size(fpath);
+          ++disk_file_count;
+        }
+      }
+    }
+    LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] === CACHE SUMMARY ===";
+    LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] In-memory programs: " << cached_programs.size();
+    LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] Disk cache files: " << disk_file_count
+                       << ", total disk size: " << total_disk_bytes << " bytes ("
+                       << (total_disk_bytes / (1024.0 * 1024.0)) << " MB)";
+  }
+  LOGS_DEFAULT(INFO) << "[precompile_all_dynamic_batch_models] All " 
                      << cached_programs.size() << " models ready";
 }
 
@@ -3882,7 +3994,8 @@ static inline bool handle_precompilation_decision(
     const std::string& mxr_filename_prefix,
     std::unordered_map<std::string, migraphx::program>& cached_programs,
     std::size_t max_dynamic_batch,
-    std::size_t max_compiled_models)
+    std::size_t max_compiled_models,
+    const std::string& compile_batches_spec)
 {
   // ═══════════════════════════════════════════════════════════════════════════
   // PRECOMPILATION: Compile models during Compile() phase instead of compute_func()
@@ -3930,7 +4043,7 @@ static inline bool handle_precompilation_decision(
       if (shapes_valid) {
         
         // All non-batch dimensions are concrete - precompile all batch models
-        auto compiled_batch_sizes = generate_compiled_batch_sizes(max_dynamic_batch, max_compiled_models);
+        auto compiled_batch_sizes = generate_compiled_batch_sizes(max_dynamic_batch, max_compiled_models, compile_batches_spec);
         
         std::ostringstream batch_ss;
         batch_ss << "[";
@@ -4129,7 +4242,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         mxr_filename_prefix,
         cached_programs_[fused_node.Name()],
         max_dynamic_batch_,
-        max_compiled_models_);
+        max_compiled_models_,
+        compile_batches_);
 
     // Create program object (may be empty if precompiled programs are in cache)
     migraphx::program prog;
@@ -4153,11 +4267,22 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       // Initialize dynamic batch support if max_dynamic_batch > 0
       if (max_dynamic_batch_ > 0) {
         p->has_dynamic_batch = true;
-        p->compiled_batch_sizes = generate_compiled_batch_sizes(max_dynamic_batch_, max_compiled_models_);
-        LOGS_DEFAULT(VERBOSE) << "[Compile][CREATE_STATE] Dynamic batch enabled for node '" << context->node_name 
-                              << "' with max_dynamic_batch=" << max_dynamic_batch_
-                              << ", max_compiled_models=" << max_compiled_models_
-                              << ", generated " << p->compiled_batch_sizes.size() << " batch sizes to compile";
+        p->compiled_batch_sizes = generate_compiled_batch_sizes(max_dynamic_batch_, max_compiled_models_, compile_batches_);
+        LOGS_DEFAULT(INFO) << "[Compile][CREATE_STATE] Dynamic batch enabled for node '" << context->node_name 
+                           << "' with max_dynamic_batch=" << max_dynamic_batch_
+                           << ", max_compiled_models=" << max_compiled_models_
+                           << ", compile_batches='" << compile_batches_ << "'"
+                           << ", generated " << p->compiled_batch_sizes.size() << " batch sizes to compile";
+        {
+          std::ostringstream bs_oss;
+          bs_oss << "[";
+          for (std::size_t bi = 0; bi < p->compiled_batch_sizes.size(); ++bi) {
+            if (bi > 0) bs_oss << ", ";
+            bs_oss << p->compiled_batch_sizes[bi];
+          }
+          bs_oss << "]";
+          LOGS_DEFAULT(INFO) << "[Compile][CREATE_STATE] Batch sizes: " << bs_oss.str();
+        }
         LOGS_DEFAULT(VERBOSE) << "[Compile][CREATE_STATE] defer_compilation=" << p->defer_compilation;
       } else {
         LOGS_DEFAULT(VERBOSE) << "[Compile][CREATE_STATE] Static model mode for node '" << context->node_name << "'";

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -161,7 +161,6 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
       external_free_{info.external_free},
       external_empty_cache_{info.external_empty_cache},
       max_dynamic_batch_{info.max_dynamic_batch},
-      max_compiled_models_{info.max_compiled_models},
       compile_batches_{info.compile_batches} {
   InitProviderOrtApi();
 
@@ -197,7 +196,6 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
 
   GET_ENV_BOOL(migraphx_env_vars::kDumpModelOps, dump_model_ops_);
   GET_ENV_BOOL(migraphx_env_vars::kExhaustiveTune, exhaustive_tune_);
-  GET_ENV(migraphx_env_vars::kMaxCompiledModels, max_compiled_models_, max_compiled_models_ = std::stoul(max_compiled_models_env));
   GET_ENV_STRING(migraphx_env_vars::kCompileBatches, compile_batches_);
 
   // If compile_batches is set, auto-derive max_dynamic_batch from the spec's max value
@@ -1327,86 +1325,54 @@ static std::vector<std::size_t> parse_compile_batches(const std::string& spec) {
   return batch_sizes;
 }
 
-// Generate a vector of batch sizes to compile based on max_compiled_models setting
-// Batch sizes are evenly spaced between 1 and max_batch_size.
-// max_compiled_models == 1: {max}
-// max_compiled_models == 2: {1, max}
-// max_compiled_models == 3: {1, max/2, max}
-// max_compiled_models == N: N evenly spaced values from 1 to max
-static std::vector<std::size_t> generate_compiled_batch_sizes(std::size_t max_batch_size, std::size_t max_compiled_models) {
+// Generate a vector of power-of-2 batch sizes from 1 up to the nearest power of 2 >= max_batch_size.
+// E.g., max_batch_size=100 returns {1, 2, 4, 8, 16, 32, 64, 128}
+static std::vector<std::size_t> generate_power_of_two_batch_sizes(std::size_t max_batch_size) {
   std::vector<std::size_t> batch_sizes;
   if (max_batch_size == 0) {
     return batch_sizes;
   }
 
-  if (max_compiled_models == 0) {
-    LOGS_DEFAULT(WARNING) << "max_compiled_models is 0. Defaulting to 1 (compile max batch size only).";
-    max_compiled_models = 1;
-  } else if (max_compiled_models > max_batch_size) {
-    LOGS_DEFAULT(WARNING) << "max_compiled_models (" << max_compiled_models
-                          << ") exceeds max_batch_size (" << max_batch_size
-                          << "). Setting max_compiled_models to " << max_batch_size << ".";
-    max_compiled_models = max_batch_size;
+  std::size_t target = 1;
+  while (target < max_batch_size) {
+    target *= 2;
   }
 
-  if (max_compiled_models == 1) {
-    batch_sizes.push_back(max_batch_size);
-  } else if (max_compiled_models >= 2) {
-    // Evenly divide the range [1, max_batch_size] into max_compiled_models points
-    std::size_t n = max_compiled_models;
-    for (std::size_t i = 0; i < n; ++i) {
-      std::size_t bs = 1 + (max_batch_size - 1) * i / (n - 1);
-      // Avoid duplicates (can happen when max_batch_size is small relative to n)
-      if (batch_sizes.empty() || bs > batch_sizes.back()) {
-        batch_sizes.push_back(bs);
-      }
-    }
+  for (std::size_t bs = 1; bs <= target; bs *= 2) {
+    batch_sizes.push_back(bs);
   }
-
-  std::ostringstream oss;
-  oss << "[MIGraphX] max_batch_size=" << max_batch_size
-      << ", max_compiled_models=" << max_compiled_models
-      << ", batch_sizes_to_compile=[";
-  for (std::size_t i = 0; i < batch_sizes.size(); ++i) {
-    if (i > 0) oss << ", ";
-    oss << batch_sizes[i];
-  }
-  oss << "] (count=" << batch_sizes.size() << ")";
-  LOGS_DEFAULT(VERBOSE) << oss.str();
-
   return batch_sizes;
 }
 
-// Overload: if compile_batches spec is given, use it; otherwise fall back to evenly-spaced scheme.
+// Two-tier batch size generation:
+//   1. If compile_batches spec is provided, use those explicit batch sizes
+//   2. Otherwise, generate power-of-two batch sizes (bounded 2x padding overhead)
 static std::vector<std::size_t> generate_compiled_batch_sizes(
-    std::size_t max_batch_size, std::size_t max_compiled_models,
+    std::size_t max_batch_size,
     const std::string& compile_batches_spec) {
   if (!compile_batches_spec.empty()) {
     auto batch_sizes = parse_compile_batches(compile_batches_spec);
     if (!batch_sizes.empty()) {
-      LOGS_DEFAULT(INFO) << "[MIGraphX] Using compile_batches specification '" << compile_batches_spec
-                         << "' (overrides max_compiled_models=" << max_compiled_models << ")";
+      LOGS_DEFAULT(INFO) << "[MIGraphX] Using explicit compile_batches: '" << compile_batches_spec << "'";
       return batch_sizes;
     }
-    LOGS_DEFAULT(WARNING) << "[MIGraphX] compile_batches parse failed, falling back to evenly-spaced scheme";
+    LOGS_DEFAULT(WARNING) << "[MIGraphX] compile_batches parse failed, falling back to power-of-two";
   }
-  return generate_compiled_batch_sizes(max_batch_size, max_compiled_models);
+  return generate_power_of_two_batch_sizes(max_batch_size);
 }
 
 // Find the smallest compiled batch size >= requested_batch from pre-computed vector.
 // The vector must be sorted in ascending order.
+// Returns 0 if no suitable batch size found (caller must handle this case).
 static std::size_t find_nearest_compiled_batch_size(
     std::size_t requested_batch,
     const std::vector<std::size_t>& compiled_batch_sizes) {
-  if (compiled_batch_sizes.empty()) {
-    return requested_batch;
-  }
   for (const auto& bs : compiled_batch_sizes) {
     if (bs >= requested_batch) {
       return bs;
     }
   }
-  return compiled_batch_sizes.back();
+  return 0;
 }
 
 // Pad input tensor data to a larger batch size
@@ -3994,7 +3960,6 @@ static inline bool handle_precompilation_decision(
     const std::string& mxr_filename_prefix,
     std::unordered_map<std::string, migraphx::program>& cached_programs,
     std::size_t max_dynamic_batch,
-    std::size_t max_compiled_models,
     const std::string& compile_batches_spec)
 {
   // ═══════════════════════════════════════════════════════════════════════════
@@ -4043,7 +4008,7 @@ static inline bool handle_precompilation_decision(
       if (shapes_valid) {
         
         // All non-batch dimensions are concrete - precompile all batch models
-        auto compiled_batch_sizes = generate_compiled_batch_sizes(max_dynamic_batch, max_compiled_models, compile_batches_spec);
+        auto compiled_batch_sizes = generate_compiled_batch_sizes(max_dynamic_batch, compile_batches_spec);
         
         std::ostringstream batch_ss;
         batch_ss << "[";
@@ -4242,7 +4207,6 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         mxr_filename_prefix,
         cached_programs_[fused_node.Name()],
         max_dynamic_batch_,
-        max_compiled_models_,
         compile_batches_);
 
     // Create program object (may be empty if precompiled programs are in cache)
@@ -4262,17 +4226,16 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             map_defer_compilation_[context->node_name], fp16_enable_, bf16_enable_, fp8_enable_, int8_enable_,
             int8_calibration_cache_available_, dynamic_range_map_,
             model_cache_path_, dump_model_ops_, exhaustive_tune_, max_dynamic_batch_,
-            max_compiled_models_, std::ref(cached_programs_[context->node_name])};
+            std::ref(cached_programs_[context->node_name])};
       
       // Initialize dynamic batch support if max_dynamic_batch > 0
       if (max_dynamic_batch_ > 0) {
         p->has_dynamic_batch = true;
-        p->compiled_batch_sizes = generate_compiled_batch_sizes(max_dynamic_batch_, max_compiled_models_, compile_batches_);
-        LOGS_DEFAULT(INFO) << "[Compile][CREATE_STATE] Dynamic batch enabled for node '" << context->node_name 
-                           << "' with max_dynamic_batch=" << max_dynamic_batch_
-                           << ", max_compiled_models=" << max_compiled_models_
-                           << ", compile_batches='" << compile_batches_ << "'"
-                           << ", generated " << p->compiled_batch_sizes.size() << " batch sizes to compile";
+        p->compiled_batch_sizes = generate_compiled_batch_sizes(max_dynamic_batch_, compile_batches_);
+        LOGS_DEFAULT(VERBOSE) << "[Compile][CREATE_STATE] Dynamic batch enabled for node '" << context->node_name 
+                              << "' with max_dynamic_batch=" << max_dynamic_batch_
+                              << ", compile_batches='" << (compile_batches_.empty() ? "(power-of-two)" : compile_batches_) << "'"
+                              << ", generated " << p->compiled_batch_sizes.size() << " batch sizes to compile";
         {
           std::ostringstream bs_oss;
           bs_oss << "[";

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -36,7 +36,6 @@ constexpr auto kINT8UseNativeMIGraphXCalibrationTable = "ORT_MIGRAPHX_INT8_USE_N
 constexpr auto kExhaustiveTune = "ORT_MIGRAPHX_EXHAUSTIVE_TUNE"sv;
 constexpr auto kModelCachePath = "ORT_MIGRAPHX_MODEL_CACHE_PATH"sv;
 constexpr auto kModelMaxDynamicBatch = "ORT_MIGRAPHX_MAX_DYNAMIC_BATCH"sv;
-constexpr auto kMaxCompiledModels = "ORT_MIGRAPHX_MAX_COMPILED_MODELS"sv;
 constexpr auto kCompileBatches = "ORT_MIGRAPHX_COMPILE_BATCHES"sv;
 }  // namespace migraphx_env_vars
 
@@ -68,7 +67,6 @@ struct MIGraphXFuncState {
   bool dump_model_ops = false;
   bool exhaustive_tune = false;
   size_t max_dynamic_batch;
-  size_t max_compiled_models = 1;  // Number of evenly-spaced batch sizes to compile (1 -> max only)
   // Reference to the cached programs map for this node (keyed by input shape hash)
   std::optional<std::reference_wrapper<std::unordered_map<std::string, migraphx::program>>> cached_programs_ref = std::nullopt;
   
@@ -210,7 +208,6 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
         {std::string{migraphx_provider_option::kGpuExternalEmptyCache}, MakeStringWithClassicLocale(external_empty_cache_)},
         {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_path_)},
         {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(max_dynamic_batch_)},
-        {std::string{migraphx_provider_option::kMaxCompiledModels}, MakeStringWithClassicLocale(max_compiled_models_)},
         {std::string{migraphx_provider_option::kCompileBatches}, compile_batches_}};
    }
 
@@ -252,7 +249,6 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   void* external_empty_cache_{nullptr};
   bool first_start_ = true;
   size_t max_dynamic_batch_{0};
-  size_t max_compiled_models_{1};  // Number of evenly-spaced batch sizes to compile (1 -> max only)
   std::string compile_batches_{};  // Comma-separated list of batch sizes to compile, e.g. "1,4,8,16,32"
 };
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -37,6 +37,7 @@ constexpr auto kExhaustiveTune = "ORT_MIGRAPHX_EXHAUSTIVE_TUNE"sv;
 constexpr auto kModelCachePath = "ORT_MIGRAPHX_MODEL_CACHE_PATH"sv;
 constexpr auto kModelMaxDynamicBatch = "ORT_MIGRAPHX_MAX_DYNAMIC_BATCH"sv;
 constexpr auto kMaxCompiledModels = "ORT_MIGRAPHX_MAX_COMPILED_MODELS"sv;
+constexpr auto kCompileBatches = "ORT_MIGRAPHX_COMPILE_BATCHES"sv;
 }  // namespace migraphx_env_vars
 
 // Tracks which dimensions are symbolic for a given input
@@ -209,7 +210,8 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
         {std::string{migraphx_provider_option::kGpuExternalEmptyCache}, MakeStringWithClassicLocale(external_empty_cache_)},
         {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_path_)},
         {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(max_dynamic_batch_)},
-        {std::string{migraphx_provider_option::kMaxCompiledModels}, MakeStringWithClassicLocale(max_compiled_models_)}};
+        {std::string{migraphx_provider_option::kMaxCompiledModels}, MakeStringWithClassicLocale(max_compiled_models_)},
+        {std::string{migraphx_provider_option::kCompileBatches}, compile_batches_}};
    }
 
  private:
@@ -251,6 +253,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   bool first_start_ = true;
   size_t max_dynamic_batch_{0};
   size_t max_compiled_models_{1};  // Number of evenly-spaced batch sizes to compile (1 -> max only)
+  std::string compile_batches_{};  // Comma-separated list of batch sizes to compile, e.g. "1,4,8,16,32"
 };
 
 }; // namespace onnxruntime

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
@@ -73,7 +73,6 @@ MIGraphXExecutionProviderInfo::MIGraphXExecutionProviderInfo(const ProviderOptio
           .AddAssignmentToReference(migraphx_provider_option::kMemLimit, mem_limit)
           .AddAssignmentToEnumReference(migraphx_provider_option::kArenaExtendStrategy, arena_extend_strategy_mapping, arena_extend_strategy)
           .AddAssignmentToReference(migraphx_provider_option::kModelMaxDynamicBatch, max_dynamic_batch)
-          .AddAssignmentToReference(migraphx_provider_option::kMaxCompiledModels, max_compiled_models)
           .AddAssignmentToReference(migraphx_provider_option::kCompileBatches, compile_batches)
           .Parse(options));
 }
@@ -87,8 +86,7 @@ MIGraphXExecutionProviderInfo::MIGraphXExecutionProviderInfo(const OrtMIGraphXPr
       exhaustive_tune{options.migraphx_exhaustive_tune != 0},
       mem_limit{options.migraphx_mem_limit},
       arena_extend_strategy{options.migraphx_arena_extend_strategy},
-      max_dynamic_batch{options.migraphx_max_dynamic_batch},
-      max_compiled_models{options.migraphx_max_compiled_models == 0 ? 1 : options.migraphx_max_compiled_models} {
+      max_dynamic_batch{options.migraphx_max_dynamic_batch} {
 }
 
 ProviderOptions MIGraphXExecutionProviderInfo::ToProviderOptions() const {
@@ -108,7 +106,6 @@ ProviderOptions MIGraphXExecutionProviderInfo::ToProviderOptions() const {
       {std::string{migraphx_provider_option::kGpuExternalEmptyCache}, MakeStringWithClassicLocale(external_empty_cache)},
       {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_dir)},
       {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(max_dynamic_batch)},
-      {std::string{migraphx_provider_option::kMaxCompiledModels}, MakeStringWithClassicLocale(max_compiled_models)},
       {std::string{migraphx_provider_option::kCompileBatches}, compile_batches},
   };
 }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
@@ -74,6 +74,7 @@ MIGraphXExecutionProviderInfo::MIGraphXExecutionProviderInfo(const ProviderOptio
           .AddAssignmentToEnumReference(migraphx_provider_option::kArenaExtendStrategy, arena_extend_strategy_mapping, arena_extend_strategy)
           .AddAssignmentToReference(migraphx_provider_option::kModelMaxDynamicBatch, max_dynamic_batch)
           .AddAssignmentToReference(migraphx_provider_option::kMaxCompiledModels, max_compiled_models)
+          .AddAssignmentToReference(migraphx_provider_option::kCompileBatches, compile_batches)
           .Parse(options));
 }
 
@@ -108,6 +109,7 @@ ProviderOptions MIGraphXExecutionProviderInfo::ToProviderOptions() const {
       {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_dir)},
       {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(max_dynamic_batch)},
       {std::string{migraphx_provider_option::kMaxCompiledModels}, MakeStringWithClassicLocale(max_compiled_models)},
+      {std::string{migraphx_provider_option::kCompileBatches}, compile_batches},
   };
 }
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
@@ -36,6 +36,7 @@ constexpr auto kGpuExternalEmptyCache = "migraphx_external_empty_cache"sv;
 constexpr auto kModelCacheDir = "migraphx_model_cache_dir"sv;
 constexpr auto kModelMaxDynamicBatch = "migraphx_max_dynamic_batch"sv;
 constexpr auto kMaxCompiledModels = "migraphx_max_compiled_models"sv;
+constexpr auto kCompileBatches = "migraphx_compile_batches"sv;
 }  // namespace migraphx_provider_option
 
 extern const EnumNameMapping<ArenaExtendStrategy> arena_extend_strategy_mapping;
@@ -59,6 +60,7 @@ struct MIGraphXExecutionProviderInfo {
   OrtArenaCfg* default_memory_arena_cfg{nullptr};
   size_t max_dynamic_batch{static_cast<size_t>(0)};
   size_t max_compiled_models{static_cast<size_t>(1)};  // Number of evenly-spaced batch sizes to compile (1 -> max only)
+  std::string compile_batches{};  // Comma-separated list of batch sizes to compile, e.g. "1,4,8,16,32"
 
   void* external_alloc{nullptr};
   void* external_free{nullptr};
@@ -106,6 +108,7 @@ struct std::hash<::onnxruntime::MIGraphXExecutionProviderInfo> {
 
     onnxruntime::HashCombine(info.max_dynamic_batch, value);
     onnxruntime::HashCombine(info.max_compiled_models, value);
+    onnxruntime::HashCombine(info.compile_batches, value);
     // The default memory arena cfg is not used in hashing right now.
     return value;
   }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
@@ -35,7 +35,6 @@ constexpr auto kGpuExternalFree = "migraphx_external_free"sv;
 constexpr auto kGpuExternalEmptyCache = "migraphx_external_empty_cache"sv;
 constexpr auto kModelCacheDir = "migraphx_model_cache_dir"sv;
 constexpr auto kModelMaxDynamicBatch = "migraphx_max_dynamic_batch"sv;
-constexpr auto kMaxCompiledModels = "migraphx_max_compiled_models"sv;
 constexpr auto kCompileBatches = "migraphx_compile_batches"sv;
 }  // namespace migraphx_provider_option
 
@@ -59,7 +58,6 @@ struct MIGraphXExecutionProviderInfo {
 
   OrtArenaCfg* default_memory_arena_cfg{nullptr};
   size_t max_dynamic_batch{static_cast<size_t>(0)};
-  size_t max_compiled_models{static_cast<size_t>(1)};  // Number of evenly-spaced batch sizes to compile (1 -> max only)
   std::string compile_batches{};  // Comma-separated list of batch sizes to compile, e.g. "1,4,8,16,32"
 
   void* external_alloc{nullptr};
@@ -107,7 +105,6 @@ struct std::hash<::onnxruntime::MIGraphXExecutionProviderInfo> {
     onnxruntime::HashCombine(reinterpret_cast<size_t>(info.external_empty_cache), value);
 
     onnxruntime::HashCombine(info.max_dynamic_batch, value);
-    onnxruntime::HashCombine(info.max_compiled_models, value);
     onnxruntime::HashCombine(info.compile_batches, value);
     // The default memory arena cfg is not used in hashing right now.
     return value;

--- a/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
@@ -147,7 +147,6 @@ struct MIGraphX_Provider final : Provider {
     migx_options->migraphx_arena_extend_strategy = static_cast<int>(internal_options.arena_extend_strategy);
     migx_options->migraphx_mem_limit = internal_options.mem_limit;
     migx_options->migraphx_max_dynamic_batch = internal_options.max_dynamic_batch;
-    migx_options->migraphx_max_compiled_models = internal_options.max_compiled_models;
   }
 
   ProviderOptions GetProviderOptions(const void* provider_options) override {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Fixes segfault seen on BERT workloads  and allows user to select either max batch size with powers of two, or a specific list of target batches to compile instead. Removes the max number of models logic as that was causing errors with fallthrough logic.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fixes bug and issue with fallthrough logic. 

Superceeds - https://github.com/ROCm/onnxruntime/pull/226 

Verified fix on workload and other customer pieces

