### PR TITLE
[AIMIGRAPHX-885]Update external stream sync

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -4136,7 +4136,7 @@ OrtDevice MIGraphXExecutionProvider::GetOrtDeviceByMemType(OrtMemType mem_type) 
 }
 
 Status MIGraphXExecutionProvider::Sync() const {
-  HIP_CALL_THROW(hipStreamSynchronize(static_cast<hipStream_t>(nullptr)));
+  HIP_CALL_THROW(hipStreamSynchronize(static_cast<hipStream_t>(stream_)));
 
   auto status = hipStreamQuery(stream_);
   if (status != hipSuccess) {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -169,6 +169,12 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
   HIP_CALL_THROW(hipSetDevice(device_id_));
   HIP_CALL_THROW(hipGetDeviceProperties(&device_prop_, device_id_));
 
+  if (info.has_user_compute_stream) {
+    external_stream_ = true;
+    stream_ = static_cast<hipStream_t>(info.user_compute_stream);
+    LOGS_DEFAULT(INFO) << "[MIGraphX EP] Using external user compute stream: " << stream_;
+  }
+
   // Overwrite initialized values with values from environment variables.
 
   LOGS_DEFAULT(INFO) << "[MIGraphX EP] MIGraphX ENV Override Variables Set:";
@@ -4123,7 +4129,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 void MIGraphXExecutionProvider::RegisterStreamHandlers(IStreamCommandHandleRegistry& stream_handle_registry,
                                                        AllocatorMap& allocators) const {
   auto allocator = allocators[GetOrtDeviceByMemType(OrtMemTypeCPU)];
-  RegisterMIGraphXStreamHandles(stream_handle_registry, OrtDevice::GPU, allocator, true, stream_, false /*TODO:external_stream_*/);
+  RegisterMIGraphXStreamHandles(stream_handle_registry, OrtDevice::GPU, allocator, true, stream_, external_stream_);
 }
 
 OrtDevice MIGraphXExecutionProvider::GetOrtDeviceByMemType(OrtMemType mem_type) const {
@@ -4150,9 +4156,10 @@ Status MIGraphXExecutionProvider::OnRunStart(const onnxruntime::RunOptions& /*ru
 }
 
 Status MIGraphXExecutionProvider::OnRunEnd(bool sync_stream, const onnxruntime::RunOptions& /*run_options*/) {
-  if (sync_stream) {
+  if (sync_stream && external_stream_) {
+    HIP_CALL_THROW(hipStreamSynchronize(stream_));
+  } else if (sync_stream) {
     auto status = hipStreamQuery(stream_);
-
     if (status != hipSuccess) {
       HIP_CALL_THROW(hipStreamSynchronize(stream_));
     }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -4149,11 +4149,13 @@ Status MIGraphXExecutionProvider::OnRunStart(const onnxruntime::RunOptions& /*ru
   return Status::OK();
 }
 
-Status MIGraphXExecutionProvider::OnRunEnd(bool /*sync_stream*/, const onnxruntime::RunOptions& /*run_options*/) {
-  auto status = hipStreamQuery(stream_);
+Status MIGraphXExecutionProvider::OnRunEnd(bool sync_stream, const onnxruntime::RunOptions& /*run_options*/) {
+  if (sync_stream) {
+    auto status = hipStreamQuery(stream_);
 
-  if (status != hipSuccess) {
-    HIP_CALL_THROW(hipStreamSynchronize(stream_));
+    if (status != hipSuccess) {
+      HIP_CALL_THROW(hipStreamSynchronize(stream_));
+    }
   }
   return Status::OK();
 }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -208,7 +208,9 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
         {std::string{migraphx_provider_option::kGpuExternalEmptyCache}, MakeStringWithClassicLocale(external_empty_cache_)},
         {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_path_)},
         {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(max_dynamic_batch_)},
-        {std::string{migraphx_provider_option::kCompileBatches}, compile_batches_}};
+        {std::string{migraphx_provider_option::kCompileBatches}, compile_batches_},
+        {std::string{migraphx_provider_option::kHasUserComputeStream}, MakeStringWithClassicLocale(external_stream_)},
+        {std::string{migraphx_provider_option::kUserComputeStream}, MakeStringWithClassicLocale(reinterpret_cast<size_t>(stream_))}};
    }
 
  private:
@@ -228,6 +230,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   bool dump_model_ops_ = false;
   migraphx::target t_;
   std::mutex mgx_mu_;
+  bool external_stream_ = false;
   hipStream_t stream_ = nullptr;
   hipDeviceProp_t device_prop_{};
   bool exhaustive_tune_ = false;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
@@ -74,7 +74,18 @@ MIGraphXExecutionProviderInfo::MIGraphXExecutionProviderInfo(const ProviderOptio
           .AddAssignmentToEnumReference(migraphx_provider_option::kArenaExtendStrategy, arena_extend_strategy_mapping, arena_extend_strategy)
           .AddAssignmentToReference(migraphx_provider_option::kModelMaxDynamicBatch, max_dynamic_batch)
           .AddAssignmentToReference(migraphx_provider_option::kCompileBatches, compile_batches)
+          .AddAssignmentToReference(migraphx_provider_option::kHasUserComputeStream, has_user_compute_stream)
+          .AddValueParser(
+              migraphx_provider_option::kUserComputeStream,
+              [this](const std::string& value_str) -> Status {
+                size_t address;
+                ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, address));
+                user_compute_stream = reinterpret_cast<void*>(address);
+                return Status::OK();
+              })
           .Parse(options));
+
+  has_user_compute_stream = (user_compute_stream != nullptr);
 }
 
 MIGraphXExecutionProviderInfo::MIGraphXExecutionProviderInfo(const OrtMIGraphXProviderOptions& options) noexcept
@@ -107,6 +118,8 @@ ProviderOptions MIGraphXExecutionProviderInfo::ToProviderOptions() const {
       {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_dir)},
       {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(max_dynamic_batch)},
       {std::string{migraphx_provider_option::kCompileBatches}, compile_batches},
+      {std::string{migraphx_provider_option::kHasUserComputeStream}, MakeStringWithClassicLocale(has_user_compute_stream)},
+      {std::string{migraphx_provider_option::kUserComputeStream}, MakeStringWithClassicLocale(reinterpret_cast<size_t>(user_compute_stream))},
   };
 }
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
@@ -36,6 +36,8 @@ constexpr auto kGpuExternalEmptyCache = "migraphx_external_empty_cache"sv;
 constexpr auto kModelCacheDir = "migraphx_model_cache_dir"sv;
 constexpr auto kModelMaxDynamicBatch = "migraphx_max_dynamic_batch"sv;
 constexpr auto kCompileBatches = "migraphx_compile_batches"sv;
+constexpr auto kHasUserComputeStream = "has_user_compute_stream"sv;
+constexpr auto kUserComputeStream = "user_compute_stream"sv;
 }  // namespace migraphx_provider_option
 
 extern const EnumNameMapping<ArenaExtendStrategy> arena_extend_strategy_mapping;
@@ -63,6 +65,9 @@ struct MIGraphXExecutionProviderInfo {
   void* external_alloc{nullptr};
   void* external_free{nullptr};
   void* external_empty_cache{nullptr};
+
+  bool has_user_compute_stream{false};
+  void* user_compute_stream{nullptr};
 
   bool UseExternalAlloc() const {
     return external_alloc != nullptr && external_free != nullptr;
@@ -106,6 +111,10 @@ struct std::hash<::onnxruntime::MIGraphXExecutionProviderInfo> {
 
     onnxruntime::HashCombine(info.max_dynamic_batch, value);
     onnxruntime::HashCombine(info.compile_batches, value);
+
+    // Stream pointer
+    onnxruntime::HashCombine(reinterpret_cast<size_t>(info.user_compute_stream), value);
+
     // The default memory arena cfg is not used in hashing right now.
     return value;
   }

--- a/onnxruntime/core/providers/migraphx/migraphx_stream_handle.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_stream_handle.cc
@@ -169,7 +169,9 @@ void RegisterMIGraphXStreamHandles(IStreamCommandHandleRegistry& stream_handle_r
     stream_handle_registry.RegisterCreateStreamFn(device_type, [cpu_allocator,
                                                                 release_cpu_buffer_on_migraphx_stream,
                                                                 external_stream](const OrtDevice& device) {
-      return std::make_unique<MIGraphXStream>(external_stream, device, cpu_allocator, release_cpu_buffer_on_migraphx_stream);
+      auto stream = std::make_unique<MIGraphXStream>(external_stream, device, cpu_allocator, release_cpu_buffer_on_migraphx_stream);
+      stream->own_stream_ = false;
+      return stream;
     });
   }
 }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Change to allow us to accept external syncs while also relaxing constraint on the endofrun call so that the we follow whether we require a sync at the end of a run via Onnxruntime API.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Customer systems sometimes employ the use of an external hipStream to perform tasks like copies, sync, etc. By only using our internal sync it's caused issues where in some cases we see inconsistent performance between runs while also seeing more overhead with copies/latency

Adding this mirror what other EPs do. Testing this with the TritonInferenceServer I was able to actually get similar parity to the migraphx-driver (with --enable-offload-copy in performance (- 2-5 Inference/Sec). 