### PR TITLE
[AIMIGRAPHX-885] Add hip graph to MIGraphX EP

### DIFF
--- a/onnxruntime/core/providers/migraphx/gpu_data_transfer.cc
+++ b/onnxruntime/core/providers/migraphx/gpu_data_transfer.cc
@@ -11,22 +11,11 @@
 
 namespace onnxruntime {
 
-namespace {
-
-struct StagingReturnInfo {
-  PinnedStagingPool* pool;
-  void* buffer;
-  size_t capacity;
-};
-
-void StagingReturnCallback(void* raw) {
-  std::unique_ptr<StagingReturnInfo> info(static_cast<StagingReturnInfo*>(raw));
-  info->pool->Release(info->buffer, info->capacity);
+GPUDataTransfer::~GPUDataTransfer() {
+  // Make sure no outstanding async copies are still referencing pinned
+  // staging buffers before we tear the reaper / pools down.
+  (void)hipDeviceSynchronize();
 }
-
-}  // namespace
-
-GPUDataTransfer::~GPUDataTransfer() = default;
 
 bool GPUDataTransfer::CanCopy(const OrtDevice& src_device, const OrtDevice& dst_device) const {
   OrtDevice::DeviceType src_type = src_device.Type();
@@ -118,10 +107,34 @@ common::Status GPUDataTransfer::CopyTensorAsync(const Tensor& src, Tensor& dst, 
           staging_pool_.Release(pinned, bytes);
           HIP_RETURN_IF_ERROR(err);
         }
-        auto cb = std::make_unique<StagingReturnInfo>(StagingReturnInfo{&staging_pool_, pinned, bytes});
-        HIP_RETURN_IF_ERROR(hipLaunchHostFunc(hip_stream, StagingReturnCallback, cb.release()));
+        // Hand the pinned buffer to the reaper, which will return it to the
+        // pool once the recorded event reports complete.  This replaces the
+        // previous hipLaunchHostFunc-based release, which serialised on the
+        // compute stream's host-function dispatcher and could deadlock when
+        // Release happened to invoke hipHostFree under heavy load.
+        hipEvent_t e = event_pool_.Acquire();
+        if (!e) {
+          // Event allocation failed — degrade gracefully by syncing on the
+          // calling thread and releasing the buffer immediately.
+          HIP_RETURN_IF_ERROR(hipStreamSynchronize(hip_stream));
+          staging_pool_.Release(pinned, bytes);
+        } else {
+          auto rec_err = hipEventRecord(e, hip_stream);
+          if (rec_err != hipSuccess) {
+            // Recording failed — same fallback as above, plus return the
+            // event to its pool for reuse.
+            (void)hipStreamSynchronize(hip_stream);
+            staging_pool_.Release(pinned, bytes);
+            event_pool_.Release(e);
+            HIP_RETURN_IF_ERROR(rec_err);
+          }
+          reaper_.Submit(e, pinned, bytes);
+        }
       } else {
-        // hipHostMalloc failed — fall back to the (synchronous) direct path
+        // hipHostMalloc failed — fall back to the direct path.  Note that
+        // hipMemcpyAsync on pageable memory is effectively synchronous from
+        // the host's point of view (the runtime stages internally), which
+        // is the desired behaviour in this degraded path.
         HIP_RETURN_IF_ERROR(hipMemcpyAsync(dst_data, src_data, bytes, hipMemcpyHostToDevice, hip_stream));
       }
     }

--- a/onnxruntime/core/providers/migraphx/gpu_data_transfer.h
+++ b/onnxruntime/core/providers/migraphx/gpu_data_transfer.h
@@ -4,7 +4,11 @@
 #pragma once
 
 #include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 #include "core/providers/migraphx/migraphx_inc.h"
@@ -15,7 +19,8 @@ namespace onnxruntime {
 // Thread-safe pool of hipHostMalloc'd staging buffers used to avoid the
 // silent synchronous fallback that hipMemcpyAsync performs when handed
 // pageable (non-pinned) host memory.  Buffers are grown on demand and
-// recycled between copies via hipLaunchHostFunc callbacks.
+// recycled between copies once the StagingReaper observes the associated
+// HIP event has completed (so Release never runs on the compute stream).
 class PinnedStagingPool {
   struct Buffer {
     void* ptr;
@@ -75,9 +80,146 @@ class PinnedStagingPool {
   }
 
  private:
-  static constexpr size_t kMaxPoolSize = 8;
+  // Sized to comfortably cover the working set at large batch sizes
+  // (~12 inputs * a few size classes) so eviction (and its hipHostFree
+  // call) effectively never fires on the hot path.
+  static constexpr size_t kMaxPoolSize = 32;
   std::mutex mu_;
   std::vector<Buffer> pool_;
+};
+
+// Reusable free-list of hipEvent_t handles.  Events are created with
+// hipEventDisableTiming because we only need ordering semantics.
+class HipEventPool {
+ public:
+  HipEventPool() = default;
+
+  ~HipEventPool() {
+    std::lock_guard<std::mutex> lock(mu_);
+    for (auto e : free_) {
+      (void)hipEventDestroy(e);
+    }
+  }
+
+  HipEventPool(const HipEventPool&) = delete;
+  HipEventPool& operator=(const HipEventPool&) = delete;
+
+  hipEvent_t Acquire() {
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      if (!free_.empty()) {
+        hipEvent_t e = free_.back();
+        free_.pop_back();
+        return e;
+      }
+    }
+    hipEvent_t e = nullptr;
+    if (hipEventCreateWithFlags(&e, hipEventDisableTiming) != hipSuccess) {
+      return nullptr;
+    }
+    return e;
+  }
+
+  void Release(hipEvent_t e) {
+    if (!e) return;
+    std::lock_guard<std::mutex> lock(mu_);
+    free_.push_back(e);
+  }
+
+ private:
+  std::mutex mu_;
+  std::vector<hipEvent_t> free_;
+};
+
+// Background worker that polls HIP events and returns staging buffers to
+// their pool once the recorded event reports complete.  This replaces the
+// previous hipLaunchHostFunc-based release path, which serialised on the
+// compute stream's host-function dispatcher and could deadlock when
+// Release happened to invoke hipHostFree under load.
+class StagingReaper {
+  struct Item {
+    hipEvent_t event;
+    void* buffer;
+    size_t capacity;
+  };
+
+ public:
+  StagingReaper(PinnedStagingPool* pool, HipEventPool* events)
+      : pool_(pool), events_(events), worker_([this] { Run(); }) {}
+
+  ~StagingReaper() {
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      stop_ = true;
+    }
+    cv_.notify_all();
+    if (worker_.joinable()) worker_.join();
+    // Drain anything still in flight so the pool can free its buffers
+    // safely in its own destructor.
+    std::deque<Item> remaining;
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      remaining.swap(queue_);
+    }
+    for (auto& it : remaining) {
+      (void)hipEventSynchronize(it.event);
+      pool_->Release(it.buffer, it.capacity);
+      events_->Release(it.event);
+    }
+  }
+
+  StagingReaper(const StagingReaper&) = delete;
+  StagingReaper& operator=(const StagingReaper&) = delete;
+
+  void Submit(hipEvent_t e, void* buffer, size_t capacity) {
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      queue_.push_back({e, buffer, capacity});
+    }
+    cv_.notify_one();
+  }
+
+ private:
+  void Run() {
+    using namespace std::chrono_literals;
+    std::unique_lock<std::mutex> lock(mu_);
+    while (!stop_ || !queue_.empty()) {
+      if (queue_.empty()) {
+        cv_.wait(lock, [this] { return stop_ || !queue_.empty(); });
+        continue;
+      }
+      Item front = queue_.front();
+      lock.unlock();
+
+      hipError_t st = hipEventQuery(front.event);
+      if (st == hipErrorNotReady) {
+        // Not ready yet — sleep briefly to avoid burning a core.
+        lock.lock();
+        cv_.wait_for(lock, 100us);
+        continue;
+      }
+      // hipSuccess (event complete) or any other error: release the buffer
+      // either way.  If the event genuinely errored, the alternative would
+      // be to spin forever; we'd rather leak any in-flight DMA's privacy
+      // guarantees than hang the reaper.
+      pool_->Release(front.buffer, front.capacity);
+      events_->Release(front.event);
+      lock.lock();
+      if (!queue_.empty()) {
+        queue_.pop_front();
+      }
+    }
+  }
+
+  PinnedStagingPool* pool_;
+  HipEventPool* events_;
+  std::mutex mu_;
+  std::condition_variable cv_;
+  std::deque<Item> queue_;
+  bool stop_ = false;
+  // worker_ must be declared last so the thread sees fully-constructed
+  // members when it starts running Run().
+  std::thread worker_;
 };
 
 class GPUDataTransfer : public IDataTransfer {
@@ -90,9 +232,14 @@ class GPUDataTransfer : public IDataTransfer {
   common::Status CopyTensorAsync(const Tensor& src, Tensor& dst, Stream& stream) const override;
 
  private:
-  static constexpr size_t kStagingThreshold = SIZE_MAX; //64 * 1024;  // 64 KiB
+  static constexpr size_t kStagingThreshold = 64 * 1024;  // 64 KiB
   hipStream_t stream_;
+  // staging_pool_ and event_pool_ MUST be declared before reaper_ because
+  // the reaper holds raw pointers into them and starts its worker thread
+  // in its constructor.
   mutable PinnedStagingPool staging_pool_;
+  mutable HipEventPool event_pool_;
+  mutable StagingReaper reaper_{&staging_pool_, &event_pool_};
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/migraphx/gpu_data_transfer.h
+++ b/onnxruntime/core/providers/migraphx/gpu_data_transfer.h
@@ -90,7 +90,7 @@ class GPUDataTransfer : public IDataTransfer {
   common::Status CopyTensorAsync(const Tensor& src, Tensor& dst, Stream& stream) const override;
 
  private:
-  static constexpr size_t kStagingThreshold = 64 * 1024;  // 64 KiB
+  static constexpr size_t kStagingThreshold = SIZE_MAX; //64 * 1024;  // 64 KiB
   hipStream_t stream_;
   mutable PinnedStagingPool staging_pool_;
 };

--- a/onnxruntime/core/providers/migraphx/migraphx_allocator.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_allocator.cc
@@ -22,18 +22,50 @@ void MIGraphXAllocator::CheckDevice() const {
 #endif
 }
 
+void MIGraphXAllocator::EnablePoolMode() {
+  std::lock_guard<std::mutex> lock(pool_mu_);
+  pool_enabled_ = true;
+}
+
 void* MIGraphXAllocator::Alloc(size_t size) {
   CheckDevice();
-  void* p = nullptr;
-  if (size > 0) {
-    HIP_CALL_THROW(hipMalloc((void**)&p, size));
+  if (size == 0) return nullptr;
+
+  if (pool_enabled_) {
+    std::lock_guard<std::mutex> lock(pool_mu_);
+    auto it = free_list_.find(size);
+    if (it != free_list_.end() && !it->second.empty()) {
+      void* p = it->second.back();
+      it->second.pop_back();
+      return p;
+    }
   }
+
+  void* p = nullptr;
+  HIP_CALL_THROW(hipMalloc((void**)&p, size));
+
+  if (pool_enabled_) {
+    std::lock_guard<std::mutex> lock(pool_mu_);
+    alloc_sizes_[p] = size;
+  }
+
   return p;
 }
 
 void MIGraphXAllocator::Free(void* p) {
   CheckDevice();
-  (void)hipFree(p);  // do not throw error since it's OK for hipFree to fail during shutdown
+  if (!p) return;
+
+  if (pool_enabled_) {
+    std::lock_guard<std::mutex> lock(pool_mu_);
+    auto it = alloc_sizes_.find(p);
+    if (it != alloc_sizes_.end()) {
+      free_list_[it->second].push_back(p);
+      return;
+    }
+  }
+
+  (void)hipFree(p);
 }
 
 void* MIGraphXExternalAllocator::Alloc(size_t size) {

--- a/onnxruntime/core/providers/migraphx/migraphx_allocator.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_allocator.h
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <mutex>
+#include <unordered_map>
 #include <unordered_set>
+#include <vector>
 #include "core/framework/allocator.h"
 
 namespace onnxruntime {
@@ -21,8 +23,20 @@ class MIGraphXAllocator : public IAllocator {
   virtual void* Alloc(size_t size) override;
   virtual void Free(void* p) override;
 
+  void EnablePoolMode();
+  bool IsPoolModeEnabled() const { return pool_enabled_; }
+
  private:
   void CheckDevice() const;
+
+  // When pool mode is enabled (for hipGraph), freed allocations are cached by
+  // size so that subsequent Alloc calls for the same size return the same
+  // device pointer.  This provides pointer stability required by hipGraph
+  // replay without the cost of intermediary buffer copies.
+  bool pool_enabled_ = false;
+  mutable std::mutex pool_mu_;
+  std::unordered_map<size_t, std::vector<void*>> free_list_;
+  std::unordered_map<void*, size_t> alloc_sizes_;
 };
 
 class MIGraphXExternalAllocator : public MIGraphXAllocator {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1820,7 +1820,6 @@ static void run_migraphx_program(
     prog_outputs = prog.run_async(m, rocm_stream);
   }
 
-  HIP_CALL_THROW(hipStreamSynchronize(rocm_stream));
 
   bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 &&
                         original_batch_size < padded_batch_size);
@@ -1835,6 +1834,7 @@ static void run_migraphx_program(
 
   if (needs_slicing && !prog_output_indices_set.empty()) {
     // Must sync before reallocating any pre-allocated output buffer for slicing.
+    HIP_CALL_THROW(hipStreamSynchronize(rocm_stream));
 
     for (std::size_t i = 0; i < output_num; ++i) {
       if (prog_output_indices_set.count(i) == 0) continue;
@@ -4997,7 +4997,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 void MIGraphXExecutionProvider::RegisterStreamHandlers(IStreamCommandHandleRegistry& stream_handle_registry,
                                                        AllocatorMap& allocators) const {
   auto allocator = allocators[GetOrtDeviceByMemType(OrtMemTypeCPU)];
-  RegisterMIGraphXStreamHandles(stream_handle_registry, OrtDevice::GPU, allocator, true, stream_, true);
+  RegisterMIGraphXStreamHandles(stream_handle_registry, OrtDevice::GPU, allocator, true, stream_, external_stream_);
 }
 
 OrtDevice MIGraphXExecutionProvider::GetOrtDeviceByMemType(OrtMemType mem_type) const {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1836,7 +1836,51 @@ static void destroy_hip_graphs(MIGraphXFuncState* mgx_state) {
 
 // Warmup run (ensures lazy GPU allocations are finalized) then capture the graph.
 // Stores extra (non-pre-allocated) output metadata so replay can materialize them.
-static constexpr int kHipGraphWarmInIterations = 8;
+//
+// The previous design used a single `kHipGraphWarmInIterations = 8` for both
+// the pre-capture eager loop AND the post-capture replay loop, regardless of
+// compiled batch size.  That had two problems:
+//   * `prog.run_async` only needs to be called once for MIGraphX's lazy
+//     allocations to finalize (`hip::hip_allocate_memory::finalize` is
+//     idempotent); the other 7 pre-capture iterations only pollute the
+//     program's persistent scratch arena with warmup-distribution data, which
+//     then bleeds into the *captured* kernel arguments.
+//   * Larger compiled batches tend to select kernels with deeper scratch
+//     dependencies (split-K reductions, attention workspaces, etc.), so a
+//     single fixed post-capture count is simultaneously too high for bs=1
+//     (wastes compile time) and too low for bs=8 (insufficient warm-in).
+//
+// The split below gives us a small constant pre-capture phase (just to
+// finalize lazy allocs) and a post-capture phase that scales gently with the
+// compiled batch size.
+static constexpr int kCaptureFinalizeIterations = 2;
+static constexpr int kPostCaptureWarmInBase     = 6;
+
+// Returns a post-capture replay count tuned to the compiled batch size.
+// One extra iteration per doubling above bs=1: 1->6, 2->7, 4->8, 8->9, 16->10.
+// Caller passes 0 when batch is unknown; we fall back to the base count.
+static inline int post_capture_warmin_for(std::size_t batch) {
+  int extra = 0;
+  for (std::size_t b = batch; b > 1; b >>= 1) ++extra;
+  return kPostCaptureWarmInBase + extra;
+}
+
+// Best-effort extraction of the compiled batch size from a program's input
+// parameter shapes.  Used purely to tune warm-in iteration counts; returns 0
+// if no input-like parameter has a leading dimension we can read.
+static std::size_t infer_compiled_batch_from_params(
+    const migraphx::program_parameter_shapes& param_shapes,
+    const std::unordered_map<std::string, std::size_t>& input_name_indexes) {
+  std::size_t batch = 0;
+  for (const auto& name : param_shapes.names()) {
+    if (input_name_indexes.find(name) == input_name_indexes.end()) continue;
+    const auto& s = param_shapes[name];
+    auto lens = s.lengths();
+    if (lens.empty()) continue;
+    batch = std::max(batch, static_cast<std::size_t>(lens[0]));
+  }
+  return batch;
+}
 
 static bool warmup_and_capture_hip_graph(
     MIGraphXFuncState* mgx_state,
@@ -1855,14 +1899,20 @@ static bool warmup_and_capture_hip_graph(
     HIP_CALL_THROW(hipMemsetAsync(pin.data, 0, pin.size_bytes, stream));
   }
 
-  // Run multiple eager warmup iterations before capture to let MIGraphX
-  // internal workspace buffers (scratch, reductions, etc.) stabilize.
+  // Pre-capture eager loop: only enough to finalize MIGraphX's lazy
+  // allocations (finalize is idempotent so this can be small).
   std::optional<migraphx::arguments> warmup_outputs;
-  for (int i = 0; i < kHipGraphWarmInIterations; ++i) {
+  for (int i = 0; i < kCaptureFinalizeIterations; ++i) {
     std::lock_guard<std::mutex> lock(*mgx_state->mgx_mu_ptr);
     warmup_outputs = prog.run_async(m, stream);
   }
   HIP_CALL_THROW(hipStreamSynchronize(stream));
+
+  // Tune post-capture warm-in to the compiled batch size (see #2 in the
+  // header comment near kCaptureFinalizeIterations).
+  const std::size_t compiled_batch = infer_compiled_batch_from_params(
+      prog.get_parameter_shapes(), mgx_state->input_name_indexes);
+  const int post_warmin = post_capture_warmin_for(compiled_batch);
 
   auto& entry = mgx_state->hip_graph_cache[shape_hash];
 
@@ -1885,7 +1935,7 @@ static bool warmup_and_capture_hip_graph(
 
     // Replay the captured graph several more times post-capture to ensure
     // workspace is fully settled before the first real inference.
-    for (int i = 0; i < kHipGraphWarmInIterations; ++i) {
+    for (int i = 0; i < post_warmin; ++i) {
       HIP_CALL_THROW(hipGraphLaunch(entry.exec, stream));
     }
     HIP_CALL_THROW(hipStreamSynchronize(stream));
@@ -1946,12 +1996,72 @@ static bool warmup_and_capture_hip_graph_direct(
     const std::unordered_map<std::string, void*>& input_ptrs,
     const std::unordered_map<std::string, void*>& output_ptrs)
 {
+  // ---- Change #1: pre-warmup output zeroing (asymmetry fix vs. pinned path).
+  //
+  // The pinned-copy capture path (warmup_and_capture_hip_graph above) zeroes
+  // its pinned input/output mirrors before the warmup loop so the captured
+  // kernel sequence is anchored to a deterministic memory baseline.  The
+  // direct-bind path historically did nothing here, which meant the captured
+  // kernels' device-pointer arguments referenced ORT-owned output buffers
+  // whose contents at first-replay time were leftover bytes from an unrelated
+  // prior call.  For graphs whose captured kernels read an output buffer
+  // before writing it within a single invocation (a common pattern with
+  // fused-attention epilogues and reduction accumulators), that stale data
+  // bleeds into the first verified replay -- the exact failure observed on
+  // bs>=4 in the cross-session interleaved verification test.
+  //
+  // We deliberately do NOT zero ORT *input* pointers: those carry user data
+  // bound by the caller via `m`, and clobbering them would feed zeros into
+  // the warmup runs.  Outputs, however, have not yet been written by this
+  // call and are safe to memset.
+  //
+  // The full structural fix (binding MIGraphX's "scratch" parameter to an
+  // EP-owned, per-shape buffer that we can memset before every replay) is
+  // tracked separately; this change closes the asymmetry vs. the pinned path
+  // and removes the dependence on whatever happened to be at the output
+  // address when capture started.
+  const auto param_shapes_for_zero = prog.get_parameter_shapes();
+  for (const auto& name : param_shapes_for_zero.names()) {
+    const int oi = compute_output_index(name);
+    if (oi < 0) continue;  // skip inputs and the "scratch" parameter
+    auto it = output_ptrs.find(name);
+    if (it == output_ptrs.end() || it->second == nullptr) continue;
+    const std::size_t bytes = param_shapes_for_zero[name].bytes();
+    if (bytes == 0) continue;
+    HIP_CALL_THROW(hipMemsetAsync(it->second, 0, bytes, stream));
+  }
+
+  // Pre-capture eager loop: only enough to finalize MIGraphX's lazy
+  // allocations.  (See the comment near kCaptureFinalizeIterations above for
+  // why this no longer scales with the previous fixed `kHipGraphWarmInIterations`.)
   std::optional<migraphx::arguments> warmup_outputs;
-  for (int i = 0; i < kHipGraphWarmInIterations; ++i) {
+  for (int i = 0; i < kCaptureFinalizeIterations; ++i) {
     std::lock_guard<std::mutex> lock(*mgx_state->mgx_mu_ptr);
     warmup_outputs = prog.run_async(m, stream);
   }
   HIP_CALL_THROW(hipStreamSynchronize(stream));
+
+  // ---- Change #1 (continued): re-zero outputs right before BeginCapture.
+  // The warmup runs above wrote real (warmup-data-derived) values into the
+  // output buffers.  If we capture now, those values become the "starting
+  // state" baked into any read-before-write captured kernel.  Reset to zero
+  // so capture is anchored to a known baseline rather than warmup-data
+  // residuals.
+  for (const auto& name : param_shapes_for_zero.names()) {
+    const int oi = compute_output_index(name);
+    if (oi < 0) continue;
+    auto it = output_ptrs.find(name);
+    if (it == output_ptrs.end() || it->second == nullptr) continue;
+    const std::size_t bytes = param_shapes_for_zero[name].bytes();
+    if (bytes == 0) continue;
+    HIP_CALL_THROW(hipMemsetAsync(it->second, 0, bytes, stream));
+  }
+  HIP_CALL_THROW(hipStreamSynchronize(stream));
+
+  // ---- Change #2: tune post-capture warm-in to the compiled batch size.
+  const std::size_t compiled_batch = infer_compiled_batch_from_params(
+      param_shapes_for_zero, mgx_state->input_name_indexes);
+  const int post_warmin = post_capture_warmin_for(compiled_batch);
 
   auto& entry = mgx_state->hip_graph_cache[shape_hash];
 
@@ -1974,7 +2084,7 @@ static bool warmup_and_capture_hip_graph_direct(
     entry.captured_input_ptrs = input_ptrs;
     entry.captured_output_ptrs = output_ptrs;
 
-    for (int i = 0; i < kHipGraphWarmInIterations; ++i) {
+    for (int i = 0; i < post_warmin; ++i) {
       HIP_CALL_THROW(hipGraphLaunch(entry.exec, stream));
     }
     HIP_CALL_THROW(hipStreamSynchronize(stream));

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1820,6 +1820,8 @@ static void run_migraphx_program(
     prog_outputs = prog.run_async(m, rocm_stream);
   }
 
+  HIP_CALL_THROW(hipStreamSynchronize(rocm_stream));
+
   bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 &&
                         original_batch_size < padded_batch_size);
 
@@ -1833,7 +1835,6 @@ static void run_migraphx_program(
 
   if (needs_slicing && !prog_output_indices_set.empty()) {
     // Must sync before reallocating any pre-allocated output buffer for slicing.
-    HIP_CALL_THROW(hipStreamSynchronize(rocm_stream));
 
     for (std::size_t i = 0; i < output_num; ++i) {
       if (prog_output_indices_set.count(i) == 0) continue;
@@ -2048,7 +2049,7 @@ static bool warmup_and_capture_hip_graph(
   HIP_CALL_THROW(hipStreamSynchronize(stream));
 
   try {
-    HIP_CALL_THROW(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+    HIP_CALL_THROW(hipStreamBeginCapture(stream, hipStreamCaptureModeThreadLocal));
     {
       std::lock_guard<std::mutex> lock(*mgx_state->mgx_mu_ptr);
       prog.run_async(m, stream);
@@ -4996,7 +4997,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 void MIGraphXExecutionProvider::RegisterStreamHandlers(IStreamCommandHandleRegistry& stream_handle_registry,
                                                        AllocatorMap& allocators) const {
   auto allocator = allocators[GetOrtDeviceByMemType(OrtMemTypeCPU)];
-  RegisterMIGraphXStreamHandles(stream_handle_registry, OrtDevice::GPU, allocator, true, stream_, external_stream_);
+  RegisterMIGraphXStreamHandles(stream_handle_registry, OrtDevice::GPU, allocator, true, stream_, true);
 }
 
 OrtDevice MIGraphXExecutionProvider::GetOrtDeviceByMemType(OrtMemType mem_type) const {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1579,9 +1579,19 @@ struct ScratchBindInfo {
   migraphx::shape mgx_shape;
 };
 
-// Returns scratch buffer info bound to the given program's "scratch" parameter,
-// allocating it on first call for `shape_hash` and zeroing it on every call.
-// Returns std::nullopt if the program has no "scratch" parameter.
+// Ensure an EP-owned scratch buffer exists (and is large enough) for the given
+// `shape_hash`, allocating on first call or when the program's scratch size
+// has grown.  Freshly-allocated buffers are zeroed; *existing* buffers are
+// NOT zeroed here, on the assumption that whoever consumes the buffer (the
+// capture/replay paths) will issue `zero_scratch_for` themselves immediately
+// before use.  This avoids a redundant `hipMemsetAsync` on every ultra-fast
+// bind (where we go straight into `run_program_or_hip_graph_direct` which
+// already does the zero), recovering most of the perf gap that the previous
+// always-zero behavior introduced.
+//
+// Returns std::nullopt if the program has no "scratch" parameter -- in that
+// case the caller should not bind anything and MIGraphX will fall back to
+// whatever internal scratch handling it has for that program.
 static std::optional<ScratchBindInfo>
 get_or_alloc_scratch(MIGraphXFuncState* mgx_state,
                      const migraphx::program_parameter_shapes& param_shapes,
@@ -1612,16 +1622,14 @@ get_or_alloc_scratch(MIGraphXFuncState* mgx_state,
     slot.data = ptr;
     slot.size_bytes = needed_bytes;
     slot.mgx_shape = scratch_shape;
+    // Zero on fresh allocation only.  Subsequent calls rely on
+    // `zero_scratch_for` at the capture/replay site to enforce the
+    // deterministic baseline.
+    HIP_CALL_THROW(hipMemsetAsync(slot.data, 0, slot.size_bytes, stream));
   } else {
     // Keep the most recent shape (same hash so usually identical, but be safe).
     slot.mgx_shape = scratch_shape;
   }
-
-  // Always zero before handing the buffer back -- this is the whole point of
-  // EP-owning scratch.  Cheap on the order of the scratch size, and bypassed
-  // entirely by the cache-hit path (no allocation) yet still issued on the
-  // compute stream so it serializes correctly against the upcoming run/replay.
-  HIP_CALL_THROW(hipMemsetAsync(slot.data, 0, slot.size_bytes, stream));
 
   return ScratchBindInfo{slot.data, slot.mgx_shape};
 }
@@ -1963,10 +1971,15 @@ static void destroy_hip_graphs(MIGraphXFuncState* mgx_state) {
 // finalize lazy allocs) and a post-capture phase that scales gently with the
 // compiled batch size.
 static constexpr int kCaptureFinalizeIterations = 2;
-static constexpr int kPostCaptureWarmInBase     = 6;
+// Bumped from 6 -> 10 after observing that the first user-data replay of bs=4
+// was tripping the test's strict rtol=0.001 by ~2/256 elements.  More warmin
+// iterations push the captured graph's internal-state-dependent kernels
+// (atomic-reduction accumulators, etc.) closer to steady state so the first
+// post-warmup user replay produces near-steady-state output.
+static constexpr int kPostCaptureWarmInBase     = 10;
 
 // Returns a post-capture replay count tuned to the compiled batch size.
-// One extra iteration per doubling above bs=1: 1->6, 2->7, 4->8, 8->9, 16->10.
+// One extra iteration per doubling above bs=1: 1->10, 2->11, 4->12, 8->13, 16->14.
 // Caller passes 0 when batch is unknown; we fall back to the base count.
 static inline int post_capture_warmin_for(std::size_t batch) {
   int extra = 0;
@@ -2058,8 +2071,17 @@ static bool warmup_and_capture_hip_graph(
                                     : nullptr;
 
     // Replay the captured graph several more times post-capture to ensure
-    // workspace is fully settled before the first real inference.
+    // workspace is fully settled before the first real inference.  Zero
+    // scratch AND the pinned output buffers between iterations so every
+    // warmin sees the same memory baseline a real replay will see -- same
+    // rationale as the direct-bind warmin loop.  (Pinned outputs are the
+    // pio.outputs[] buffers; zeroing them is cheap and matches what the
+    // pre-warmup zero already does at the start of this function.)
     for (int i = 0; i < post_warmin; ++i) {
+      zero_scratch_for(mgx_state, shape_hash, stream);
+      for (auto& pin : pio.outputs) {
+        HIP_CALL_THROW(hipMemsetAsync(pin.data, 0, pin.size_bytes, stream));
+      }
       HIP_CALL_THROW(hipGraphLaunch(entry.exec, stream));
     }
     HIP_CALL_THROW(hipStreamSynchronize(stream));
@@ -2102,6 +2124,19 @@ static void replay_hip_graph(MIGraphXFuncState* mgx_state,
   // from the previous replay, which is the source of the non-deterministic
   // back-to-back outputs we observed.
   zero_scratch_for(mgx_state, shape_hash, stream);
+  // Same rationale for the pinned output buffers: captured kernels that do
+  // read-modify-write on outputs would otherwise inherit the previous
+  // replay's output values.  copy_pinned_outputs_to_ort runs after every
+  // replay so the prior contents have already been copied out by the time
+  // we get here -- safe to clobber.
+  auto& pio = mgx_state->pinned_io;
+  if (pio.allocated) {
+    for (auto& pin : pio.outputs) {
+      if (pin.data) {
+        HIP_CALL_THROW(hipMemsetAsync(pin.data, 0, pin.size_bytes, stream));
+      }
+    }
+  }
   auto& entry = mgx_state->hip_graph_cache.at(shape_hash);
   HIP_CALL_THROW(hipGraphLaunch(entry.exec, stream));
 }
@@ -2228,7 +2263,33 @@ static bool warmup_and_capture_hip_graph_direct(
                                       : nullptr;
     }
 
+    // Record (ptr, bytes) for every ORT-bound output so replay can zero them
+    // before each launch.  We use param_shapes_for_zero[name].bytes() rather
+    // than output_shapes[oi].bytes() because the captured kernels touch the
+    // *program-side* buffer extent, which for padded-batch programs is the
+    // padded shape -- exactly what we want to zero.
+    entry.captured_output_zeroes.clear();
+    entry.captured_output_zeroes.reserve(output_ptrs.size());
+    for (const auto& [name, ptr] : output_ptrs) {
+      if (ptr == nullptr) continue;
+      // program_parameter_shapes::operator[] takes const char*, not std::string.
+      const std::size_t bytes = param_shapes_for_zero[name.c_str()].bytes();
+      if (bytes == 0) continue;
+      entry.captured_output_zeroes.emplace_back(ptr, bytes);
+    }
+
+    // Post-capture warmin loop: zero scratch AND outputs before each launch so
+    // every warmin iteration sees the same memory baseline that real replays
+    // will see.  Without this, the 8th warmin iteration (e.g.) feeds the 9th
+    // its dirty-scratch / dirty-output state, leaving the captured graph in a
+    // post-warmin state that differs from what the first user replay starts
+    // from (we zero before every replay).  That mismatch is what was leaving
+    // the first user replay ~5e-3 away from eager on the larger reductions.
     for (int i = 0; i < post_warmin; ++i) {
+      zero_scratch_for(mgx_state, shape_hash, stream);
+      for (const auto& [ptr, bytes] : entry.captured_output_zeroes) {
+        HIP_CALL_THROW(hipMemsetAsync(ptr, 0, bytes, stream));
+      }
       HIP_CALL_THROW(hipGraphLaunch(entry.exec, stream));
     }
     HIP_CALL_THROW(hipStreamSynchronize(stream));
@@ -2324,6 +2385,17 @@ static void run_program_or_hip_graph_direct(
       // every direct-bind replay so the captured kernel sequence isn't
       // contaminated by the prior replay's scratch residue.
       zero_scratch_for(mgx_state, shape_hash, stream);
+      // Also zero every ORT-bound output before the launch.  Required because
+      // some captured kernels (split-K, fused-attention epilogues) do
+      // read-modify-write on the output buffer.  The ORT allocator pool
+      // recycles addresses across batch-size transitions, so a fresh user
+      // call may inherit the previous batch-size's output residue at the
+      // same address -- producing first-replay drift on the larger-reduction
+      // outputs.  Zeroing here pins the read-side of any R-M-W to zero,
+      // matching the eager allocator's fresh-buffer semantics.
+      for (const auto& [ptr, bytes] : it->second.captured_output_zeroes) {
+        HIP_CALL_THROW(hipMemsetAsync(ptr, 0, bytes, stream));
+      }
       HIP_CALL_THROW(hipGraphLaunch(it->second.exec, stream));
       if (!it->second.extra_outputs.empty()) {
         materialize_extra_outputs(ctx, stream, it->second.extra_outputs,

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -3061,12 +3061,21 @@ static InputShapeResult handle_input_shape(
 }
 
 // Helper: Compile models for all configured batch sizes and cache them
+// rocm_stream is the per-Run compute stream resolved from ctx.GetGPUComputeStream()
+// in compute_func.  It MUST be threaded through to allocate_pinned_io so the
+// stream-ordered memory pool used by hipMallocAsync has the same lineage as the
+// stream that will later issue copies, captured-graph launches, and replays
+// against those pinned buffers.  Using a different stream here (e.g. the EP's
+// own mgx_state->stream) is undefined behavior under the hipMemPool semantics
+// and on ROCm typically surfaces as the captured graph reading stale or
+// uninitialized pinned memory on first replay.
 static void compile_dynamic_batch_models(
     MIGraphXFuncState* mgx_state,
     const std::filesystem::path& model_cache_path,
     const std::filesystem::path& model_path,
     const std::string& mxr_filename_prefix,
-    const Ort::KernelContext& ctx) {
+    const Ort::KernelContext& ctx,
+    hipStream_t rocm_stream) {
   
   if (!mgx_state->has_dynamic_batch || mgx_state->compiled_batch_sizes.empty()) {
     return;
@@ -3195,7 +3204,7 @@ static void compile_dynamic_batch_models(
       if (largest_prog && max_batch > 0) {
         auto ps = largest_prog->get_parameter_shapes();
         auto os = largest_prog->get_output_shapes();
-        allocate_pinned_io(mgx_state, ps, os, max_batch, mgx_state->stream);
+        allocate_pinned_io(mgx_state, ps, os, max_batch, rocm_stream);
       }
     }
   }
@@ -3223,7 +3232,7 @@ static void execute_standard_path(
   // If precompilation happened during Compile(), max_dynamic_batch will be > 0 but defer_compilation = false
   // In that case, the programs are already in cache and we can skip runtime compilation
   if (mgx_state->has_dynamic_batch && mgx_state->max_dynamic_batch > 0 && mgx_state->defer_compilation) {
-    compile_dynamic_batch_models(mgx_state, model_cache_path, model_path, mxr_filename_prefix, ctx);
+    compile_dynamic_batch_models(mgx_state, model_cache_path, model_path, mxr_filename_prefix, ctx, rocm_stream);
 
     // Validate newly compiled programs for hipGraph compatibility
     if (mgx_state->hip_graph_enabled && mgx_state->cached_programs_ref.has_value()) {
@@ -4482,6 +4491,13 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       }
 
       // Allocate pinned I/O buffers from the cached programs.
+      // create_state_func runs ONCE at session init (long before any Run()),
+      // so there is no per-Run compute stream to query here — ComputeContext
+      // does not expose one.  We use stream_ (the EP-owned init stream) and
+      // rely on the hipStreamSynchronize(stream) inside allocate_pinned_io to
+      // establish the hipMallocAsync pool memory so the per-Run compute stream
+      // (resolved from ctx.GetGPUComputeStream() in compute_func) can safely
+      // consume these pointers without further cross-stream ordering.
       // Uses the program compiled for the largest batch size so that
       // allocate_pinned_io sees parameter shapes whose batch dim matches
       // max_batch. All smaller batches share the same buffers.
@@ -4558,9 +4574,17 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       Ort::KernelContext ctx(context);
       MIGraphXFuncState* mgx_state = reinterpret_cast<MIGraphXFuncState*>(state);
 
+      // Run on whichever stream ORT elected for this device for THIS Run().
+      // - external_stream_=true   -> ORT wrapper around the user-supplied stream
+      // - external_stream_=false  -> stream ORT created via RegisterCreateStreamFn
+      // Either way, ORT's MemcpyFromHost/MemcpyToHost ran on this stream, so issuing
+      // kernels on it removes the cross-stream race that EP::stream_ would introduce.
+      hipStream_t run_stream = static_cast<hipStream_t>(ctx.GetGPUComputeStream());
+      if (run_stream == nullptr) run_stream = stream_;  // fallback for harnesses w/o stream registry
+
       const auto& map_input_name_index = mgx_state->input_name_indexes;
 
-      if (execute_ultra_fast_path(mgx_state, stream_, ctx)) {
+      if (execute_ultra_fast_path(mgx_state, run_stream, ctx)) {
         return Status::OK();
       }
 
@@ -4572,11 +4596,11 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       }
       const auto current_hash = make_hash(all_input_shapes);
 
-      if (execute_fast_path(mgx_state, stream_, ctx, current_hash, all_input_shapes)) {
+      if (execute_fast_path(mgx_state, run_stream, ctx, current_hash, all_input_shapes)) {
         return Status::OK();
       }
 
-      execute_standard_path(mgx_state, stream_, ctx, current_hash, std::move(all_input_shapes),
+      execute_standard_path(mgx_state, run_stream, ctx, current_hash, std::move(all_input_shapes),
                             model_cache_path_, model_path_, mxr_filename_prefix);
 
       return Status::OK();

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1551,6 +1551,105 @@ static void free_pinned_io(MIGraphXFuncState* mgx_state, hipStream_t stream) {
   pio.allocated = false;
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// Scratch buffer management (one EP-owned buffer per compiled program)
+//
+// Why we own scratch:
+//   MIGraphX programs expose a "scratch" parameter.  If the EP doesn't bind
+//   it, MIGraphX falls back to its internal arena -- whose contents persist
+//   across calls and bleed into any hipGraph kernel that reads scratch before
+//   writing it.  Owning the buffer lets us zero it before every replay and
+//   before capture, anchoring kernels to a deterministic memory baseline.
+//
+// Lifetime:
+//   Keyed by shape_hash so each compiled batch variant has its own buffer.
+//   Allocated lazily on first bind, reused across all subsequent runs for
+//   that shape.  Reallocated only if MIGraphX reports a different scratch
+//   size for the same hash (defensive; in practice the size is constant per
+//   shape).  Freed on session teardown via free_scratch_bufs.
+//
+// Stream semantics:
+//   Allocations and zeroing go through hipMallocAsync/hipMemsetAsync on the
+//   same `stream` the EP uses for compute.  This keeps scratch ordering
+//   consistent with the program runs that consume it.
+// ═══════════════════════════════════════════════════════════════════════════
+
+struct ScratchBindInfo {
+  void* ptr;
+  migraphx::shape mgx_shape;
+};
+
+// Returns scratch buffer info bound to the given program's "scratch" parameter,
+// allocating it on first call for `shape_hash` and zeroing it on every call.
+// Returns std::nullopt if the program has no "scratch" parameter.
+static std::optional<ScratchBindInfo>
+get_or_alloc_scratch(MIGraphXFuncState* mgx_state,
+                     const migraphx::program_parameter_shapes& param_shapes,
+                     const std::string& shape_hash,
+                     hipStream_t stream)
+{
+  bool has_scratch = false;
+  for (const auto& name : param_shapes.names()) {
+    if (std::string_view(name) == "scratch") { has_scratch = true; break; }
+  }
+  if (!has_scratch) return std::nullopt;
+
+  const auto& scratch_shape = param_shapes["scratch"];
+  const std::size_t needed_bytes = scratch_shape.bytes();
+
+  auto& slot = mgx_state->scratch_bufs[shape_hash];
+
+  // (Re)allocate if size grew or buffer is missing.  Shrinking-only is fine to
+  // keep -- avoids freeing in the steady state.
+  if (slot.data == nullptr || needed_bytes > slot.size_bytes) {
+    if (slot.data != nullptr) {
+      (void)hipFreeAsync(slot.data, stream);
+      slot.data = nullptr;
+      slot.size_bytes = 0;
+    }
+    void* ptr = nullptr;
+    HIP_CALL_THROW(hipMallocAsync(&ptr, needed_bytes, stream));
+    slot.data = ptr;
+    slot.size_bytes = needed_bytes;
+    slot.mgx_shape = scratch_shape;
+  } else {
+    // Keep the most recent shape (same hash so usually identical, but be safe).
+    slot.mgx_shape = scratch_shape;
+  }
+
+  // Always zero before handing the buffer back -- this is the whole point of
+  // EP-owning scratch.  Cheap on the order of the scratch size, and bypassed
+  // entirely by the cache-hit path (no allocation) yet still issued on the
+  // compute stream so it serializes correctly against the upcoming run/replay.
+  HIP_CALL_THROW(hipMemsetAsync(slot.data, 0, slot.size_bytes, stream));
+
+  return ScratchBindInfo{slot.data, slot.mgx_shape};
+}
+
+// Zero an already-allocated scratch buffer (no allocation, no shape lookup).
+// Used right before every hipGraph replay so each replay starts from a known
+// memory baseline.  No-op if no scratch was bound for this shape_hash.
+static void zero_scratch_for(MIGraphXFuncState* mgx_state,
+                             const std::string& shape_hash,
+                             hipStream_t stream)
+{
+  auto it = mgx_state->scratch_bufs.find(shape_hash);
+  if (it == mgx_state->scratch_bufs.end()) return;
+  if (it->second.data == nullptr || it->second.size_bytes == 0) return;
+  HIP_CALL_THROW(hipMemsetAsync(it->second.data, 0, it->second.size_bytes, stream));
+}
+
+static void free_scratch_bufs(MIGraphXFuncState* mgx_state, hipStream_t stream) {
+  for (auto& [hash, slot] : mgx_state->scratch_bufs) {
+    if (slot.data) {
+      (void)hipFreeAsync(slot.data, stream);
+      slot.data = nullptr;
+    }
+  }
+  HIP_CALL_THROW(hipStreamSynchronize(stream));
+  mgx_state->scratch_bufs.clear();
+}
+
 // Copy ORT input tensors into pinned buffers and pad if needed.
 static void copy_inputs_to_pinned(
     MIGraphXFuncState* mgx_state,
@@ -1612,7 +1711,9 @@ static PinnedBindResult
 bind_pinned_program_params(
     MIGraphXFuncState* mgx_state,
     const migraphx::program_parameter_shapes& param_shapes,
-    const migraphx::shapes& output_shapes)
+    const migraphx::shapes& output_shapes,
+    const std::string& shape_hash,
+    hipStream_t stream)
 {
   auto& pio = mgx_state->pinned_io;
   const auto& map_input_name_index = mgx_state->input_name_indexes;
@@ -1624,6 +1725,14 @@ bind_pinned_program_params(
       auto pin_it = pio.input_name_to_idx.find(name);
       if (pin_it == pio.input_name_to_idx.end()) continue;
       result.params.add(name, migraphx::argument(param_shapes[name], pio.inputs[pin_it->second].data));
+    } else if (std::string_view(name) == "scratch") {
+      // Bind EP-owned scratch buffer (allocate-and-zero on first use, zero-only
+      // thereafter).  Skipping this would force MIGraphX to use its internal
+      // arena whose state bleeds across runs -- see header note on ScratchBuf.
+      auto scratch = get_or_alloc_scratch(mgx_state, param_shapes, shape_hash, stream);
+      if (scratch) {
+        result.params.add(name, migraphx::argument(scratch->mgx_shape, scratch->ptr));
+      }
     } else {
       const auto oi = compute_output_index(name);
       if (oi != -1) {
@@ -1898,6 +2007,10 @@ static bool warmup_and_capture_hip_graph(
   for (auto& pin : pio.outputs) {
     HIP_CALL_THROW(hipMemsetAsync(pin.data, 0, pin.size_bytes, stream));
   }
+  // Zero EP-owned scratch too -- caller bound it via bind_pinned_program_params
+  // but the warmup runs below would otherwise leave warmup-derived bytes in
+  // scratch that then get baked into the capture.
+  zero_scratch_for(mgx_state, shape_hash, stream);
 
   // Pre-capture eager loop: only enough to finalize MIGraphX's lazy
   // allocations (finalize is idempotent so this can be small).
@@ -1916,6 +2029,11 @@ static bool warmup_and_capture_hip_graph(
 
   auto& entry = mgx_state->hip_graph_cache[shape_hash];
 
+  // Re-zero scratch right before BeginCapture so the captured kernel sequence
+  // is anchored to a known baseline (the warmup loop just dirtied it).
+  zero_scratch_for(mgx_state, shape_hash, stream);
+  HIP_CALL_THROW(hipStreamSynchronize(stream));
+
   try {
     HIP_CALL_THROW(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
     {
@@ -1932,6 +2050,12 @@ static bool warmup_and_capture_hip_graph(
 
     HIP_CALL_THROW(hipGraphInstantiate(&entry.exec, entry.graph, nullptr, nullptr, 0));
     entry.captured = true;
+    // Record the scratch pointer that was baked into the captured kernels so
+    // we can detect re-allocation across replays (e.g. after pool reuse).
+    auto scratch_it = mgx_state->scratch_bufs.find(shape_hash);
+    entry.captured_scratch_ptr = (scratch_it != mgx_state->scratch_bufs.end())
+                                    ? scratch_it->second.data
+                                    : nullptr;
 
     // Replay the captured graph several more times post-capture to ensure
     // workspace is fully settled before the first real inference.
@@ -1972,6 +2096,12 @@ static bool warmup_and_capture_hip_graph(
 static void replay_hip_graph(MIGraphXFuncState* mgx_state,
                              hipStream_t stream,
                              const std::string& shape_hash) {
+  // Zero EP-owned scratch (no-op if none) before each replay so the captured
+  // kernels see the same memory baseline every time.  Without this, any
+  // captured kernel that reads scratch before writing it inherits residue
+  // from the previous replay, which is the source of the non-deterministic
+  // back-to-back outputs we observed.
+  zero_scratch_for(mgx_state, shape_hash, stream);
   auto& entry = mgx_state->hip_graph_cache.at(shape_hash);
   HIP_CALL_THROW(hipGraphLaunch(entry.exec, stream));
 }
@@ -2030,6 +2160,11 @@ static bool warmup_and_capture_hip_graph_direct(
     if (bytes == 0) continue;
     HIP_CALL_THROW(hipMemsetAsync(it->second, 0, bytes, stream));
   }
+  // Also zero EP-owned scratch -- this is the structural fix that replaces
+  // the "do nothing about scratch" gap noted in the prior comment.  Whatever
+  // ran before this Run() left arbitrary bytes in scratch; zero them so the
+  // warmup runs and the subsequent capture start from a known baseline.
+  zero_scratch_for(mgx_state, shape_hash, stream);
 
   // Pre-capture eager loop: only enough to finalize MIGraphX's lazy
   // allocations.  (See the comment near kCaptureFinalizeIterations above for
@@ -2056,6 +2191,9 @@ static bool warmup_and_capture_hip_graph_direct(
     if (bytes == 0) continue;
     HIP_CALL_THROW(hipMemsetAsync(it->second, 0, bytes, stream));
   }
+  // And re-zero scratch right before BeginCapture, for the same reason -- the
+  // warmup runs just wrote warmup-derived bytes into scratch.
+  zero_scratch_for(mgx_state, shape_hash, stream);
   HIP_CALL_THROW(hipStreamSynchronize(stream));
 
   // ---- Change #2: tune post-capture warm-in to the compiled batch size.
@@ -2083,6 +2221,12 @@ static bool warmup_and_capture_hip_graph_direct(
     entry.captured = true;
     entry.captured_input_ptrs = input_ptrs;
     entry.captured_output_ptrs = output_ptrs;
+    {
+      auto scratch_it = mgx_state->scratch_bufs.find(shape_hash);
+      entry.captured_scratch_ptr = (scratch_it != mgx_state->scratch_bufs.end())
+                                      ? scratch_it->second.data
+                                      : nullptr;
+    }
 
     for (int i = 0; i < post_warmin; ++i) {
       HIP_CALL_THROW(hipGraphLaunch(entry.exec, stream));
@@ -2119,11 +2263,13 @@ static bool warmup_and_capture_hip_graph_direct(
 }
 
 // Check whether ORT's current tensor pointers match the addresses stored
-// during capture.  Returns true if all pointers match.
+// during capture.  Returns true if all pointers match (including the EP-owned
+// scratch buffer, which is also baked into the captured kernel arguments).
 static bool check_captured_ptrs_match(
     const MIGraphXFuncState::CapturedHipGraph& entry,
     const std::unordered_map<std::string, void*>& current_input_ptrs,
-    const std::unordered_map<std::string, void*>& current_output_ptrs)
+    const std::unordered_map<std::string, void*>& current_output_ptrs,
+    void* current_scratch_ptr)
 {
   for (const auto& [name, ptr] : current_input_ptrs) {
     auto it = entry.captured_input_ptrs.find(name);
@@ -2133,6 +2279,7 @@ static bool check_captured_ptrs_match(
     auto it = entry.captured_output_ptrs.find(name);
     if (it == entry.captured_output_ptrs.end() || it->second != ptr) return false;
   }
+  if (entry.captured_scratch_ptr != current_scratch_ptr) return false;
   return true;
 }
 
@@ -2153,7 +2300,12 @@ static void run_program_or_hip_graph_direct(
 {
   auto it = mgx_state->hip_graph_cache.find(shape_hash);
   if (it != mgx_state->hip_graph_cache.end() && it->second.captured) {
-    if (!check_captured_ptrs_match(it->second, input_ptrs, output_ptrs)) {
+    void* current_scratch = nullptr;
+    {
+      auto sit = mgx_state->scratch_bufs.find(shape_hash);
+      if (sit != mgx_state->scratch_bufs.end()) current_scratch = sit->second.data;
+    }
+    if (!check_captured_ptrs_match(it->second, input_ptrs, output_ptrs, current_scratch)) {
       ++mgx_state->direct_recapture_count;
       if (mgx_state->direct_recapture_count > MIGraphXFuncState::kMaxDirectRecaptures) {
         LOGS_DEFAULT(WARNING) << "[HipGraph] Too many pointer-drift re-captures ("
@@ -2168,6 +2320,10 @@ static void run_program_or_hip_graph_direct(
       if (it->second.graph) { (void)hipGraphDestroy(it->second.graph); it->second.graph = nullptr; }
       it->second.captured = false;
     } else {
+      // Same rationale as in replay_hip_graph: zero EP-owned scratch before
+      // every direct-bind replay so the captured kernel sequence isn't
+      // contaminated by the prior replay's scratch residue.
+      zero_scratch_for(mgx_state, shape_hash, stream);
       HIP_CALL_THROW(hipGraphLaunch(it->second.exec, stream));
       if (!it->second.extra_outputs.empty()) {
         materialize_extra_outputs(ctx, stream, it->second.extra_outputs,
@@ -2586,12 +2742,20 @@ static void handle_input_shape_mismatch(
 // Overload: Handle program inputs and outputs binding with pre-cached output shapes
 // This avoids calling prog.get_output_shapes() when shapes are already cached
 // When needs_slicing is true, allocates temporary GPU buffers for outputs instead of binding directly
+//
+// `mgx_state`, `shape_hash` and `stream` are used to bind the program's
+// "scratch" parameter to an EP-owned, per-shape buffer that we can zero
+// before every replay.  Pass mgx_state=nullptr (and any stream) to skip
+// scratch binding -- MIGraphX will then fall back to its internal arena.
 static
 std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program_input_outputs(
     const migraphx::program_parameter_shapes& param_shapes,
     const migraphx::shapes& output_shapes,
     const std::unordered_map<std::string, std::size_t>& map_input_name_index,
     const Ort::KernelContext& ctx,
+    MIGraphXFuncState* mgx_state,
+    const std::string& shape_hash,
+    hipStream_t stream,
     bool needs_slicing = false,
     std::vector<void*>* temp_output_buffers = nullptr)
 {
@@ -2614,6 +2778,16 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
         const auto& mgx_s = param_shapes[name];
         m.add(name, migraphx::argument(mgx_s,
                                        const_cast<void*>(input_tensor.GetTensorRawData())));
+      } else if (std::string_view(name) == "scratch") {
+        // Bind EP-owned scratch (allocate-and-zero on first use, zero-only
+        // thereafter).  Without this MIGraphX silently uses its internal
+        // arena and hipGraph replays inherit cross-run state.
+        if (mgx_state != nullptr) {
+          auto scratch = get_or_alloc_scratch(mgx_state, param_shapes, shape_hash, stream);
+          if (scratch) {
+            m.add(name, migraphx::argument(scratch->mgx_shape, scratch->ptr));
+          }
+        }
       } else {
         // Output parameter
         const auto output_index = compute_output_index(name);
@@ -2847,6 +3021,20 @@ static bool execute_ultra_fast_path(
       m.add(out.name.c_str(), migraphx::argument(out.mgx_shape, ptr));
       output_ptrs[out.name] = ptr;
     }
+    // Rebind EP-owned scratch on every invocation.  populate_ultra_fast_caches
+    // only tracks inputs and outputs, never "scratch", so it never lands in
+    // `m` from the caches; we have to add it here.  get_or_alloc_scratch is a
+    // no-op alloc / mandatory zero on the cache-hit path -- exactly what we
+    // need to flush any state the previous run left behind.
+    if (mgx_state->cached_mgx_param_shapes.has_value()) {
+      auto scratch = get_or_alloc_scratch(mgx_state,
+                                          mgx_state->cached_mgx_param_shapes.value(),
+                                          mgx_state->last_input_shape_hash,
+                                          rocm_stream);
+      if (scratch) {
+        m.add("scratch", migraphx::argument(scratch->mgx_shape, scratch->ptr));
+      }
+    }
     run_program_or_hip_graph_direct(mgx_state, rocm_stream, ctx, prog, m,
                                      mgx_state->cached_prog_output_indices,
                                      mgx_state->last_input_shape_hash,
@@ -3018,7 +3206,8 @@ static bool execute_fast_path(
   // Direct-bind hipGraph path: bind ORT pointers and replay, no copies
   if (mgx_state->use_direct_hip_graph && !fast_needs_padding) {
     auto [m, prog_output_indices] = handle_program_input_outputs(
-        param_shapes, output_shapes, map_input_name_index, ctx);
+        param_shapes, output_shapes, map_input_name_index, ctx,
+        mgx_state, effective_program_hash, rocm_stream);
 
     std::unordered_map<std::string, void*> input_ptrs, output_ptrs;
     for (const auto& name : param_shapes.names()) {
@@ -3056,7 +3245,8 @@ static bool execute_fast_path(
 
   if (needs_pinned) {
     copy_inputs_to_pinned(mgx_state, param_shapes, ctx, actual_batch, compiled_batch, rocm_stream);
-    auto bind_result = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
+    auto bind_result = bind_pinned_program_params(mgx_state, param_shapes, output_shapes,
+                                                  effective_program_hash, rocm_stream);
 
     mgx_state->cached_prog_params = std::move(bind_result.params);
     mgx_state->cached_prog_output_indices = std::move(bind_result.prog_output_indices);
@@ -3078,7 +3268,8 @@ static bool execute_fast_path(
   }
 
   auto [m, prog_output_indices] = handle_program_input_outputs(
-      param_shapes, output_shapes, map_input_name_index, ctx);
+      param_shapes, output_shapes, map_input_name_index, ctx,
+      mgx_state, effective_program_hash, rocm_stream);
 
   mgx_state->cached_prog_params = std::move(m);
   mgx_state->cached_prog_output_indices = std::move(prog_output_indices);
@@ -3415,7 +3606,8 @@ static void execute_standard_path(
           // Direct-bind hipGraph for exact-match batch (no padding)
           if (mgx_state->use_direct_hip_graph && !needs_padding) {
             auto [m, prog_output_indices] = handle_program_input_outputs(
-                param_shapes, output_shapes, map_input_name_index, ctx);
+                param_shapes, output_shapes, map_input_name_index, ctx,
+                mgx_state, padded_hash, rocm_stream);
 
             std::unordered_map<std::string, void*> input_ptrs, output_ptrs;
             for (const auto& name : param_shapes.names()) {
@@ -3478,7 +3670,8 @@ static void execute_standard_path(
 
             std::size_t copy_actual = needs_padding ? original_batch_size : padded_batch_size;
             copy_inputs_to_pinned(mgx_state, param_shapes, ctx, copy_actual, padded_batch_size, rocm_stream);
-            auto bind_result = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
+            auto bind_result = bind_pinned_program_params(mgx_state, param_shapes, output_shapes,
+                                                          padded_hash, rocm_stream);
 
             mgx_state->cached_prog_params = bind_result.params;
             mgx_state->cached_prog_output_indices = bind_result.prog_output_indices;
@@ -3496,7 +3689,8 @@ static void execute_standard_path(
                                        ctx, copy_actual, rocm_stream);
           } else {
             auto [m, prog_output_indices] = handle_program_input_outputs(
-                param_shapes, output_shapes, map_input_name_index, ctx);
+                param_shapes, output_shapes, map_input_name_index, ctx,
+                mgx_state, padded_hash, rocm_stream);
 
             mgx_state->cached_prog_params = m;
             mgx_state->cached_prog_output_indices = prog_output_indices;
@@ -3560,7 +3754,8 @@ static void execute_standard_path(
   // Direct-bind hipGraph for standard path (no padding case)
   if (mgx_state->use_direct_hip_graph) {
     auto [m, prog_output_indices] = handle_program_input_outputs(
-        param_shapes, output_shapes, map_input_name_index, ctx);
+        param_shapes, output_shapes, map_input_name_index, ctx,
+        mgx_state, current_hash, rocm_stream);
 
     std::unordered_map<std::string, void*> input_ptrs, output_ptrs;
     for (const auto& name : param_shapes.names()) {
@@ -3597,7 +3792,8 @@ static void execute_standard_path(
       if (!shape.empty()) { actual_batch = static_cast<std::size_t>(shape[0]); break; }
     }
     copy_inputs_to_pinned(mgx_state, param_shapes, ctx, actual_batch, actual_batch, rocm_stream);
-    auto bind_result = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
+    auto bind_result = bind_pinned_program_params(mgx_state, param_shapes, output_shapes,
+                                                  current_hash, rocm_stream);
 
     mgx_state->cached_prog_params = bind_result.params;
     mgx_state->cached_prog_output_indices = bind_result.prog_output_indices;
@@ -3616,7 +3812,8 @@ static void execute_standard_path(
   }
 
   auto [m, prog_output_indices] = handle_program_input_outputs(
-      param_shapes, output_shapes, map_input_name_index, ctx);
+      param_shapes, output_shapes, map_input_name_index, ctx,
+      mgx_state, current_hash, rocm_stream);
 
   mgx_state->cached_prog_params = m;
   mgx_state->cached_prog_output_indices = prog_output_indices;
@@ -4675,6 +4872,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       if (state) {
         auto* s = static_cast<MIGraphXFuncState*>(state);
         destroy_hip_graphs(s);
+        // Free EP-owned scratch before pinned I/O -- both use hipFreeAsync on
+        // the EP stream so ordering between them only matters at process exit.
+        free_scratch_bufs(s, s->stream);
         free_pinned_io(s, s->stream);
         delete s;
       }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1418,190 +1418,6 @@ static void pad_input_tensor(const void* src_data, void* dst_data,
   }
 }
 
-// Allocate padded input buffers and pad the data for dynamic batching
-// Returns true if padding was applied, false otherwise
-// OPTIMIZATION: Reuses existing buffers if padded batch size matches
-static bool allocate_and_pad_inputs(
-    MIGraphXFuncState* mgx_state,
-    Ort::KernelContext& ctx,
-    std::size_t original_batch_size,
-    std::size_t padded_batch_size,
-    hipStream_t stream) {
-  
-  if (padded_batch_size <= original_batch_size || mgx_state->cached_inputs.empty()) {
-    return false;  // No padding needed
-  }
-  
-  // ═══════════════════════════════════════════════════════════════════════════
-  // OPTIMIZATION: Check if we can reuse existing padded buffers
-  // ═══════════════════════════════════════════════════════════════════════════
-  bool can_reuse_buffers = (
-      mgx_state->last_padded_batch_size == padded_batch_size &&
-      !mgx_state->padded_input_buffers.empty() &&
-      mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()
-  );
-  
-  if (can_reuse_buffers) {
-    
-    // Just copy new data into existing buffers - skip allocation
-    for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
-      const auto& cached_inp = mgx_state->cached_inputs[i];
-      auto input_tensor = ctx.GetInput(cached_inp.ort_index);
-      auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-      const auto tensor_shape = tensor_info.GetShape();
-      
-      if (tensor_shape.empty()) continue;
-      
-      auto& padded_buf = mgx_state->padded_input_buffers[i];
-      
-      // Calculate elements per batch
-      std::size_t elements_per_batch = 1;
-      for (std::size_t j = 1; j < tensor_shape.size(); ++j) {
-        elements_per_batch *= tensor_shape[j];
-      }
-      
-      // Calculate element size from tensor type
-      std::size_t element_size_bytes;
-      switch (tensor_info.GetElementType()) {
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
-          element_size_bytes = sizeof(float);
-          break;
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
-          element_size_bytes = sizeof(uint16_t);
-          break;
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
-          element_size_bytes = sizeof(int64_t);
-          break;
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
-          element_size_bytes = sizeof(int32_t);
-          break;
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
-          element_size_bytes = sizeof(int16_t);
-          break;
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:
-          element_size_bytes = sizeof(int8_t);
-          break;
-        default:
-          element_size_bytes = sizeof(float);  // Fallback to float
-          break;
-      }
-      
-      // Reuse existing buffer - just pad with new data
-      const void* original_data = input_tensor.GetTensorRawData();
-      pad_input_tensor(original_data, padded_buf.data, original_batch_size, padded_batch_size,
-                      element_size_bytes, elements_per_batch, stream);
-    }
-    
-    // Update original batch tracking (padded batch is already correct)
-    mgx_state->last_original_batch_size = original_batch_size;
-    
-    return true;
-  }
-  
-  // ═══════════════════════════════════════════════════════════════════════════
-  // Normal path: Allocate new buffers (batch size changed or first run)
-  // ═══════════════════════════════════════════════════════════════════════════
-  
-  // Free old buffers if they exist
-  for (auto& buf : mgx_state->padded_input_buffers) {
-    if (buf.data != nullptr) {
-      HIP_CALL_THROW(hipFree(buf.data));
-      buf.data = nullptr;
-    }
-  }
-  mgx_state->padded_input_buffers.clear();
-  
-  // Allocate and pad each input
-  mgx_state->padded_input_buffers.reserve(mgx_state->cached_inputs.size());
-  
-  for (const auto& cached_inp : mgx_state->cached_inputs) {
-    auto input_tensor = ctx.GetInput(cached_inp.ort_index);
-    auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-    const auto tensor_shape = tensor_info.GetShape();
-    
-    if (tensor_shape.empty()) {
-      continue;
-    }
-    
-    // Calculate padded shape
-    std::vector<std::size_t> padded_lens(tensor_shape.begin(), tensor_shape.end());
-    padded_lens[0] = padded_batch_size;  // Replace batch dimension
-    
-    // Create padded MIGraphX shape
-    migraphx::shape padded_mgx_shape{cached_inp.mgx_shape.type(), padded_lens};
-    std::size_t padded_bytes = padded_mgx_shape.bytes();
-    
-    // Allocate GPU buffer for padded data
-    void* padded_data = nullptr;
-    HIP_CALL_THROW(hipMalloc(&padded_data, padded_bytes));
-    
-    // Calculate elements per batch
-    std::size_t elements_per_batch = 1;
-    for (std::size_t i = 1; i < tensor_shape.size(); ++i) {
-      elements_per_batch *= tensor_shape[i];
-    }
-    
-    // Calculate element size from tensor type
-    std::size_t element_size_bytes;
-    switch (tensor_info.GetElementType()) {
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
-        element_size_bytes = sizeof(float);
-        break;
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
-        element_size_bytes = sizeof(uint16_t);
-        break;
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
-        element_size_bytes = sizeof(int64_t);
-        break;
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
-        element_size_bytes = sizeof(int32_t);
-        break;
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
-        element_size_bytes = sizeof(int16_t);
-        break;
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:
-        element_size_bytes = sizeof(int8_t);
-        break;
-      default:
-        element_size_bytes = sizeof(float);  // Fallback to float
-        break;
-    }
-    
-    // Pad the data
-    const void* original_data = input_tensor.GetTensorRawData();
-    pad_input_tensor(original_data, padded_data, original_batch_size, padded_batch_size,
-                    element_size_bytes, elements_per_batch, stream);
-    
-    // Store padded buffer info
-    MIGraphXFuncState::PaddedBuffer buf;
-    buf.data = padded_data;
-    buf.size_bytes = padded_bytes;
-    buf.mgx_shape = padded_mgx_shape;
-    mgx_state->padded_input_buffers.push_back(buf);
-    
-  }
-  
-  // Update batch tracking
-  mgx_state->last_original_batch_size = original_batch_size;
-  mgx_state->last_padded_batch_size = padded_batch_size;
-  
-  return true;
-}
-
 // Helper: Extract output index from MIGraphX output parameter name
 // MIGraphX names outputs as "#output_0", "#output_1", etc.
 static int compute_output_index(const std::string_view sv) {
@@ -1614,17 +1430,193 @@ static int compute_output_index(const std::string_view sv) {
   return ToInteger(Trim(index_str, std::isdigit));
 }
 
-// Free temporary output buffers
-static void free_temp_output_buffers(MIGraphXFuncState* mgx_state) {
-  for (auto& buf : mgx_state->temp_output_buffers) {
-    if (buf.data != nullptr) {
-      (void)hipFree(buf.data);  // Don't throw on cleanup
-      buf.data = nullptr;
+
+// Allocate pinned I/O buffers at the given max batch size.  Called once per node
+// at session creation (or lazily on first inference for deferred compilation).
+// All batch sizes share these buffers — smaller batches use the leading prefix.
+static void allocate_pinned_io(
+    MIGraphXFuncState* mgx_state,
+    const migraphx::program_parameter_shapes& param_shapes,
+    const migraphx::shapes& output_shapes,
+    std::size_t max_batch_size)
+{
+  auto& pio = mgx_state->pinned_io;
+  if (pio.allocated) return;
+
+  const auto& map_input_name_index = mgx_state->input_name_indexes;
+
+  pio.inputs.clear();
+  for (const auto& name : param_shapes.names()) {
+    if (map_input_name_index.find(name) == map_input_name_index.end()) continue;
+    const auto& base_shape = param_shapes[name];
+    auto lens = base_shape.lengths();
+    if (!lens.empty()) lens[0] = max_batch_size;
+    auto max_shape = migraphx::shape(base_shape.type(), lens);
+    std::size_t bytes = max_shape.bytes();
+
+    void* ptr = nullptr;
+    HIP_CALL_THROW(hipMalloc(&ptr, bytes));
+    HIP_CALL_THROW(hipMemset(ptr, 0, bytes));
+    pio.inputs.push_back({ptr, bytes, max_shape});
+  }
+
+  pio.outputs.clear();
+  for (std::size_t i = 0; i < output_shapes.size(); ++i) {
+    auto lens = output_shapes[i].lengths();
+    if (!lens.empty()) lens[0] = max_batch_size;
+    auto max_shape = migraphx::shape(output_shapes[i].type(), lens);
+    std::size_t bytes = max_shape.bytes();
+
+    void* ptr = nullptr;
+    HIP_CALL_THROW(hipMalloc(&ptr, bytes));
+    HIP_CALL_THROW(hipMemset(ptr, 0, bytes));
+    pio.outputs.push_back({ptr, bytes, max_shape});
+  }
+
+  pio.max_batch_size = max_batch_size;
+  pio.allocated = true;
+
+  std::size_t total_bytes = 0;
+  for (const auto& b : pio.inputs) total_bytes += b.size_bytes;
+  for (const auto& b : pio.outputs) total_bytes += b.size_bytes;
+  LOGS_DEFAULT(INFO) << "[PinnedIO] Allocated: max_batch=" << max_batch_size
+                     << " inputs=" << pio.inputs.size()
+                     << " outputs=" << pio.outputs.size()
+                     << " total=" << (total_bytes / (1024.0 * 1024.0)) << " MB";
+}
+
+static void free_pinned_io(MIGraphXFuncState* mgx_state) {
+  auto& pio = mgx_state->pinned_io;
+  for (auto& buf : pio.inputs) {
+    if (buf.data) { (void)hipFree(buf.data); buf.data = nullptr; }
+  }
+  pio.inputs.clear();
+  for (auto& buf : pio.outputs) {
+    if (buf.data) { (void)hipFree(buf.data); buf.data = nullptr; }
+  }
+  pio.outputs.clear();
+  pio.allocated = false;
+}
+
+// Copy ORT input tensors into pinned buffers and pad if needed.
+// Returns the number of bytes-per-batch for each input (used for element-size calc).
+static void copy_inputs_to_pinned(
+    MIGraphXFuncState* mgx_state,
+    const migraphx::program_parameter_shapes& param_shapes,
+    Ort::KernelContext& ctx,
+    std::size_t actual_batch,
+    std::size_t compiled_batch,
+    hipStream_t stream)
+{
+  auto& pio = mgx_state->pinned_io;
+  const auto& map_input_name_index = mgx_state->input_name_indexes;
+  std::size_t idx = 0;
+
+  for (const auto& name : param_shapes.names()) {
+    auto it = map_input_name_index.find(name);
+    if (it == map_input_name_index.end()) continue;
+
+    auto& pin = pio.inputs[idx];
+    const auto& input_tensor = ctx.GetInput(it->second);
+    const void* src = input_tensor.GetTensorRawData();
+    const auto& base_shape = param_shapes[name];
+    auto lens = base_shape.lengths();
+
+    std::size_t elements_per_batch = 1;
+    for (std::size_t d = 1; d < lens.size(); ++d) elements_per_batch *= lens[d];
+
+    std::size_t total_elems = 1;
+    for (auto l : lens) total_elems *= l;
+    std::size_t byte_per_elem = (total_elems > 0) ? base_shape.bytes() / total_elems : 0;
+    std::size_t bytes_per_batch = elements_per_batch * byte_per_elem;
+
+    if (actual_batch == compiled_batch) {
+      std::size_t copy_bytes = actual_batch * bytes_per_batch;
+      if (copy_bytes > 0) {
+        HIP_CALL_THROW(hipMemcpyAsync(pin.data, src, copy_bytes, hipMemcpyDefault, stream));
+      }
+    } else {
+      pad_input_tensor(src, pin.data, actual_batch, compiled_batch,
+                       byte_per_elem, elements_per_batch, stream);
+    }
+    ++idx;
+  }
+}
+
+// Build program_parameters binding pinned buffers at the given compiled shape.
+static std::pair<migraphx::program_parameters, std::vector<std::size_t>>
+bind_pinned_program_params(
+    MIGraphXFuncState* mgx_state,
+    const migraphx::program_parameter_shapes& param_shapes,
+    const migraphx::shapes& output_shapes)
+{
+  auto& pio = mgx_state->pinned_io;
+  const auto& map_input_name_index = mgx_state->input_name_indexes;
+
+  migraphx::program_parameters m;
+  std::vector<std::size_t> prog_output_indices;
+
+  std::size_t input_idx = 0;
+  std::size_t output_idx = 0;
+
+  for (const auto& name : param_shapes.names()) {
+    if (map_input_name_index.find(name) != map_input_name_index.end()) {
+      m.add(name, migraphx::argument(param_shapes[name], pio.inputs[input_idx].data));
+      ++input_idx;
+    } else {
+      const auto oi = compute_output_index(name);
+      if (oi != -1) {
+        m.add(name, migraphx::argument(param_shapes[name], pio.outputs[output_idx].data));
+        prog_output_indices.push_back(static_cast<std::size_t>(oi));
+        ++output_idx;
+      }
     }
   }
-  mgx_state->temp_output_buffers.clear();
-  mgx_state->temp_output_padded_batch_size = 0;
+
+  return {std::move(m), std::move(prog_output_indices)};
 }
+
+// Copy results from pinned output buffers to ORT output tensors.
+static void copy_pinned_outputs_to_ort(
+    MIGraphXFuncState* mgx_state,
+    const migraphx::shapes& output_shapes,
+    const std::vector<std::size_t>& prog_output_indices,
+    Ort::KernelContext& ctx,
+    std::size_t actual_batch,
+    hipStream_t stream)
+{
+  auto& pio = mgx_state->pinned_io;
+
+  for (std::size_t i = 0; i < prog_output_indices.size() && i < pio.outputs.size(); ++i) {
+    const auto oi = prog_output_indices[i];
+    const auto& pin = pio.outputs[i];
+    const auto& out_shape = output_shapes[oi];
+    auto lens = out_shape.lengths();
+
+    std::vector<int64_t> ort_shape(lens.begin(), lens.end());
+    if (!ort_shape.empty()) {
+      ort_shape[0] = static_cast<int64_t>(actual_batch);
+    }
+
+    auto output_tensor = ctx.GetOutput(oi, ort_shape.data(), ort_shape.size());
+    void* dst = output_tensor.GetTensorMutableRawData();
+
+    std::size_t total_elems = 1;
+    for (auto l : lens) total_elems *= l;
+    std::size_t copy_bytes = 0;
+    if (total_elems > 0 && !lens.empty()) {
+      std::size_t byte_per_elem = out_shape.bytes() / total_elems;
+      std::size_t elems_per_batch = total_elems / std::max<std::size_t>(1, lens[0]);
+      copy_bytes = actual_batch * elems_per_batch * byte_per_elem;
+    }
+
+    if (copy_bytes > 0) {
+      HIP_CALL_THROW(hipMemcpyAsync(dst, pin.data, copy_bytes, hipMemcpyDefault, stream));
+    }
+  }
+}
+
+
 
 // Clear cached MIGraphX shapes (call when program changes)
 static void clear_cached_mgx_shapes(MIGraphXFuncState* mgx_state) {
@@ -1632,74 +1624,6 @@ static void clear_cached_mgx_shapes(MIGraphXFuncState* mgx_state) {
   mgx_state->cached_mgx_output_shapes.reset();
   mgx_state->ultra_fast_caches_populated = false;
   mgx_state->cached_program_hash.clear();
-}
-
-// Allocate or reuse temporary output buffers for slicing mode
-// Returns vector of raw pointers for use with handle_program_input_outputs
-static std::vector<void*> get_or_allocate_temp_output_buffers(
-    MIGraphXFuncState* mgx_state,
-    const migraphx::program_parameter_shapes& param_shapes,
-    const migraphx::shapes& output_shapes,
-    const std::unordered_map<std::string, std::size_t>& map_input_name_index,
-    std::size_t padded_batch_size)
-{
-  // Check if we can reuse existing buffers
-  bool can_reuse = (
-      mgx_state->temp_output_padded_batch_size == padded_batch_size &&
-      !mgx_state->temp_output_buffers.empty()
-  );
-  
-  if (can_reuse) {
-    // Return raw pointers from existing buffers
-    std::vector<void*> ptrs;
-    ptrs.reserve(mgx_state->temp_output_buffers.size());
-    for (const auto& buf : mgx_state->temp_output_buffers) {
-      ptrs.push_back(buf.data);
-    }
-    return ptrs;
-  }
-  
-  // Free old buffers if they exist
-  free_temp_output_buffers(mgx_state);
-  
-  // Count outputs and allocate
-  std::vector<void*> ptrs;
-  for (const auto& name : param_shapes.names()) {
-    // Skip inputs
-    if (map_input_name_index.find(name) != map_input_name_index.end()) {
-      continue;
-    }
-    
-    // This is an output
-    const auto output_index = compute_output_index(name);
-    if (output_index != -1) {
-      const auto& mgx_shape = param_shapes[name];
-      std::size_t size_bytes = mgx_shape.bytes();
-      
-      void* buffer = nullptr;
-      auto hip_status = hipMalloc(&buffer, size_bytes);
-      if (hip_status != hipSuccess) {
-        // Clean up any allocated buffers on failure
-        for (auto& buf : mgx_state->temp_output_buffers) {
-          if (buf.data) (void)hipFree(buf.data);
-        }
-        mgx_state->temp_output_buffers.clear();
-        ORT_THROW("hipMalloc failed for temporary output buffer");
-      }
-      
-      MIGraphXFuncState::TempOutputBuffer temp_buf;
-      temp_buf.data = buffer;
-      temp_buf.size_bytes = size_bytes;
-      temp_buf.mgx_shape = mgx_shape;
-      mgx_state->temp_output_buffers.push_back(temp_buf);
-      ptrs.push_back(buffer);
-      
-    }
-  }
-  
-  mgx_state->temp_output_padded_batch_size = padded_batch_size;
-  
-  return ptrs;
 }
 
 // Order matters here especially if the program uses mixed quantization
@@ -2310,84 +2234,58 @@ static bool execute_ultra_fast_path(
   if (!mgx_state->caches_valid || mgx_state->last_input_shapes_raw.empty()) {
     return false;
   }
-  
-  // Ultra-fast path not supported when outputs need dynamic slicing
+
   if (mgx_state->cached_outputs.empty()) {
     return false;
   }
 
-  // Quick shape comparison
   bool shapes_match = true;
   std::size_t offset = 0;
   const auto& last_shapes = mgx_state->last_input_shapes_raw;
-  
+
   std::size_t original_batch_size = 0;
   std::size_t padded_batch_size = 0;
   bool is_first = true;
 
   for (const auto& inp : mgx_state->cached_inputs) {
     const auto& shape = ctx.GetInput(inp.ort_index).GetTensorTypeAndShapeInfo().GetShape();
-    
+
     if (offset + shape.size() > last_shapes.size()) {
       shapes_match = false;
       break;
     }
-    
-    // For dynamic batch, we check if the current batch needs padding
+
     if (mgx_state->has_dynamic_batch && !mgx_state->compiled_batch_sizes.empty()) {
-      // Get batch sizes from first input
       if (is_first) {
         original_batch_size = static_cast<std::size_t>(shape[0]);
         padded_batch_size = static_cast<std::size_t>(last_shapes[offset]);
         is_first = false;
-        
-        // Check if the batch size matches (original or padded)
+
         if (shape[0] != last_shapes[offset]) {
-          // Batch size changed - check if we can use padding
           std::size_t required_padded = find_nearest_compiled_batch_size(
               original_batch_size, mgx_state->compiled_batch_sizes);
-          
           if (required_padded != padded_batch_size) {
             shapes_match = false;
             break;
           }
         }
       }
-      
-      // All current inputs should have the same batch size (original_batch_size)
+
       if (static_cast<std::size_t>(shape[0]) != original_batch_size) {
-        shapes_match = false;
-        break;
+        shapes_match = false; break;
       }
-      
-      // Cached shape should have padded batch size in dimension 0
       if (last_shapes[offset] != static_cast<std::int64_t>(padded_batch_size)) {
-        shapes_match = false;
-        break;
+        shapes_match = false; break;
       }
-      
-      // Check non-batch dimensions (current vs cached)
-      bool rest_matches = true;
       for (std::size_t i = 1; i < shape.size(); ++i) {
-        if (last_shapes[offset + i] != shape[i]) {
-          rest_matches = false;
-          break;
-        }
-      }
-      if (!rest_matches) {
-        shapes_match = false;
-        break;
+        if (last_shapes[offset + i] != shape[i]) { shapes_match = false; break; }
       }
     } else {
-      // No dynamic batching - strict comparison
       for (std::size_t i = 0; i < shape.size(); ++i) {
-        if (last_shapes[offset + i] != shape[i]) {
-          shapes_match = false;
-          break;
-        }
+        if (last_shapes[offset + i] != shape[i]) { shapes_match = false; break; }
       }
     }
-    
+
     if (!shapes_match) break;
     offset += shape.size();
   }
@@ -2396,40 +2294,38 @@ static bool execute_ultra_fast_path(
     return false;
   }
 
-  // Ultra-fast path doesn't support output slicing because cached_output_ort_shapes
-  // contains padded shapes, not sliced shapes. Fall back to fast path which handles
-  // slicing properly via temp output buffers.
-  if (padded_batch_size > 0 && original_batch_size > 0 && padded_batch_size > original_batch_size) {
-    return false;
-  }
-
-  // Shapes unchanged (or compatible with padding) - rebind pointers and run directly
-  auto& m = mgx_state->cached_prog_params.value();
   auto& prog = mgx_state->prog;
-  
-  // Allocate and pad inputs if needed for dynamic batching
-  bool using_padded_inputs = false;
-  if (padded_batch_size > original_batch_size) {
-    using_padded_inputs = allocate_and_pad_inputs(mgx_state, ctx, original_batch_size, 
-                                                  padded_batch_size, rocm_stream);
+  std::size_t actual_batch = original_batch_size > 0 ? original_batch_size
+      : (!mgx_state->cached_inputs.empty()
+          ? static_cast<std::size_t>(ctx.GetInput(mgx_state->cached_inputs[0].ort_index)
+                .GetTensorTypeAndShapeInfo().GetShape()[0])
+          : 0);
+  std::size_t compiled_batch = padded_batch_size > 0 ? padded_batch_size : actual_batch;
+  bool needs_pinned = (actual_batch < compiled_batch) && mgx_state->pinned_io.allocated;
+
+  if (needs_pinned && mgx_state->cached_mgx_param_shapes.has_value()) {
+    // Pinned I/O path: pad inputs -> run -> slice outputs
+    const auto& param_shapes = mgx_state->cached_mgx_param_shapes.value();
+    const auto& output_shapes = mgx_state->cached_mgx_output_shapes.value();
+
+    copy_inputs_to_pinned(mgx_state, param_shapes, ctx, actual_batch, compiled_batch, rocm_stream);
+
+    auto& m = mgx_state->cached_prog_params.value();
+    run_migraphx_program(mgx_state->mgx_mu_ptr, rocm_stream, ctx, prog, m,
+                         mgx_state->cached_prog_output_indices);
+
+    copy_pinned_outputs_to_ort(mgx_state, output_shapes, mgx_state->cached_prog_output_indices,
+                               ctx, actual_batch, rocm_stream);
+    return true;
   }
 
-  // Rebind inputs - use padded buffers if available, otherwise use original inputs
-  if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
-    for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
-      const auto& inp = mgx_state->cached_inputs[i];
-      const auto& padded_buf = mgx_state->padded_input_buffers[i];
-      m.add(inp.name.c_str(), migraphx::argument(padded_buf.mgx_shape, padded_buf.data));
-    }
-  } else {
-    for (const auto& inp : mgx_state->cached_inputs) {
-      const auto& input_tensor = ctx.GetInput(inp.ort_index);
-      m.add(inp.name.c_str(), migraphx::argument(inp.mgx_shape,
-                                         const_cast<void*>(input_tensor.GetTensorRawData())));
-    }
+  // Direct ORT pointer path: bind ORT tensors directly — zero memcpy overhead
+  auto& m = mgx_state->cached_prog_params.value();
+  for (const auto& inp : mgx_state->cached_inputs) {
+    const auto& input_tensor = ctx.GetInput(inp.ort_index);
+    m.add(inp.name.c_str(), migraphx::argument(inp.mgx_shape,
+                                       const_cast<void*>(input_tensor.GetTensorRawData())));
   }
-
-  // Rebind outputs - direct iteration, uses pre-allocated shape vectors
   for (std::size_t i = 0; i < mgx_state->cached_outputs.size(); ++i) {
     const auto& out = mgx_state->cached_outputs[i];
     const auto& ort_shape = mgx_state->cached_output_ort_shapes[i];
@@ -2437,12 +2333,8 @@ static bool execute_ultra_fast_path(
     m.add(out.name.c_str(), migraphx::argument(out.mgx_shape,
                                        output_tensor.GetTensorMutableRawData()));
   }
-
-  // Run directly - minimal overhead path
   run_migraphx_program(mgx_state->mgx_mu_ptr, rocm_stream, ctx, prog, m,
-                       mgx_state->cached_prog_output_indices,
-                       original_batch_size, padded_batch_size);
-  
+                       mgx_state->cached_prog_output_indices);
   return true;
 }
 
@@ -2456,125 +2348,95 @@ static bool execute_fast_path(
     const std::string& current_hash,
     std::vector<std::int64_t>& all_input_shapes)
 {
-  
-  if (mgx_state->defer_compilation || !mgx_state->cached_programs_ref.has_value()) {
+  if (!mgx_state->cached_programs_ref.has_value()) {
     return false;
   }
 
   auto& cached_programs = mgx_state->cached_programs_ref.value().get();
+
+  if (mgx_state->defer_compilation && cached_programs.empty()) {
+    return false;
+  }
+
   auto prog_it = cached_programs.find(current_hash);
-  
-  // If not found directly, check if we need to use a padded batch size
+
   std::size_t original_batch_size = 0;
   std::size_t padded_batch_size = 0;
   bool needs_padding = false;
-  
-  if (prog_it == cached_programs.end() && mgx_state->has_dynamic_batch && 
+
+  if (prog_it == cached_programs.end() && mgx_state->has_dynamic_batch &&
       !mgx_state->compiled_batch_sizes.empty()) {
-    // Try to find a padded batch size
     const auto& map_input_name_index = mgx_state->input_name_indexes;
-    
+
     for (const auto& [name, index] : map_input_name_index) {
       auto input_tensor = ctx.GetInput(index);
-      auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-      const auto tensor_shape = tensor_info.GetShape();
+      const auto tensor_shape = input_tensor.GetTensorTypeAndShapeInfo().GetShape();
       if (!tensor_shape.empty()) {
         original_batch_size = static_cast<std::size_t>(tensor_shape[0]);
         padded_batch_size = find_nearest_compiled_batch_size(original_batch_size,
-                                                                    mgx_state->compiled_batch_sizes);
+                                                            mgx_state->compiled_batch_sizes);
         needs_padding = (padded_batch_size > original_batch_size);
         break;
       }
     }
-    
+
     if (needs_padding && padded_batch_size > 0) {
-      // Build padded shapes in alphabetical order (map order) for hash calculation
-      // This matches the order used during compilation in compile_dynamic_batch_models
       std::vector<std::int64_t> padded_shapes_for_hash;
       padded_shapes_for_hash.reserve(all_input_shapes.size());
-      
       for (const auto& [name, index] : map_input_name_index) {
-        auto input_tensor = ctx.GetInput(index);
-        auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-        const auto tensor_shape = tensor_info.GetShape();
-        
+        const auto tensor_shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
         if (!tensor_shape.empty()) {
           padded_shapes_for_hash.push_back(static_cast<std::int64_t>(padded_batch_size));
           padded_shapes_for_hash.insert(padded_shapes_for_hash.end(), tensor_shape.begin() + 1, tensor_shape.end());
         }
       }
-      
       auto padded_hash = make_hash(padded_shapes_for_hash);
       prog_it = cached_programs.find(padded_hash);
-      
-      if (prog_it != cached_programs.end()) {
-        
-        // Now rebuild padded_shapes in cached_inputs order for saving to last_input_shapes_raw
-        // This ensures ultra-fast path shape comparison works correctly
-        if (!mgx_state->cached_inputs.empty()) {
-          std::vector<std::int64_t> padded_shapes_for_cache;
-          padded_shapes_for_cache.reserve(mgx_state->cached_inputs.size() * 2);
-          
-          for (const auto& cached_inp : mgx_state->cached_inputs) {
-            auto input_tensor = ctx.GetInput(cached_inp.ort_index);
-            auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-            const auto tensor_shape = tensor_info.GetShape();
-            
-            if (!tensor_shape.empty()) {
-              padded_shapes_for_cache.push_back(static_cast<std::int64_t>(padded_batch_size));
-              padded_shapes_for_cache.insert(padded_shapes_for_cache.end(), tensor_shape.begin() + 1, tensor_shape.end());
-            }
+
+      if (prog_it != cached_programs.end() && !mgx_state->cached_inputs.empty()) {
+        std::vector<std::int64_t> padded_shapes_for_cache;
+        padded_shapes_for_cache.reserve(mgx_state->cached_inputs.size() * 2);
+        for (const auto& cached_inp : mgx_state->cached_inputs) {
+          const auto tensor_shape = ctx.GetInput(cached_inp.ort_index).GetTensorTypeAndShapeInfo().GetShape();
+          if (!tensor_shape.empty()) {
+            padded_shapes_for_cache.push_back(static_cast<std::int64_t>(padded_batch_size));
+            padded_shapes_for_cache.insert(padded_shapes_for_cache.end(), tensor_shape.begin() + 1, tensor_shape.end());
           }
-          all_input_shapes = std::move(padded_shapes_for_cache);
-        } else {
-          // Fallback: use map order (shouldn't happen if caches are populated)
-          all_input_shapes = std::move(padded_shapes_for_hash);
         }
+        all_input_shapes = std::move(padded_shapes_for_cache);
       }
     }
   }
-  
+
   if (prog_it == cached_programs.end()) {
     return false;
   }
 
-  // Determine which hash was used to find the program
-  // This is needed to detect program changes and invalidate caches
   std::string effective_program_hash = current_hash;
   if (needs_padding && padded_batch_size > 0) {
-    // If we used padded hash, compute it for tracking
     std::vector<std::int64_t> padded_shapes_for_hash_tracking;
     for (const auto& [name, index] : mgx_state->input_name_indexes) {
-      auto input_tensor = ctx.GetInput(index);
-      auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-      const auto tensor_shape = tensor_info.GetShape();
+      const auto tensor_shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
       if (!tensor_shape.empty()) {
         padded_shapes_for_hash_tracking.push_back(static_cast<std::int64_t>(padded_batch_size));
-        padded_shapes_for_hash_tracking.insert(padded_shapes_for_hash_tracking.end(), 
+        padded_shapes_for_hash_tracking.insert(padded_shapes_for_hash_tracking.end(),
                                                tensor_shape.begin() + 1, tensor_shape.end());
       }
     }
     effective_program_hash = make_hash(padded_shapes_for_hash_tracking);
   }
 
-  // Found cached program - use it and populate caches
   auto& prog = mgx_state->prog;
   prog = prog_it->second;
 
   const auto& map_input_name_index = mgx_state->input_name_indexes;
 
-  // ═══════════════════════════════════════════════════════════════════════════
-  // OPTIMIZATION 1: Cache MIGraphX API results (avoid redundant API calls)
-  // Check if program changed - if so, invalidate caches
-  // ═══════════════════════════════════════════════════════════════════════════
   bool program_changed = (mgx_state->cached_program_hash != effective_program_hash);
-  
   if (program_changed) {
     clear_cached_mgx_shapes(mgx_state);
-    free_temp_output_buffers(mgx_state);
     mgx_state->cached_program_hash = effective_program_hash;
   }
-  
+
   if (!mgx_state->cached_mgx_param_shapes.has_value()) {
     mgx_state->cached_mgx_param_shapes = prog.get_parameter_shapes();
     mgx_state->cached_mgx_output_shapes = prog.get_output_shapes();
@@ -2582,68 +2444,56 @@ static bool execute_fast_path(
   const auto& param_shapes = mgx_state->cached_mgx_param_shapes.value();
   const auto& output_shapes = mgx_state->cached_mgx_output_shapes.value();
 
-  bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 && 
-                        original_batch_size < padded_batch_size);
-  
-  // ═══════════════════════════════════════════════════════════════════════════
-  // OPTIMIZATION 2: Skip populate_ultra_fast_caches when already populated
-  // ═══════════════════════════════════════════════════════════════════════════
   if (!mgx_state->ultra_fast_caches_populated) {
     populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index,
                               original_batch_size, padded_batch_size);
     mgx_state->ultra_fast_caches_populated = true;
   }
 
-  // Allocate and pad inputs if needed for dynamic batching
-  bool using_padded_inputs = false;
-  if (padded_batch_size > original_batch_size) {
-    using_padded_inputs = allocate_and_pad_inputs(mgx_state, ctx, original_batch_size, 
-                                                  padded_batch_size, rocm_stream);
+  std::size_t actual_batch = original_batch_size > 0 ? original_batch_size : 0;
+  if (actual_batch == 0) {
+    for (const auto& [name, index] : map_input_name_index) {
+      auto shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
+      if (!shape.empty()) { actual_batch = static_cast<std::size_t>(shape[0]); break; }
+    }
+  }
+  std::size_t compiled_batch = padded_batch_size > 0 ? padded_batch_size : actual_batch;
+  bool needs_pinned = (actual_batch < compiled_batch) && mgx_state->pinned_io.allocated;
+
+  if (needs_pinned) {
+    // Pinned I/O path: pad inputs -> run on compiled shape -> slice outputs
+    copy_inputs_to_pinned(mgx_state, param_shapes, ctx, actual_batch, compiled_batch, rocm_stream);
+    auto [m, out_indices] = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
+
+    mgx_state->cached_prog_params = std::move(m);
+    mgx_state->cached_prog_output_indices = std::move(out_indices);
+    mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(
+        mgx_state, ctx, padded_batch_size);
+    mgx_state->last_input_shape_hash = current_hash;
+    mgx_state->caches_valid = true;
+
+    run_migraphx_program(mgx_state->mgx_mu_ptr, rocm_stream, ctx, prog,
+                         mgx_state->cached_prog_params.value(),
+                         mgx_state->cached_prog_output_indices);
+
+    copy_pinned_outputs_to_ort(mgx_state, output_shapes, mgx_state->cached_prog_output_indices,
+                               ctx, actual_batch, rocm_stream);
+    return true;
   }
 
-  // ═══════════════════════════════════════════════════════════════════════════
-  // OPTIMIZATION 3: Reuse temp output buffers when slicing
-  // ═══════════════════════════════════════════════════════════════════════════
-  std::vector<void*> temp_output_buffer_ptrs;
-  if (needs_slicing) {
-    temp_output_buffer_ptrs = get_or_allocate_temp_output_buffers(
-        mgx_state, param_shapes, output_shapes, map_input_name_index, padded_batch_size);
-  }
-
-  // Bind inputs/outputs (use temp buffers for outputs when slicing)
+  // Direct ORT pointer path: bind ORT tensors directly — zero memcpy overhead
   auto [m, prog_output_indices] = handle_program_input_outputs(
-      param_shapes, output_shapes, map_input_name_index, ctx, needs_slicing, 
-      needs_slicing ? &temp_output_buffer_ptrs : nullptr);
+      param_shapes, output_shapes, map_input_name_index, ctx);
 
   mgx_state->cached_prog_params = std::move(m);
   mgx_state->cached_prog_output_indices = std::move(prog_output_indices);
-  
-  // IMPORTANT: Build last_input_shapes_raw in cached_inputs order (MIGraphX parameter order)
-  // This ensures ultra-fast path shape comparison uses consistent ordering
-  mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(
-      mgx_state, ctx, using_padded_inputs ? padded_batch_size : 0);
-  
+  mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(mgx_state, ctx, 0);
   mgx_state->last_input_shape_hash = current_hash;
   mgx_state->caches_valid = true;
 
-  // Rebind padded inputs to program parameters
-  if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
-    auto& prog_params = mgx_state->cached_prog_params.value();
-    for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
-      const auto& inp = mgx_state->cached_inputs[i];
-      const auto& padded_buf = mgx_state->padded_input_buffers[i];
-      prog_params.add(inp.name.c_str(), migraphx::argument(padded_buf.mgx_shape, padded_buf.data));
-    }
-  }
-
   run_migraphx_program(mgx_state->mgx_mu_ptr, rocm_stream, ctx, prog,
                        mgx_state->cached_prog_params.value(),
-                       mgx_state->cached_prog_output_indices,
-                       original_batch_size, padded_batch_size);
-  
-  // NOTE: Temp output buffers are kept for reuse - they will be freed when batch size changes
-  // NOTE: Padded input buffers are also kept for reuse
-  
+                       mgx_state->cached_prog_output_indices);
   return true;
 }
 
@@ -2873,10 +2723,27 @@ static void compile_dynamic_batch_models(
   // Disable dynamic batch compilation for subsequent runs (set max_dynamic_batch to 0)
   mgx_state->max_dynamic_batch = 0;
   
-  // Also disable defer_compilation since we've now compiled
   mgx_state->defer_compilation = false;
   LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Set defer_compilation = false";
-  
+
+  // Allocate pinned I/O now that all batch models are compiled
+  if (!mgx_state->pinned_io.allocated && mgx_state->cached_programs_ref.has_value()) {
+    auto& progs = mgx_state->cached_programs_ref.value().get();
+    if (!progs.empty()) {
+      std::size_t max_batch = 0;
+      if (!mgx_state->compiled_batch_sizes.empty()) {
+        max_batch = *std::max_element(mgx_state->compiled_batch_sizes.begin(),
+                                      mgx_state->compiled_batch_sizes.end());
+      }
+      auto& last_prog = progs.begin()->second;
+      auto ps = last_prog.get_parameter_shapes();
+      auto os = last_prog.get_output_shapes();
+      if (max_batch > 0) {
+        allocate_pinned_io(mgx_state, ps, os, max_batch);
+      }
+    }
+  }
+
   LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ==== EXITING compile_dynamic_batch_models ====";
 }
 
@@ -2962,87 +2829,48 @@ static void execute_standard_path(
           auto param_shapes = prog.get_parameter_shapes();
           auto output_shapes = prog.get_output_shapes();
           
-          if (needs_padding) {
-            // ============ PADDING PATH: Batch size needs to be padded ============
-            
-            // Populate caches (with slicing info so ultra-fast path is disabled)
-            populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index,
-                                      original_batch_size, padded_batch_size);
-            
-            // Rebuild padded_shapes in cached_inputs order (MIGraphX parameter order)
-            // This ensures consistency with ultra-fast path shape comparison
-            padded_shapes.clear();
-            padded_shapes.reserve(mgx_state->cached_inputs.size() * 2);
-            for (const auto& cached_inp : mgx_state->cached_inputs) {
-              auto input_tensor = ctx.GetInput(cached_inp.ort_index);
-              auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
-              const auto tensor_shape = tensor_info.GetShape();
-              
-              if (!tensor_shape.empty()) {
-                padded_shapes.push_back(static_cast<std::int64_t>(padded_batch_size));
-                padded_shapes.insert(padded_shapes.end(), tensor_shape.begin() + 1, tensor_shape.end());
-              }
-            }
-            
-            // Allocate and pad inputs for dynamic batching
-            bool using_padded_inputs = allocate_and_pad_inputs(mgx_state, ctx, original_batch_size, 
-                                                               padded_batch_size, rocm_stream);
-            
-            // Get or reuse cached temp output buffers (avoids hipMalloc/hipFree per run)
-            auto temp_output_buffer_ptrs = get_or_allocate_temp_output_buffers(
-                mgx_state, param_shapes, output_shapes, map_input_name_index, padded_batch_size);
+          populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index,
+                                    original_batch_size, padded_batch_size);
 
-            auto [m, prog_output_indices] = handle_program_input_outputs(
-                param_shapes, output_shapes, map_input_name_index, ctx, true, &temp_output_buffer_ptrs);
-            
+          if (needs_padding) {
+            // Padding required — use pinned I/O for pad + slice
+            if (!mgx_state->pinned_io.allocated) {
+              std::size_t max_batch = padded_batch_size;
+              if (!mgx_state->compiled_batch_sizes.empty()) {
+                max_batch = *std::max_element(mgx_state->compiled_batch_sizes.begin(),
+                                              mgx_state->compiled_batch_sizes.end());
+              }
+              allocate_pinned_io(mgx_state, param_shapes, output_shapes, max_batch);
+            }
+
+            copy_inputs_to_pinned(mgx_state, param_shapes, ctx, original_batch_size, padded_batch_size, rocm_stream);
+            auto [m, out_indices] = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
+
             mgx_state->cached_prog_params = m;
-            mgx_state->cached_prog_output_indices = prog_output_indices;
-            mgx_state->last_input_shapes_raw = std::move(padded_shapes);
+            mgx_state->cached_prog_output_indices = out_indices;
+            mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(
+                mgx_state, ctx, padded_batch_size);
             mgx_state->last_input_shape_hash = padded_hash;
             mgx_state->caches_valid = true;
-            
-            // Rebind padded inputs to program parameters
-            if (using_padded_inputs && mgx_state->padded_input_buffers.size() == mgx_state->cached_inputs.size()) {
-              for (size_t i = 0; i < mgx_state->cached_inputs.size(); ++i) {
-                const auto& inp = mgx_state->cached_inputs[i];
-                const auto& padded_buf = mgx_state->padded_input_buffers[i];
-                m.add(inp.name.c_str(), migraphx::argument(padded_buf.mgx_shape, padded_buf.data));
-              }
-            }
-            
-            run_migraphx_program(mgx_state->mgx_mu_ptr, rocm_stream, ctx, prog, m, 
-                                prog_output_indices, original_batch_size, padded_batch_size);
-            
-            // Temp output buffers are cached on mgx_state for reuse across runs.
-            // They are freed when the batch size changes or when the state is destroyed.
-            
-            return;
+
+            run_migraphx_program(mgx_state->mgx_mu_ptr, rocm_stream, ctx, prog, m, out_indices);
+
+            copy_pinned_outputs_to_ort(mgx_state, output_shapes, out_indices,
+                                       ctx, original_batch_size, rocm_stream);
           } else {
-            // ============ EXACT MATCH PATH: Batch size matches exactly, no padding needed ============
-            
-            // Populate caches for ultra-fast path (no slicing needed)
-            populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
-            
-            // Bind inputs and allocate outputs (no slicing)
+            // Exact batch match — direct ORT pointer binding
             auto [m, prog_output_indices] = handle_program_input_outputs(
                 param_shapes, output_shapes, map_input_name_index, ctx);
-            
-            // Complete cache population
+
             mgx_state->cached_prog_params = m;
             mgx_state->cached_prog_output_indices = prog_output_indices;
-            
-            // IMPORTANT: Build last_input_shapes_raw in cached_inputs order (MIGraphX parameter order)
-            // This ensures ultra-fast path shape comparison uses consistent ordering
             mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(mgx_state, ctx, 0);
-            
             mgx_state->last_input_shape_hash = current_hash;
             mgx_state->caches_valid = true;
-            
-            run_migraphx_program(mgx_state->mgx_mu_ptr, rocm_stream, ctx, prog, m, prog_output_indices, 
-                                0, 0);
-            
-            return;
+
+            run_migraphx_program(mgx_state->mgx_mu_ptr, rocm_stream, ctx, prog, m, prog_output_indices);
           }
+          return;
         }
       }
     }
@@ -3068,30 +2896,39 @@ static void execute_standard_path(
     param_shapes = prog.get_parameter_shapes();
   }
 
-  // Fetch output shapes once
   auto output_shapes = prog.get_output_shapes();
 
-  // Populate optimized caches for ultra-fast path
   populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
 
-  // Bind inputs and allocate outputs
+  // Lazily allocate pinned I/O for future pad/slice use (e.g. first inference after JIT compile).
+  // The buffers are not used on this path since the program was compiled for the exact shape.
+  if (!mgx_state->pinned_io.allocated) {
+    std::size_t batch_for_alloc = 0;
+    if (!mgx_state->compiled_batch_sizes.empty()) {
+      batch_for_alloc = *std::max_element(mgx_state->compiled_batch_sizes.begin(),
+                                          mgx_state->compiled_batch_sizes.end());
+    }
+    if (batch_for_alloc == 0) {
+      for (const auto& [name, index] : map_input_name_index) {
+        auto shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
+        if (!shape.empty()) { batch_for_alloc = static_cast<std::size_t>(shape[0]); break; }
+      }
+    }
+    if (batch_for_alloc > 0) {
+      allocate_pinned_io(mgx_state, param_shapes, output_shapes, batch_for_alloc);
+    }
+  }
+
+  // Direct ORT pointer path: program compiled for exact runtime shape — no padding needed
   auto [m, prog_output_indices] = handle_program_input_outputs(
       param_shapes, output_shapes, map_input_name_index, ctx);
 
-  // Complete cache population
   mgx_state->cached_prog_params = m;
   mgx_state->cached_prog_output_indices = prog_output_indices;
-  
-  // IMPORTANT: Build last_input_shapes_raw in cached_inputs order (MIGraphX parameter order)
-  // This ensures ultra-fast path shape comparison uses consistent ordering
   mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(mgx_state, ctx, 0);
-  
   mgx_state->last_input_shape_hash = current_hash;
   mgx_state->caches_valid = true;
 
-  // The program at this point was compiled (or already matched) for the exact
-  // runtime input shapes, so its outputs already have the original batch
-  // dimension.  Pass 0,0 to avoid incorrect slicing arithmetic.
   run_migraphx_program(mgx_state->mgx_mu_ptr, rocm_stream, ctx, prog, m, prog_output_indices);
 }
 
@@ -3722,6 +3559,54 @@ static inline void precompile_static_model(
   LOGS_DEFAULT(INFO) << "[precompile_static_model] ✓ Static model precompiled and cached";
 }
 
+// Scan disk cache for .mxr files matching the node prefix and pre-load them
+// into the in-memory cache.  Eliminates first-inference stalls for deferred
+// compilation where .mxr files exist from a previous session.
+static void preload_mxr_cache_from_disk(
+    const std::filesystem::path& model_cache_path,
+    const std::string& mxr_filename_prefix,
+    std::unordered_map<std::string, migraphx::program>& cached_programs)
+{
+  if (model_cache_path.empty() || !std::filesystem::exists(model_cache_path)) return;
+
+  const std::string suffix = ".mxr";
+  std::vector<std::pair<std::string, std::filesystem::path>> to_load;
+
+  for (const auto& entry : std::filesystem::directory_iterator(model_cache_path)) {
+    if (!entry.is_regular_file()) continue;
+    const auto fname = entry.path().filename().string();
+    if (fname.size() <= mxr_filename_prefix.size() + suffix.size()) continue;
+    if (fname.substr(0, mxr_filename_prefix.size()) != mxr_filename_prefix) continue;
+    if (fname.substr(fname.size() - suffix.size()) != suffix) continue;
+
+    auto hash = fname.substr(mxr_filename_prefix.size(),
+                             fname.size() - mxr_filename_prefix.size() - suffix.size());
+    if (cached_programs.find(hash) != cached_programs.end()) continue;
+    to_load.emplace_back(hash, entry.path());
+  }
+
+  if (to_load.empty()) return;
+
+  LOGS_DEFAULT(INFO) << "[preload_mxr_cache] Found " << to_load.size()
+                     << " .mxr file(s) to pre-load for prefix '" << mxr_filename_prefix << "'";
+
+  std::mutex mu;
+  std::vector<std::future<void>> futs;
+  for (const auto& [hash, path] : to_load) {
+    futs.push_back(std::async(std::launch::async, [&, hash, path]() {
+      migraphx::program prog;
+      if (load_precompiled_model(prog, path)) {
+        std::lock_guard<std::mutex> lk(mu);
+        cached_programs[hash] = std::move(prog);
+      }
+    }));
+  }
+  for (auto& f : futs) f.get();
+
+  LOGS_DEFAULT(INFO) << "[preload_mxr_cache] Pre-loaded " << cached_programs.size()
+                     << " program(s) into in-memory cache";
+}
+
 // Encapsulates precompilation decision logic from Compile()
 // Returns true if compilation should be deferred to runtime, false if precompilation succeeded
 static inline bool handle_precompilation_decision(
@@ -3994,6 +3879,10 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         max_dynamic_batch_,
         compile_batches_);
 
+    // Pre-load any .mxr files from disk that aren't already in memory.
+    preload_mxr_cache_from_disk(model_cache_path_, mxr_filename_prefix,
+                                cached_programs_[fused_node.Name()]);
+
     // Create program object (may be empty if precompiled programs are in cache)
     migraphx::program prog;
     map_progs_[fused_node.Name()] = prog;
@@ -4036,7 +3925,53 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         LOGS_DEFAULT(VERBOSE) << "[Compile][CREATE_STATE] Static model mode for node '" << context->node_name << "'";
         LOGS_DEFAULT(VERBOSE) << "[Compile][CREATE_STATE] defer_compilation=" << p->defer_compilation;
       }
-      
+
+      // Allocate pinned I/O buffers from the cached programs.
+      // For dynamic batch: use max compiled batch size.
+      // For static: use the program's own batch size.
+      if (p->cached_programs_ref.has_value() && !p->cached_programs_ref.value().get().empty()) {
+        std::size_t max_batch = 0;
+        if (!p->compiled_batch_sizes.empty()) {
+          max_batch = *std::max_element(p->compiled_batch_sizes.begin(),
+                                        p->compiled_batch_sizes.end());
+        }
+        // Find the program with the largest batch to get representative shapes
+        migraphx::program* largest_prog = nullptr;
+        for (auto& [hash, prog] : p->cached_programs_ref.value().get()) {
+          if (!largest_prog) {
+            largest_prog = &prog;
+            if (max_batch == 0) {
+              auto ps = prog.get_parameter_shapes();
+              for (const auto& name : ps.names()) {
+                if (p->input_name_indexes.find(name) != p->input_name_indexes.end()) {
+                  auto lens = ps[name].lengths();
+                  if (!lens.empty() && lens[0] > 0) {
+                    max_batch = lens[0];
+                    break;
+                  }
+                }
+              }
+            }
+          }
+          largest_prog = &prog;
+        }
+        if (largest_prog && max_batch > 0) {
+          auto ps = largest_prog->get_parameter_shapes();
+          auto os = largest_prog->get_output_shapes();
+          allocate_pinned_io(p.get(), ps, os, max_batch);
+        }
+
+        // If all batch sizes are pre-loaded, disable deferred compilation
+        if (p->defer_compilation && p->has_dynamic_batch && !p->compiled_batch_sizes.empty()) {
+          auto& progs = p->cached_programs_ref.value().get();
+          if (progs.size() >= p->compiled_batch_sizes.size()) {
+            p->defer_compilation = false;
+            LOGS_DEFAULT(INFO) << "[Compile][CREATE_STATE] All " << p->compiled_batch_sizes.size()
+                               << " batch model(s) pre-loaded — defer_compilation disabled";
+          }
+        }
+      }
+
       *state = p.release();
       return 0;
     };
@@ -4044,12 +3979,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     compute_info.release_state_func = [](FunctionState state) {
       if (state) {
         auto* s = static_cast<MIGraphXFuncState*>(state);
-        for (auto& buf : s->padded_input_buffers) {
-          if (buf.data) (void)hipFree(buf.data);
-        }
-        for (auto& buf : s->temp_output_buffers) {
-          if (buf.data) (void)hipFree(buf.data);
-        }
+        free_pinned_io(s);
         delete s;
       }
     };

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -2020,7 +2020,16 @@ static void run_program_or_hip_graph_direct(
   auto it = mgx_state->hip_graph_cache.find(shape_hash);
   if (it != mgx_state->hip_graph_cache.end() && it->second.captured) {
     if (!check_captured_ptrs_match(it->second, input_ptrs, output_ptrs)) {
-      // Pointer drift -- destroy old graph and re-capture
+      ++mgx_state->direct_recapture_count;
+      if (mgx_state->direct_recapture_count > MIGraphXFuncState::kMaxDirectRecaptures) {
+        LOGS_DEFAULT(WARNING) << "[HipGraph] Too many pointer-drift re-captures ("
+                              << mgx_state->direct_recapture_count
+                              << "), falling back to eager execution";
+        mgx_state->use_direct_hip_graph = false;
+        run_migraphx_program(mgx_state->mgx_mu_ptr, stream, ctx, prog, m,
+                             prog_output_indices, original_batch_size, padded_batch_size);
+        return;
+      }
       if (it->second.exec) { (void)hipGraphExecDestroy(it->second.exec); it->second.exec = nullptr; }
       if (it->second.graph) { (void)hipGraphDestroy(it->second.graph); it->second.graph = nullptr; }
       it->second.captured = false;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1481,16 +1481,17 @@ static void allocate_pinned_io(
 {
   auto& pio = mgx_state->pinned_io;
   if (pio.allocated) {
-    LOGS_DEFAULT(INFO) << "[PinnedIO] Already allocated (max_batch=" << pio.max_batch_size
+    LOGS_DEFAULT(WARNING) << "[PinnedIO] Already allocated (max_batch=" << pio.max_batch_size
                        << "), skipping re-allocation for max_batch=" << max_batch_size;
     return;
   }
 
-  LOGS_DEFAULT(INFO) << "[PinnedIO] Allocating buffers: max_batch=" << max_batch_size;
+  LOGS_DEFAULT(WARNING) << "[PinnedIO] Allocating buffers: max_batch=" << max_batch_size;
 
   const auto& map_input_name_index = mgx_state->input_name_indexes;
 
   pio.inputs.clear();
+  pio.input_name_to_idx.clear();
   std::size_t input_total_bytes = 0;
   for (const auto& name : param_shapes.names()) {
     if (map_input_name_index.find(name) == map_input_name_index.end()) continue;
@@ -1501,6 +1502,7 @@ static void allocate_pinned_io(
     std::size_t bytes = max_shape.bytes();
     input_total_bytes += bytes;
 
+    pio.input_name_to_idx[name] = pio.inputs.size();
     void* ptr = nullptr;
     HIP_CALL_THROW(hipMallocAsync(&ptr, bytes, stream));
     HIP_CALL_THROW(hipMemsetAsync(ptr, 0, bytes, stream));
@@ -1508,18 +1510,29 @@ static void allocate_pinned_io(
   }
 
   pio.outputs.clear();
+  pio.output_name_to_idx.clear();
   std::size_t output_total_bytes = 0;
-  for (const auto& out_shape : output_shapes) {
+  std::size_t output_alloc_idx = 0;
+  for (const auto& name : param_shapes.names()) {
+    if (map_input_name_index.find(name) != map_input_name_index.end()) continue;
+    const auto oi = compute_output_index(name);
+    if (oi == -1) continue;
+    if (static_cast<std::size_t>(oi) >= output_shapes.size()) continue;
+    if (output_alloc_idx >= output_shapes.size()) break;
+
+    const auto& out_shape = output_shapes[oi];
     auto lens = out_shape.lengths();
     if (!lens.empty()) lens[0] = max_batch_size;
     auto max_shape = migraphx::shape(out_shape.type(), lens);
     std::size_t bytes = max_shape.bytes();
     output_total_bytes += bytes;
 
+    pio.output_name_to_idx[name] = pio.outputs.size();
     void* ptr = nullptr;
     HIP_CALL_THROW(hipMallocAsync(&ptr, bytes, stream));
     HIP_CALL_THROW(hipMemsetAsync(ptr, 0, bytes, stream));
     pio.outputs.push_back({ptr, bytes, max_shape});
+    ++output_alloc_idx;
   }
 
   HIP_CALL_THROW(hipStreamSynchronize(stream));
@@ -1528,7 +1541,7 @@ static void allocate_pinned_io(
   pio.allocated = true;
 
   std::size_t total_bytes = input_total_bytes + output_total_bytes;
-  LOGS_DEFAULT(INFO) << "[PinnedIO] Allocated: max_batch=" << max_batch_size
+  LOGS_DEFAULT(WARNING) << "[PinnedIO] Allocated: max_batch=" << max_batch_size
                      << " inputs=" << pio.inputs.size()
                      << " (" << (input_total_bytes / (1024.0 * 1024.0)) << " MB)"
                      << " outputs=" << pio.outputs.size()
@@ -1551,7 +1564,6 @@ static void free_pinned_io(MIGraphXFuncState* mgx_state, hipStream_t stream) {
 }
 
 // Copy ORT input tensors into pinned buffers and pad if needed.
-// Returns the number of bytes-per-batch for each input (used for element-size calc).
 static void copy_inputs_to_pinned(
     MIGraphXFuncState* mgx_state,
     const migraphx::program_parameter_shapes& param_shapes,
@@ -1562,13 +1574,15 @@ static void copy_inputs_to_pinned(
 {
   auto& pio = mgx_state->pinned_io;
   const auto& map_input_name_index = mgx_state->input_name_indexes;
-  std::size_t idx = 0;
 
   for (const auto& name : param_shapes.names()) {
     auto it = map_input_name_index.find(name);
     if (it == map_input_name_index.end()) continue;
 
-    auto& pin = pio.inputs[idx];
+    auto pin_it = pio.input_name_to_idx.find(name);
+    if (pin_it == pio.input_name_to_idx.end()) continue;
+    auto& pin = pio.inputs[pin_it->second];
+
     const auto& input_tensor = ctx.GetInput(it->second);
     const void* src = input_tensor.GetTensorRawData();
     const auto& base_shape = param_shapes[name];
@@ -1582,8 +1596,10 @@ static void copy_inputs_to_pinned(
     std::size_t byte_per_elem = (total_elems > 0) ? base_shape.bytes() / total_elems : 0;
     std::size_t bytes_per_batch = elements_per_batch * byte_per_elem;
 
+    std::size_t copy_bytes = actual_batch * bytes_per_batch;
+    if (copy_bytes > pin.size_bytes) copy_bytes = pin.size_bytes;
+
     if (actual_batch == compiled_batch) {
-      std::size_t copy_bytes = actual_batch * bytes_per_batch;
       if (copy_bytes > 0) {
         HIP_CALL_THROW(hipMemcpyAsync(pin.data, src, copy_bytes, hipMemcpyDefault, stream));
       }
@@ -1591,12 +1607,20 @@ static void copy_inputs_to_pinned(
       pad_input_tensor(src, pin.data, actual_batch, compiled_batch,
                        byte_per_elem, elements_per_batch, stream);
     }
-    ++idx;
   }
 }
 
 // Build program_parameters binding pinned buffers at the given compiled shape.
-static std::pair<migraphx::program_parameters, std::vector<std::size_t>>
+// Uses name-based lookup into pinned buffers so parameter ordering differences
+// between compiled programs don't cause mismatched buffer access.
+// Returns: {program_parameters, ORT_output_indices, pinned_buffer_indices}
+struct PinnedBindResult {
+  migraphx::program_parameters params;
+  std::vector<std::size_t> prog_output_indices;
+  std::vector<std::size_t> pinned_output_indices;
+};
+
+static PinnedBindResult
 bind_pinned_program_params(
     MIGraphXFuncState* mgx_state,
     const migraphx::program_parameter_shapes& param_shapes,
@@ -1605,27 +1629,26 @@ bind_pinned_program_params(
   auto& pio = mgx_state->pinned_io;
   const auto& map_input_name_index = mgx_state->input_name_indexes;
 
-  migraphx::program_parameters m;
-  std::vector<std::size_t> prog_output_indices;
-
-  std::size_t input_idx = 0;
-  std::size_t output_idx = 0;
+  PinnedBindResult result;
 
   for (const auto& name : param_shapes.names()) {
     if (map_input_name_index.find(name) != map_input_name_index.end()) {
-      m.add(name, migraphx::argument(param_shapes[name], pio.inputs[input_idx].data));
-      ++input_idx;
+      auto pin_it = pio.input_name_to_idx.find(name);
+      if (pin_it == pio.input_name_to_idx.end()) continue;
+      result.params.add(name, migraphx::argument(param_shapes[name], pio.inputs[pin_it->second].data));
     } else {
       const auto oi = compute_output_index(name);
       if (oi != -1) {
-        m.add(name, migraphx::argument(param_shapes[name], pio.outputs[output_idx].data));
-        prog_output_indices.push_back(static_cast<std::size_t>(oi));
-        ++output_idx;
+        auto pin_it = pio.output_name_to_idx.find(name);
+        if (pin_it == pio.output_name_to_idx.end()) continue;
+        result.params.add(name, migraphx::argument(param_shapes[name], pio.outputs[pin_it->second].data));
+        result.prog_output_indices.push_back(static_cast<std::size_t>(oi));
+        result.pinned_output_indices.push_back(pin_it->second);
       }
     }
   }
 
-  return {std::move(m), std::move(prog_output_indices)};
+  return result;
 }
 
 // Copy results from pinned output buffers to ORT output tensors.
@@ -1633,15 +1656,18 @@ static void copy_pinned_outputs_to_ort(
     MIGraphXFuncState* mgx_state,
     const migraphx::shapes& output_shapes,
     const std::vector<std::size_t>& prog_output_indices,
+    const std::vector<std::size_t>& pinned_output_indices,
     Ort::KernelContext& ctx,
     std::size_t actual_batch,
     hipStream_t stream)
 {
   auto& pio = mgx_state->pinned_io;
 
-  for (std::size_t i = 0; i < prog_output_indices.size() && i < pio.outputs.size(); ++i) {
+  for (std::size_t i = 0; i < prog_output_indices.size() && i < pinned_output_indices.size(); ++i) {
     const auto oi = prog_output_indices[i];
-    const auto& pin = pio.outputs[i];
+    const auto pin_idx = pinned_output_indices[i];
+    if (pin_idx >= pio.outputs.size()) continue;
+    const auto& pin = pio.outputs[pin_idx];
     const auto& out_shape = output_shapes[oi];
     auto lens = out_shape.lengths();
 
@@ -1683,7 +1709,7 @@ static void run_migraphx_program(
     std::size_t original_batch_size = 0,
     std::size_t padded_batch_size = 0)
 {
-  LOGS_DEFAULT(INFO) << "[RunMIGraphX] run_async START"
+  LOGS_DEFAULT(WARNING) << "[RunMIGraphX] run_async START"
                      << " original_batch=" << original_batch_size
                      << " padded_batch=" << padded_batch_size;
   std::optional<migraphx::arguments> prog_outputs;
@@ -1691,7 +1717,7 @@ static void run_migraphx_program(
     std::lock_guard<std::mutex> lock(*mgx_mu_ptr);
     prog_outputs = prog.run_async(m, rocm_stream);
   }
-  LOGS_DEFAULT(INFO) << "[RunMIGraphX] run_async DONE";
+  LOGS_DEFAULT(WARNING) << "[RunMIGraphX] run_async DONE";
 
   bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 &&
                         original_batch_size < padded_batch_size);
@@ -1825,21 +1851,32 @@ static void destroy_hip_graphs(MIGraphXFuncState* mgx_state) {
 }
 
 // Warmup run (ensures lazy GPU allocations are finalized) then capture the graph.
-// The warmup output is discarded — pinned output buffers are overwritten on replay.
+// Stores extra (non-pre-allocated) output metadata so replay can materialize them.
 static bool warmup_and_capture_hip_graph(
     MIGraphXFuncState* mgx_state,
     hipStream_t stream,
     migraphx::program& prog,
     migraphx::program_parameters& m,
+    const std::vector<std::size_t>& prog_output_indices,
     const std::string& shape_hash)
 {
-  LOGS_DEFAULT(INFO) << "[HipGraph] WARMUP: running eager execution for hash=" << shape_hash.substr(0, 12) << "...";
+  // Zero all pinned buffers before warmup to avoid stale data from prior batch runs
+  auto& pio = mgx_state->pinned_io;
+  for (auto& pin : pio.inputs) {
+    HIP_CALL_THROW(hipMemsetAsync(pin.data, 0, pin.size_bytes, stream));
+  }
+  for (auto& pin : pio.outputs) {
+    HIP_CALL_THROW(hipMemsetAsync(pin.data, 0, pin.size_bytes, stream));
+  }
+
+  LOGS_DEFAULT(WARNING) << "[HipGraph] WARMUP: running eager execution for hash=" << shape_hash.substr(0, 12) << "...";
+  std::optional<migraphx::arguments> warmup_outputs;
   {
     std::lock_guard<std::mutex> lock(*mgx_state->mgx_mu_ptr);
-    prog.run_async(m, stream);
+    warmup_outputs = prog.run_async(m, stream);
   }
   HIP_CALL_THROW(hipStreamSynchronize(stream));
-  LOGS_DEFAULT(INFO) << "[HipGraph] WARMUP complete, starting CAPTURE";
+  LOGS_DEFAULT(WARNING) << "[HipGraph] WARMUP complete, starting CAPTURE";
 
   auto& entry = mgx_state->hip_graph_cache[shape_hash];
 
@@ -1861,7 +1898,29 @@ static bool warmup_and_capture_hip_graph(
 
     HIP_CALL_THROW(hipGraphInstantiate(&entry.exec, entry.graph, nullptr, nullptr, 0));
     entry.captured = true;
-    LOGS_DEFAULT(INFO) << "[HipGraph] CAPTURE SUCCESS: instantiated graph for hash="
+
+    std::unordered_set<std::size_t> pre_alloc_set(prog_output_indices.begin(),
+                                                   prog_output_indices.end());
+    entry.extra_outputs.clear();
+    if (warmup_outputs) {
+      auto output_num = warmup_outputs->size();
+      for (std::size_t i = 0; i < output_num; ++i) {
+        if (pre_alloc_set.count(i) > 0) continue;
+        auto gpu_res = (*warmup_outputs)[i];
+        migraphx::shape res_shape = gpu_res.get_shape();
+        auto res_lens = res_shape.lengths();
+        std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
+        entry.extra_outputs.push_back({i, std::move(ort_shape),
+                                       gpu_res.data(), res_shape.bytes()});
+      }
+      if (!entry.extra_outputs.empty()) {
+        LOGS_DEFAULT(WARNING) << "[HipGraph] Recorded " << entry.extra_outputs.size()
+                           << " extra (non-pre-allocated) outputs for hash="
+                           << shape_hash.substr(0, 12) << "...";
+      }
+    }
+
+    LOGS_DEFAULT(WARNING) << "[HipGraph] CAPTURE SUCCESS: instantiated graph for hash="
                        << shape_hash.substr(0, 12) << "..."
                        << " total_graphs=" << mgx_state->hip_graph_cache.size();
     return true;
@@ -1881,9 +1940,41 @@ static bool warmup_and_capture_hip_graph(
 static void replay_hip_graph(MIGraphXFuncState* mgx_state,
                              hipStream_t stream,
                              const std::string& shape_hash) {
-  LOGS_DEFAULT(INFO) << "[HipGraph] REPLAY launch for hash=" << shape_hash.substr(0, 12) << "...";
+  LOGS_DEFAULT(WARNING) << "[HipGraph] REPLAY launch for hash=" << shape_hash.substr(0, 12) << "...";
   auto& entry = mgx_state->hip_graph_cache.at(shape_hash);
   HIP_CALL_THROW(hipGraphLaunch(entry.exec, stream));
+}
+
+// Materialize extra (non-pre-allocated) outputs recorded during hipGraph capture.
+// These are MIGraphX outputs not exposed as named parameters — their GPU data
+// pointers are stable across replays because hipGraph replays the same kernels.
+static void materialize_extra_outputs(
+    Ort::KernelContext& ctx,
+    hipStream_t stream,
+    const std::vector<MIGraphXFuncState::ExtraOutputInfo>& extras,
+    std::size_t original_batch_size,
+    std::size_t padded_batch_size)
+{
+  bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 &&
+                        original_batch_size < padded_batch_size);
+
+  for (const auto& extra : extras) {
+    auto ort_shape = extra.ort_shape;
+    std::size_t bytes = extra.bytes;
+    if (needs_slicing && !ort_shape.empty()) {
+      std::size_t full_batch = static_cast<std::size_t>(ort_shape[0]);
+      if (full_batch > 0) {
+        bytes = (extra.bytes / full_batch) * original_batch_size;
+      }
+      ort_shape[0] = static_cast<int64_t>(original_batch_size);
+    }
+
+    auto output_tensor = ctx.GetOutput(extra.output_index, ort_shape.data(), ort_shape.size());
+    void* output_data = output_tensor.GetTensorMutableRawData();
+
+    HIP_CALL_THROW(hipMemcpyWithStream(output_data, extra.gpu_data,
+                                       bytes, hipMemcpyDeviceToDevice, stream));
+  }
 }
 
 // Dispatch point: replay a cached hipGraph, capture one on first use, or fall back to eager.
@@ -1902,7 +1993,7 @@ static void run_program_or_hip_graph(
     std::size_t padded_batch_size = 0)
 {
   if (!mgx_state->hip_graph_enabled) {
-    LOGS_DEFAULT(INFO) << "[Dispatch] EAGER run_async (hipGraph disabled)"
+    LOGS_DEFAULT(WARNING) << "[Dispatch] EAGER run_async (hipGraph disabled)"
                        << " hash=" << shape_hash.substr(0, 12) << "...";
     run_migraphx_program(mgx_state->mgx_mu_ptr, stream, ctx, prog, m,
                          prog_output_indices, original_batch_size, padded_batch_size);
@@ -1911,18 +2002,30 @@ static void run_program_or_hip_graph(
 
   auto it = mgx_state->hip_graph_cache.find(shape_hash);
   if (it != mgx_state->hip_graph_cache.end() && it->second.captured) {
-    LOGS_DEFAULT(INFO) << "[Dispatch] REPLAY hipGraph"
+    LOGS_DEFAULT(WARNING) << "[Dispatch] REPLAY hipGraph"
                        << " hash=" << shape_hash.substr(0, 12) << "..."
                        << " cache_size=" << mgx_state->hip_graph_cache.size();
     replay_hip_graph(mgx_state, stream, shape_hash);
+
+    if (!it->second.extra_outputs.empty()) {
+      materialize_extra_outputs(ctx, stream, it->second.extra_outputs,
+                                original_batch_size, padded_batch_size);
+    }
   } else {
-    LOGS_DEFAULT(INFO) << "[Dispatch] WARMUP+CAPTURE hipGraph"
+    LOGS_DEFAULT(WARNING) << "[Dispatch] WARMUP+CAPTURE hipGraph"
                        << " hash=" << shape_hash.substr(0, 12) << "..."
                        << " cache_size=" << mgx_state->hip_graph_cache.size();
-    if (!warmup_and_capture_hip_graph(mgx_state, stream, prog, m, shape_hash)) {
+    if (!warmup_and_capture_hip_graph(mgx_state, stream, prog, m,
+                                       prog_output_indices, shape_hash)) {
       LOGS_DEFAULT(WARNING) << "[Dispatch] Capture FAILED — falling back to EAGER";
       run_migraphx_program(mgx_state->mgx_mu_ptr, stream, ctx, prog, m,
                            prog_output_indices, original_batch_size, padded_batch_size);
+    } else {
+      auto& entry = mgx_state->hip_graph_cache.at(shape_hash);
+      if (!entry.extra_outputs.empty()) {
+        materialize_extra_outputs(ctx, stream, entry.extra_outputs,
+                                  original_batch_size, padded_batch_size);
+      }
     }
   }
 }
@@ -2125,11 +2228,11 @@ static migraphx::program load_or_compile_model(
 {
   migraphx::program prog;
 
-  LOGS_DEFAULT(INFO) << "[LoadOrCompile] batch_size=" << (batch_size > 0 ? std::to_string(batch_size) : "(default)")
+  LOGS_DEFAULT(WARNING) << "[LoadOrCompile] batch_size=" << (batch_size > 0 ? std::to_string(batch_size) : "(default)")
                      << " cache_file=" << (cache_file.empty() ? "(none)" : cache_file.string());
 
   if (!load_precompiled_model(prog, cache_file)) {
-    LOGS_DEFAULT(INFO) << "[LoadOrCompile] DISK CACHE MISS — COMPILING batch_size="
+    LOGS_DEFAULT(WARNING) << "[LoadOrCompile] DISK CACHE MISS — COMPILING batch_size="
                        << (batch_size > 0 ? std::to_string(batch_size) : "(default)");
 
     prog = CompileProgramWithBatch(
@@ -2150,15 +2253,15 @@ static migraphx::program load_or_compile_model(
         all_input_base_shapes,
         batch_size);
 
-    LOGS_DEFAULT(INFO) << "[LoadOrCompile] Compilation DONE batch_size="
+    LOGS_DEFAULT(WARNING) << "[LoadOrCompile] Compilation DONE batch_size="
                        << (batch_size > 0 ? std::to_string(batch_size) : "(default)");
     
     save_compiled_model(prog, cache_file);
     if (!cache_file.empty()) {
-      LOGS_DEFAULT(INFO) << "[LoadOrCompile] Saved to disk: " << cache_file.string();
+      LOGS_DEFAULT(WARNING) << "[LoadOrCompile] Saved to disk: " << cache_file.string();
     }
   } else {
-    LOGS_DEFAULT(INFO) << "[LoadOrCompile] DISK CACHE HIT — loaded batch_size="
+    LOGS_DEFAULT(WARNING) << "[LoadOrCompile] DISK CACHE HIT — loaded batch_size="
                        << (batch_size > 0 ? std::to_string(batch_size) : "(default)")
                        << " from " << cache_file.string();
   }
@@ -2507,7 +2610,7 @@ static bool execute_ultra_fast_path(
                       && mgx_state->pinned_io.allocated;
 
   if (needs_pinned && mgx_state->cached_mgx_param_shapes.has_value()) {
-    LOGS_DEFAULT(INFO) << "[UltraFastPath] batch=" << actual_batch
+    LOGS_DEFAULT(WARNING) << "[UltraFastPath] batch=" << actual_batch
                        << " compiled_batch=" << compiled_batch
                        << " mode=PINNED_IO"
                        << " hipGraph=" << (mgx_state->hip_graph_enabled ? "ON" : "OFF");
@@ -2522,11 +2625,12 @@ static bool execute_ultra_fast_path(
                              mgx_state->last_input_shape_hash);
 
     copy_pinned_outputs_to_ort(mgx_state, output_shapes, mgx_state->cached_prog_output_indices,
+                               mgx_state->cached_pinned_output_indices,
                                ctx, actual_batch, rocm_stream);
     return true;
   }
 
-  LOGS_DEFAULT(INFO) << "[UltraFastPath] batch=" << actual_batch
+  LOGS_DEFAULT(WARNING) << "[UltraFastPath] batch=" << actual_batch
                      << " compiled_batch=" << compiled_batch
                      << " mode=DIRECT_ORT_POINTERS";
   auto& m = mgx_state->cached_prog_params.value();
@@ -2672,17 +2776,18 @@ static bool execute_fast_path(
                       && mgx_state->pinned_io.allocated;
 
   if (needs_pinned) {
-    LOGS_DEFAULT(INFO) << "[FastPath] batch=" << actual_batch
+    LOGS_DEFAULT(WARNING) << "[FastPath] batch=" << actual_batch
                        << " compiled_batch=" << compiled_batch
                        << " padded=" << (needs_padding ? "YES" : "NO")
                        << " mode=PINNED_IO"
                        << " hipGraph=" << (mgx_state->hip_graph_enabled ? "ON" : "OFF")
                        << " program_changed=" << (program_changed ? "YES" : "NO");
     copy_inputs_to_pinned(mgx_state, param_shapes, ctx, actual_batch, compiled_batch, rocm_stream);
-    auto [m, out_indices] = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
+    auto bind_result = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
 
-    mgx_state->cached_prog_params = std::move(m);
-    mgx_state->cached_prog_output_indices = std::move(out_indices);
+    mgx_state->cached_prog_params = std::move(bind_result.params);
+    mgx_state->cached_prog_output_indices = std::move(bind_result.prog_output_indices);
+    mgx_state->cached_pinned_output_indices = std::move(bind_result.pinned_output_indices);
     mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(
         mgx_state, ctx, padded_batch_size);
     mgx_state->last_input_shape_hash = current_hash;
@@ -2694,11 +2799,12 @@ static bool execute_fast_path(
                              effective_program_hash);
 
     copy_pinned_outputs_to_ort(mgx_state, output_shapes, mgx_state->cached_prog_output_indices,
+                               mgx_state->cached_pinned_output_indices,
                                ctx, actual_batch, rocm_stream);
     return true;
   }
 
-  LOGS_DEFAULT(INFO) << "[FastPath] batch=" << actual_batch
+  LOGS_DEFAULT(WARNING) << "[FastPath] batch=" << actual_batch
                      << " compiled_batch=" << compiled_batch
                      << " mode=DIRECT_ORT_POINTERS"
                      << " program_changed=" << (program_changed ? "YES" : "NO");
@@ -2803,13 +2909,13 @@ static void compile_dynamic_batch_models(
     const std::string& mxr_filename_prefix,
     const Ort::KernelContext& ctx) {
   
-  LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] ==== ENTERING compile_dynamic_batch_models ====";
-  LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] has_dynamic_batch=" << mgx_state->has_dynamic_batch
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ==== ENTERING compile_dynamic_batch_models ====";
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] has_dynamic_batch=" << mgx_state->has_dynamic_batch
                      << " batch_sizes_count=" << mgx_state->compiled_batch_sizes.size()
                      << " max_dynamic_batch=" << mgx_state->max_dynamic_batch;
   
   if (!mgx_state->has_dynamic_batch || mgx_state->compiled_batch_sizes.empty()) {
-    LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] Skipping - dynamic batch disabled or no batch sizes";
+    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Skipping - dynamic batch disabled or no batch sizes";
     return;
   }
   
@@ -2819,7 +2925,7 @@ static void compile_dynamic_batch_models(
       if (i > 0) bs_list << ", ";
       bs_list << mgx_state->compiled_batch_sizes[i];
     }
-    LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] Batch sizes to compile: [" << bs_list.str() << "]";
+    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Batch sizes to compile: [" << bs_list.str() << "]";
   }
   
   // Get input names and base shapes (without batch dimension)
@@ -2827,7 +2933,7 @@ static void compile_dynamic_batch_models(
   std::vector<std::string> input_names;
   std::vector<std::vector<std::int64_t>> all_input_base_shapes;
   
-  LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] Processing " << map_input_name_index.size() << " input parameters";
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Processing " << map_input_name_index.size() << " input parameters";
   for (const auto& [name, index] : map_input_name_index) {
     input_names.push_back(name);
     auto input_tensor = ctx.GetInput(index);
@@ -2863,7 +2969,7 @@ static void compile_dynamic_batch_models(
   
   // Compile a model for each configured batch size
   for (const auto& batch_size : mgx_state->compiled_batch_sizes) {
-    LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] Processing batch_size=" << batch_size;
+    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Processing batch_size=" << batch_size;
     
     std::vector<std::int64_t> batch_shape_key;
     for (size_t i = 0; i < input_names.size(); ++i) {
@@ -2877,21 +2983,21 @@ static void compile_dynamic_batch_models(
     if (mgx_state->cached_programs_ref.has_value()) {
       auto& cached_progs = mgx_state->cached_programs_ref.value().get();
       if (cached_progs.find(cache_hash) != cached_progs.end()) {
-        LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] batch_size=" << batch_size
+        LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] batch_size=" << batch_size
                            << " CACHE HIT (in-memory), skipping";
         continue;
       }
-      LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] batch_size=" << batch_size
+      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] batch_size=" << batch_size
                          << " CACHE MISS (in-memory cache_size=" << cached_progs.size() << ")";
     }
     
     std::filesystem::path batch_cache_file;
     if (!model_cache_path.empty()) {
       batch_cache_file = model_cache_path / (mxr_filename_prefix + cache_hash + ".mxr");
-      LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] Disk cache: " << batch_cache_file.string();
+      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Disk cache: " << batch_cache_file.string();
     }
     
-    LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] load_or_compile batch_size=" << batch_size << " hash=" << cache_hash.substr(0, 12) << "...";
+    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] load_or_compile batch_size=" << batch_size << " hash=" << cache_hash.substr(0, 12) << "...";
     migraphx::program batch_prog = load_or_compile_model(
         batch_cache_file,
         mgx_state->onnx_string,
@@ -2913,19 +3019,21 @@ static void compile_dynamic_batch_models(
     
     if (mgx_state->cached_programs_ref.has_value()) {
       mgx_state->cached_programs_ref.value().get()[cache_hash] = batch_prog;
-      LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] batch_size=" << batch_size
+      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] batch_size=" << batch_size
                          << " STORED in cache (total_programs="
                          << mgx_state->cached_programs_ref.value().get().size() << ")";
     }
   }
   
-  LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] ==== All batch models compiled/loaded ====";
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ==== All batch models compiled/loaded ====";
   
   mgx_state->max_dynamic_batch = 0;
   mgx_state->defer_compilation = false;
-  LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] defer_compilation=false, max_dynamic_batch=0";
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] defer_compilation=false, max_dynamic_batch=0";
 
-  // Allocate pinned I/O now that all batch models are compiled
+  // Allocate pinned I/O now that all batch models are compiled.
+  // Must use the largest-batch program's shapes so the buffer count and
+  // parameter ordering match every subsequent bind_pinned_program_params call.
   if (!mgx_state->pinned_io.allocated && mgx_state->cached_programs_ref.has_value()) {
     auto& progs = mgx_state->cached_programs_ref.value().get();
     if (!progs.empty()) {
@@ -2934,16 +3042,35 @@ static void compile_dynamic_batch_models(
         max_batch = *std::max_element(mgx_state->compiled_batch_sizes.begin(),
                                       mgx_state->compiled_batch_sizes.end());
       }
-      auto& last_prog = progs.begin()->second;
-      auto ps = last_prog.get_parameter_shapes();
-      auto os = last_prog.get_output_shapes();
-      if (max_batch > 0) {
+      migraphx::program* largest_prog = nullptr;
+      std::size_t largest_batch_found = 0;
+      for (auto& [hash, prog] : progs) {
+        auto ps = prog.get_parameter_shapes();
+        std::size_t prog_batch = 0;
+        for (const auto& name : ps.names()) {
+          if (mgx_state->input_name_indexes.find(name) != mgx_state->input_name_indexes.end()) {
+            auto lens = ps[name].lengths();
+            if (!lens.empty() && lens[0] > 0) {
+              prog_batch = lens[0];
+              break;
+            }
+          }
+        }
+        if (prog_batch > largest_batch_found) {
+          largest_batch_found = prog_batch;
+          largest_prog = &prog;
+        }
+      }
+      if (max_batch == 0) max_batch = largest_batch_found;
+      if (largest_prog && max_batch > 0) {
+        auto ps = largest_prog->get_parameter_shapes();
+        auto os = largest_prog->get_output_shapes();
         allocate_pinned_io(mgx_state, ps, os, max_batch, mgx_state->stream);
       }
     }
   }
 
-  LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] ==== EXITING compile_dynamic_batch_models ====";
+  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ==== EXITING compile_dynamic_batch_models ====";
 }
 
 // Standard path: Shape checking, potential recompilation, and execution
@@ -2966,14 +3093,14 @@ static void execute_standard_path(
   // NOTE: max_dynamic_batch > 0 means compilation was deferred to runtime (not precompiled)
   // If precompilation happened during Compile(), max_dynamic_batch will be > 0 but defer_compilation = false
   // In that case, the programs are already in cache and we can skip runtime compilation
-  LOGS_DEFAULT(INFO) << "[StandardPath] Entered: defer_compilation=" << mgx_state->defer_compilation
+  LOGS_DEFAULT(WARNING) << "[StandardPath] Entered: defer_compilation=" << mgx_state->defer_compilation
                      << " has_dynamic_batch=" << mgx_state->has_dynamic_batch
                      << " max_dynamic_batch=" << mgx_state->max_dynamic_batch
                      << " hipGraph=" << (mgx_state->hip_graph_enabled ? "ON" : "OFF")
                      << " pinned_allocated=" << (mgx_state->pinned_io.allocated ? "YES" : "NO");
 
   if (mgx_state->has_dynamic_batch && mgx_state->max_dynamic_batch > 0 && mgx_state->defer_compilation) {
-    LOGS_DEFAULT(INFO) << "[StandardPath] Triggering DEFERRED COMPILATION for all batch sizes";
+    LOGS_DEFAULT(WARNING) << "[StandardPath] Triggering DEFERRED COMPILATION for all batch sizes";
     compile_dynamic_batch_models(mgx_state, model_cache_path, model_path, mxr_filename_prefix, ctx);
 
     // Validate newly compiled programs for hipGraph compatibility
@@ -3045,7 +3172,7 @@ static void execute_standard_path(
 
           bool use_pinned = needs_padding || mgx_state->hip_graph_enabled;
           if (use_pinned) {
-            LOGS_DEFAULT(INFO) << "[StandardPath] batch=" << original_batch_size
+            LOGS_DEFAULT(WARNING) << "[StandardPath] batch=" << original_batch_size
                               << " padded_batch=" << padded_batch_size
                               << " padded=" << (needs_padding ? "YES" : "NO")
                               << " mode=PINNED_IO (dynamic batch cache hit)"
@@ -3056,27 +3183,49 @@ static void execute_standard_path(
                 max_batch = *std::max_element(mgx_state->compiled_batch_sizes.begin(),
                                               mgx_state->compiled_batch_sizes.end());
               }
-              allocate_pinned_io(mgx_state, param_shapes, output_shapes, max_batch, rocm_stream);
+              auto alloc_ps = param_shapes;
+              auto alloc_os = output_shapes;
+              if (max_batch > padded_batch_size && mgx_state->cached_programs_ref.has_value()) {
+                bool found = false;
+                for (auto& [h, p] : mgx_state->cached_programs_ref.value().get()) {
+                  if (found) break;
+                  auto candidate_ps = p.get_parameter_shapes();
+                  for (const auto& nm : candidate_ps.names()) {
+                    if (mgx_state->input_name_indexes.count(nm)) {
+                      auto lens = candidate_ps[nm].lengths();
+                      if (!lens.empty() && lens[0] == max_batch) {
+                        alloc_ps = candidate_ps;
+                        alloc_os = p.get_output_shapes();
+                        found = true;
+                      }
+                      break;
+                    }
+                  }
+                }
+              }
+              allocate_pinned_io(mgx_state, alloc_ps, alloc_os, max_batch, rocm_stream);
             }
 
             std::size_t copy_actual = needs_padding ? original_batch_size : padded_batch_size;
             copy_inputs_to_pinned(mgx_state, param_shapes, ctx, copy_actual, padded_batch_size, rocm_stream);
-            auto [m, out_indices] = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
+            auto bind_result = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
 
-            mgx_state->cached_prog_params = m;
-            mgx_state->cached_prog_output_indices = out_indices;
+            mgx_state->cached_prog_params = bind_result.params;
+            mgx_state->cached_prog_output_indices = bind_result.prog_output_indices;
+            mgx_state->cached_pinned_output_indices = bind_result.pinned_output_indices;
             mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(
                 mgx_state, ctx, padded_batch_size);
             mgx_state->last_input_shape_hash = padded_hash;
             mgx_state->caches_valid = true;
 
-            run_program_or_hip_graph(mgx_state, rocm_stream, ctx, prog, m,
-                                     out_indices, padded_hash);
+            run_program_or_hip_graph(mgx_state, rocm_stream, ctx, prog, bind_result.params,
+                                     bind_result.prog_output_indices, padded_hash);
 
-            copy_pinned_outputs_to_ort(mgx_state, output_shapes, out_indices,
+            copy_pinned_outputs_to_ort(mgx_state, output_shapes, bind_result.prog_output_indices,
+                                       bind_result.pinned_output_indices,
                                        ctx, copy_actual, rocm_stream);
           } else {
-            LOGS_DEFAULT(INFO) << "[StandardPath] batch=" << original_batch_size
+            LOGS_DEFAULT(WARNING) << "[StandardPath] batch=" << original_batch_size
                               << " padded_batch=" << padded_batch_size
                               << " mode=DIRECT_ORT_POINTERS (dynamic batch cache hit, exact match)";
             auto [m, prog_output_indices] = handle_program_input_outputs(
@@ -3100,7 +3249,7 @@ static void execute_standard_path(
       mgx_state->defer_compilation, map_input_name_index, ctx, cmp_options, prog);
 
   if (!input_shape_match) {
-    LOGS_DEFAULT(INFO) << "[StandardPath] Input shape MISMATCH — triggering recompilation";
+    LOGS_DEFAULT(WARNING) << "[StandardPath] Input shape MISMATCH — triggering recompilation";
     mgx_state->caches_valid = false;
 
     handle_input_shape_mismatch(
@@ -3113,7 +3262,7 @@ static void execute_standard_path(
         input_shapes);
 
     param_shapes = prog.get_parameter_shapes();
-    LOGS_DEFAULT(INFO) << "[StandardPath] Recompilation complete";
+    LOGS_DEFAULT(WARNING) << "[StandardPath] Recompilation complete";
 
     if (mgx_state->hip_graph_enabled && !check_hip_graph_compatibility(prog, "standard_path_recompile")) {
       mgx_state->hip_graph_enabled = false;
@@ -3148,23 +3297,25 @@ static void execute_standard_path(
       auto shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
       if (!shape.empty()) { actual_batch = static_cast<std::size_t>(shape[0]); break; }
     }
-    LOGS_DEFAULT(INFO) << "[StandardPath] batch=" << actual_batch
+    LOGS_DEFAULT(WARNING) << "[StandardPath] batch=" << actual_batch
                        << " mode=PINNED_IO (hipGraph static path)"
                        << " hipGraph=ON";
 
     copy_inputs_to_pinned(mgx_state, param_shapes, ctx, actual_batch, actual_batch, rocm_stream);
-    auto [m, prog_output_indices] = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
+    auto bind_result = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
 
-    mgx_state->cached_prog_params = m;
-    mgx_state->cached_prog_output_indices = prog_output_indices;
+    mgx_state->cached_prog_params = bind_result.params;
+    mgx_state->cached_prog_output_indices = bind_result.prog_output_indices;
+    mgx_state->cached_pinned_output_indices = bind_result.pinned_output_indices;
     mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(mgx_state, ctx, 0);
     mgx_state->last_input_shape_hash = current_hash;
     mgx_state->caches_valid = true;
 
-    run_program_or_hip_graph(mgx_state, rocm_stream, ctx, prog, m,
-                             prog_output_indices, current_hash);
+    run_program_or_hip_graph(mgx_state, rocm_stream, ctx, prog, bind_result.params,
+                             bind_result.prog_output_indices, current_hash);
 
-    copy_pinned_outputs_to_ort(mgx_state, output_shapes, prog_output_indices,
+    copy_pinned_outputs_to_ort(mgx_state, output_shapes, bind_result.prog_output_indices,
+                               bind_result.pinned_output_indices,
                                ctx, actual_batch, rocm_stream);
     return;
   }
@@ -3175,7 +3326,7 @@ static void execute_standard_path(
       auto shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
       if (!shape.empty()) { actual_batch = static_cast<std::size_t>(shape[0]); break; }
     }
-    LOGS_DEFAULT(INFO) << "[StandardPath] batch=" << actual_batch
+    LOGS_DEFAULT(WARNING) << "[StandardPath] batch=" << actual_batch
                        << " mode=DIRECT_ORT_POINTERS (static fallback)"
                        << " hipGraph=OFF";
   }
@@ -4202,34 +4353,35 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       }
 
       // Allocate pinned I/O buffers from the cached programs.
-      // For dynamic batch: use max compiled batch size.
-      // For static: use the program's own batch size.
+      // Uses the program compiled for the largest batch size so that
+      // allocate_pinned_io sees parameter shapes whose batch dim matches
+      // max_batch. All smaller batches share the same buffers.
       if (p->cached_programs_ref.has_value() && !p->cached_programs_ref.value().get().empty()) {
         std::size_t max_batch = 0;
         if (!p->compiled_batch_sizes.empty()) {
           max_batch = *std::max_element(p->compiled_batch_sizes.begin(),
                                         p->compiled_batch_sizes.end());
         }
-        // Find the program with the largest batch to get representative shapes
         migraphx::program* largest_prog = nullptr;
+        std::size_t largest_batch_found = 0;
         for (auto& [hash, prog] : p->cached_programs_ref.value().get()) {
-          if (!largest_prog) {
-            largest_prog = &prog;
-            if (max_batch == 0) {
-              auto ps = prog.get_parameter_shapes();
-              for (const auto& name : ps.names()) {
-                if (p->input_name_indexes.find(name) != p->input_name_indexes.end()) {
-                  auto lens = ps[name].lengths();
-                  if (!lens.empty() && lens[0] > 0) {
-                    max_batch = lens[0];
-                    break;
-                  }
-                }
+          auto ps = prog.get_parameter_shapes();
+          std::size_t prog_batch = 0;
+          for (const auto& name : ps.names()) {
+            if (p->input_name_indexes.find(name) != p->input_name_indexes.end()) {
+              auto lens = ps[name].lengths();
+              if (!lens.empty() && lens[0] > 0) {
+                prog_batch = lens[0];
+                break;
               }
             }
           }
-          largest_prog = &prog;
+          if (prog_batch > largest_batch_found) {
+            largest_batch_found = prog_batch;
+            largest_prog = &prog;
+          }
         }
+        if (max_batch == 0) max_batch = largest_batch_found;
         if (largest_prog && max_batch > 0) {
           auto ps = largest_prog->get_parameter_shapes();
           auto os = largest_prog->get_output_shapes();
@@ -4257,9 +4409,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           }
         }
         if (p->hip_graph_enabled) {
-          LOGS_DEFAULT(INFO) << "[HipGraph] Enabled for node '" << context->node_name << "'";
+          LOGS_DEFAULT(WARNING) << "[HipGraph] Enabled for node '" << context->node_name << "'";
         } else {
-          LOGS_DEFAULT(INFO) << "[HipGraph] Disabled for node '" << context->node_name << "'";
+          LOGS_DEFAULT(WARNING) << "[HipGraph] Disabled for node '" << context->node_name << "'";
         }
       }
 
@@ -4299,7 +4451,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       // ═══════════════════════════════════════════════════════════════════════
       // Build input shape hash - only computed when shapes change
       // ═══════════════════════════════════════════════════════════════════════
-      LOGS_DEFAULT(INFO) << "[Compute] UltraFast miss — building hash for batch=" << log_batch
+      LOGS_DEFAULT(WARNING) << "[Compute] UltraFast miss — building hash for batch=" << log_batch
                          << " inputs=" << map_input_name_index.size()
                          << " hipGraph=" << (mgx_state->hip_graph_enabled ? "ON" : "OFF");
       std::vector<std::int64_t> all_input_shapes;
@@ -4317,7 +4469,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         return Status::OK();
       }
 
-      LOGS_DEFAULT(INFO) << "[Compute] FastPath miss — entering StandardPath for batch=" << log_batch
+      LOGS_DEFAULT(WARNING) << "[Compute] FastPath miss — entering StandardPath for batch=" << log_batch
                          << " hash=" << current_hash.substr(0, 12) << "...";
 
       // ═══════════════════════════════════════════════════════════════════════

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1480,11 +1480,18 @@ static void allocate_pinned_io(
     hipStream_t stream)
 {
   auto& pio = mgx_state->pinned_io;
-  if (pio.allocated) return;
+  if (pio.allocated) {
+    LOGS_DEFAULT(INFO) << "[PinnedIO] Already allocated (max_batch=" << pio.max_batch_size
+                       << "), skipping re-allocation for max_batch=" << max_batch_size;
+    return;
+  }
+
+  LOGS_DEFAULT(INFO) << "[PinnedIO] Allocating buffers: max_batch=" << max_batch_size;
 
   const auto& map_input_name_index = mgx_state->input_name_indexes;
 
   pio.inputs.clear();
+  std::size_t input_total_bytes = 0;
   for (const auto& name : param_shapes.names()) {
     if (map_input_name_index.find(name) == map_input_name_index.end()) continue;
     const auto& base_shape = param_shapes[name];
@@ -1492,6 +1499,7 @@ static void allocate_pinned_io(
     if (!lens.empty()) lens[0] = max_batch_size;
     auto max_shape = migraphx::shape(base_shape.type(), lens);
     std::size_t bytes = max_shape.bytes();
+    input_total_bytes += bytes;
 
     void* ptr = nullptr;
     HIP_CALL_THROW(hipMallocAsync(&ptr, bytes, stream));
@@ -1500,11 +1508,13 @@ static void allocate_pinned_io(
   }
 
   pio.outputs.clear();
+  std::size_t output_total_bytes = 0;
   for (const auto& out_shape : output_shapes) {
     auto lens = out_shape.lengths();
     if (!lens.empty()) lens[0] = max_batch_size;
     auto max_shape = migraphx::shape(out_shape.type(), lens);
     std::size_t bytes = max_shape.bytes();
+    output_total_bytes += bytes;
 
     void* ptr = nullptr;
     HIP_CALL_THROW(hipMallocAsync(&ptr, bytes, stream));
@@ -1517,12 +1527,12 @@ static void allocate_pinned_io(
   pio.max_batch_size = max_batch_size;
   pio.allocated = true;
 
-  std::size_t total_bytes = 0;
-  for (const auto& b : pio.inputs) total_bytes += b.size_bytes;
-  for (const auto& b : pio.outputs) total_bytes += b.size_bytes;
+  std::size_t total_bytes = input_total_bytes + output_total_bytes;
   LOGS_DEFAULT(INFO) << "[PinnedIO] Allocated: max_batch=" << max_batch_size
                      << " inputs=" << pio.inputs.size()
+                     << " (" << (input_total_bytes / (1024.0 * 1024.0)) << " MB)"
                      << " outputs=" << pio.outputs.size()
+                     << " (" << (output_total_bytes / (1024.0 * 1024.0)) << " MB)"
                      << " total=" << (total_bytes / (1024.0 * 1024.0)) << " MB";
 }
 
@@ -1659,6 +1669,104 @@ static void copy_pinned_outputs_to_ort(
 }
 
 
+// Helper: Run the MIGraphX program and handle outputs
+// This function executes the compiled MIGraphX program and copies outputs that
+// were not pre-allocated (input parameters reused as outputs) to the ORT output tensors
+// If original_batch_size is provided and < padded batch size, slices the output to remove padding
+static void run_migraphx_program(
+    std::mutex* mgx_mu_ptr,
+    hipStream_t rocm_stream,
+    Ort::KernelContext& ctx,
+    migraphx::program& prog,
+    migraphx::program_parameters& m,
+    const std::vector<std::size_t>& prog_output_indices,
+    std::size_t original_batch_size = 0,
+    std::size_t padded_batch_size = 0)
+{
+  LOGS_DEFAULT(INFO) << "[RunMIGraphX] run_async START"
+                     << " original_batch=" << original_batch_size
+                     << " padded_batch=" << padded_batch_size;
+  std::optional<migraphx::arguments> prog_outputs;
+  {
+    std::lock_guard<std::mutex> lock(*mgx_mu_ptr);
+    prog_outputs = prog.run_async(m, rocm_stream);
+  }
+  LOGS_DEFAULT(INFO) << "[RunMIGraphX] run_async DONE";
+
+  bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 &&
+                        original_batch_size < padded_batch_size);
+
+  auto output_num = prog_outputs->size();
+
+  // Fast path: no padding/slicing and all outputs were pre-allocated — nothing to do.
+  if (!needs_slicing && prog_output_indices.size() == output_num)
+    return;
+
+  std::unordered_set<std::size_t> prog_output_indices_set(prog_output_indices.begin(), prog_output_indices.end());
+
+  if (needs_slicing && !prog_output_indices_set.empty()) {
+    // Must sync before reallocating any pre-allocated output buffer for slicing.
+    HIP_CALL_THROW(hipStreamSynchronize(rocm_stream));
+
+    for (std::size_t i = 0; i < output_num; ++i) {
+      if (prog_output_indices_set.count(i) == 0) continue;
+
+      auto gpu_res = (*prog_outputs)[i];
+      migraphx::shape res_shape = gpu_res.get_shape();
+      auto res_lens = res_shape.lengths();
+
+      std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
+      if (!ort_shape.empty() && static_cast<std::size_t>(ort_shape[0]) != original_batch_size) {
+        ort_shape[0] = static_cast<int64_t>(original_batch_size);
+
+        std::size_t bytes_per_batch = res_shape.bytes() / padded_batch_size;
+        std::size_t bytes_to_copy = bytes_per_batch * original_batch_size;
+
+        const void* src_data = gpu_res.data();
+        auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
+        void* output_data = output_tensor.GetTensorMutableRawData();
+
+        if (output_data != src_data) {
+          HIP_CALL_THROW(hipMemcpyWithStream(output_data,
+                                             src_data,
+                                             bytes_to_copy,
+                                             hipMemcpyDeviceToDevice,
+                                             rocm_stream));
+        }
+      }
+    }
+  }
+
+  // Copy outputs that were not pre-allocated into ORT output tensors.
+  // All copies are async on rocm_stream — no sync needed here.
+  for (std::size_t i = 0; i < output_num; ++i) {
+    if (prog_output_indices_set.count(i) > 0) continue;
+
+    auto gpu_res = (*prog_outputs)[i];
+    migraphx::shape res_shape = gpu_res.get_shape();
+    auto res_lens = res_shape.lengths();
+
+    std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
+    if (needs_slicing && !ort_shape.empty()) {
+      ort_shape[0] = original_batch_size;
+    }
+
+    auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
+    void* output_data = output_tensor.GetTensorMutableRawData();
+
+    std::size_t bytes_to_copy = res_shape.bytes();
+    if (needs_slicing && !res_lens.empty()) {
+      bytes_to_copy = (res_shape.bytes() / padded_batch_size) * original_batch_size;
+    }
+
+    HIP_CALL_THROW(hipMemcpyWithStream(output_data,
+                                       gpu_res.data(),
+                                       bytes_to_copy,
+                                       hipMemcpyDeviceToDevice,
+                                       rocm_stream));
+  }
+}
+
 
 // Clear cached MIGraphX shapes (call when program changes)
 static void clear_cached_mgx_shapes(MIGraphXFuncState* mgx_state) {
@@ -1666,6 +1774,157 @@ static void clear_cached_mgx_shapes(MIGraphXFuncState* mgx_state) {
   mgx_state->cached_mgx_output_shapes.reset();
   mgx_state->ultra_fast_caches_populated = false;
   mgx_state->cached_program_hash.clear();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// hipGraph CAPTURE / REPLAY helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+static bool check_hip_graph_compatibility(const migraphx::program& prog,
+                                          const std::string& node_name) {
+ /* std::ostringstream prog_text;
+  prog.print(prog_text);
+  const std::string text = prog_text.str();
+
+  static const std::vector<std::string> unsafe_ops = {
+      "hip::sync_stream",
+      "hip::allocate",
+      "hip::copy_from_gpu",
+      "hip::copy_to_gpu",
+      "gpu::record_event",
+      "gpu::wait_event",
+      "gpu::set_stream",
+  };
+
+  for (const auto& op : unsafe_ops) {
+    if (text.find(op) != std::string::npos) {
+      LOGS_DEFAULT(WARNING)
+          << "[HipGraph] Node '" << node_name
+          << "' contains '" << op
+          << "' which is incompatible with hipGraph capture. "
+          << "Falling back to eager execution for this node.";
+      return false;
+    }
+  }  */
+  return true;
+}
+
+static void destroy_hip_graphs(MIGraphXFuncState* mgx_state) {
+  for (auto& [hash, entry] : mgx_state->hip_graph_cache) {
+    if (entry.exec) {
+      (void)hipGraphExecDestroy(entry.exec);
+      entry.exec = nullptr;
+    }
+    if (entry.graph) {
+      (void)hipGraphDestroy(entry.graph);
+      entry.graph = nullptr;
+    }
+    entry.captured = false;
+  }
+  mgx_state->hip_graph_cache.clear();
+}
+
+// Warmup run (ensures lazy GPU allocations are finalized) then capture the graph.
+// The warmup output is discarded — pinned output buffers are overwritten on replay.
+static bool warmup_and_capture_hip_graph(
+    MIGraphXFuncState* mgx_state,
+    hipStream_t stream,
+    migraphx::program& prog,
+    migraphx::program_parameters& m,
+    const std::string& shape_hash)
+{
+  LOGS_DEFAULT(INFO) << "[HipGraph] WARMUP: running eager execution for hash=" << shape_hash.substr(0, 12) << "...";
+  {
+    std::lock_guard<std::mutex> lock(*mgx_state->mgx_mu_ptr);
+    prog.run_async(m, stream);
+  }
+  HIP_CALL_THROW(hipStreamSynchronize(stream));
+  LOGS_DEFAULT(INFO) << "[HipGraph] WARMUP complete, starting CAPTURE";
+
+  auto& entry = mgx_state->hip_graph_cache[shape_hash];
+
+  try {
+    HIP_CALL_THROW(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+    {
+      std::lock_guard<std::mutex> lock(*mgx_state->mgx_mu_ptr);
+      prog.run_async(m, stream);
+    }
+    hipError_t err = hipStreamEndCapture(stream, &entry.graph);
+    if (err != hipSuccess || entry.graph == nullptr) {
+      LOGS_DEFAULT(WARNING) << "[HipGraph] CAPTURE FAILED (err=" << err
+                            << "). Falling back to eager execution.";
+      entry.graph = nullptr;
+      entry.captured = false;
+      mgx_state->hip_graph_enabled = false;
+      return false;
+    }
+
+    HIP_CALL_THROW(hipGraphInstantiate(&entry.exec, entry.graph, nullptr, nullptr, 0));
+    entry.captured = true;
+    LOGS_DEFAULT(INFO) << "[HipGraph] CAPTURE SUCCESS: instantiated graph for hash="
+                       << shape_hash.substr(0, 12) << "..."
+                       << " total_graphs=" << mgx_state->hip_graph_cache.size();
+    return true;
+  } catch (...) {
+    LOGS_DEFAULT(WARNING) << "[HipGraph] CAPTURE EXCEPTION. Falling back to eager execution.";
+    hipGraph_t dummy = nullptr;
+    (void)hipStreamEndCapture(stream, &dummy);
+    if (dummy) (void)hipGraphDestroy(dummy);
+    entry.graph = nullptr;
+    entry.exec = nullptr;
+    entry.captured = false;
+    mgx_state->hip_graph_enabled = false;
+    return false;
+  }
+}
+
+static void replay_hip_graph(MIGraphXFuncState* mgx_state,
+                             hipStream_t stream,
+                             const std::string& shape_hash) {
+  LOGS_DEFAULT(INFO) << "[HipGraph] REPLAY launch for hash=" << shape_hash.substr(0, 12) << "...";
+  auto& entry = mgx_state->hip_graph_cache.at(shape_hash);
+  HIP_CALL_THROW(hipGraphLaunch(entry.exec, stream));
+}
+
+// Dispatch point: replay a cached hipGraph, capture one on first use, or fall back to eager.
+// This replaces run_migraphx_program in all pinned-I/O paths when hipGraph is enabled.
+// IMPORTANT: when hipGraph is enabled this function must ONLY be called via the pinned-I/O
+// code path so that buffer addresses captured in the graph remain stable across replays.
+static void run_program_or_hip_graph(
+    MIGraphXFuncState* mgx_state,
+    hipStream_t stream,
+    Ort::KernelContext& ctx,
+    migraphx::program& prog,
+    migraphx::program_parameters& m,
+    const std::vector<std::size_t>& prog_output_indices,
+    const std::string& shape_hash,
+    std::size_t original_batch_size = 0,
+    std::size_t padded_batch_size = 0)
+{
+  if (!mgx_state->hip_graph_enabled) {
+    LOGS_DEFAULT(INFO) << "[Dispatch] EAGER run_async (hipGraph disabled)"
+                       << " hash=" << shape_hash.substr(0, 12) << "...";
+    run_migraphx_program(mgx_state->mgx_mu_ptr, stream, ctx, prog, m,
+                         prog_output_indices, original_batch_size, padded_batch_size);
+    return;
+  }
+
+  auto it = mgx_state->hip_graph_cache.find(shape_hash);
+  if (it != mgx_state->hip_graph_cache.end() && it->second.captured) {
+    LOGS_DEFAULT(INFO) << "[Dispatch] REPLAY hipGraph"
+                       << " hash=" << shape_hash.substr(0, 12) << "..."
+                       << " cache_size=" << mgx_state->hip_graph_cache.size();
+    replay_hip_graph(mgx_state, stream, shape_hash);
+  } else {
+    LOGS_DEFAULT(INFO) << "[Dispatch] WARMUP+CAPTURE hipGraph"
+                       << " hash=" << shape_hash.substr(0, 12) << "..."
+                       << " cache_size=" << mgx_state->hip_graph_cache.size();
+    if (!warmup_and_capture_hip_graph(mgx_state, stream, prog, m, shape_hash)) {
+      LOGS_DEFAULT(WARNING) << "[Dispatch] Capture FAILED — falling back to EAGER";
+      run_migraphx_program(mgx_state->mgx_mu_ptr, stream, ctx, prog, m,
+                           prog_output_indices, original_batch_size, padded_batch_size);
+    }
+  }
 }
 
 // Order matters here especially if the program uses mixed quantization
@@ -1866,18 +2125,12 @@ static migraphx::program load_or_compile_model(
 {
   migraphx::program prog;
 
-  LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] ==== ENTERING ====";
-  LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] Cache file: " << (cache_file.empty() ? "(none)" : cache_file.string());
-  LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] Batch size: " << (batch_size > 0 ? std::to_string(batch_size) : "(default)");
+  LOGS_DEFAULT(INFO) << "[LoadOrCompile] batch_size=" << (batch_size > 0 ? std::to_string(batch_size) : "(default)")
+                     << " cache_file=" << (cache_file.empty() ? "(none)" : cache_file.string());
 
   if (!load_precompiled_model(prog, cache_file)) {
-    // Cache miss - need to compile
-    if (batch_size > 0) {
-      LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] ✗ CACHE MISS for batch size " << batch_size << " - COMPILING...";
-    } else {
-      LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] ✗ CACHE MISS - COMPILING...";
-    }
-    LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] Compilation started (this may take a while)...";
+    LOGS_DEFAULT(INFO) << "[LoadOrCompile] DISK CACHE MISS — COMPILING batch_size="
+                       << (batch_size > 0 ? std::to_string(batch_size) : "(default)");
 
     prog = CompileProgramWithBatch(
         onnx_string,
@@ -1897,119 +2150,22 @@ static migraphx::program load_or_compile_model(
         all_input_base_shapes,
         batch_size);
 
-    LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] Compilation finished";
+    LOGS_DEFAULT(INFO) << "[LoadOrCompile] Compilation DONE batch_size="
+                       << (batch_size > 0 ? std::to_string(batch_size) : "(default)");
     
     save_compiled_model(prog, cache_file);
     if (!cache_file.empty()) {
-      LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] Saved compiled model to disk: " << cache_file.string();
+      LOGS_DEFAULT(INFO) << "[LoadOrCompile] Saved to disk: " << cache_file.string();
     }
   } else {
-    // Cache hit - loaded from disk
-    if (batch_size > 0) {
-      LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] ✓ CACHE HIT - LOADING FROM DISK for batch size " << batch_size;
-    } else {
-      LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] ✓ CACHE HIT - LOADING FROM DISK";
-    }
-    LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] Loaded precompiled model from: " << cache_file.string();
+    LOGS_DEFAULT(INFO) << "[LoadOrCompile] DISK CACHE HIT — loaded batch_size="
+                       << (batch_size > 0 ? std::to_string(batch_size) : "(default)")
+                       << " from " << cache_file.string();
   }
-
-  LOGS_DEFAULT(VERBOSE) << "[load_or_compile_model] ==== EXITING ====";
   return prog;
 }
 
-// Helper: Run the MIGraphX program and handle outputs
-// This function executes the compiled MIGraphX program and copies outputs that
-// were not pre-allocated (input parameters reused as outputs) to the ORT output tensors
-// If original_batch_size is provided and < padded batch size, slices the output to remove padding
-static void run_migraphx_program(
-    std::mutex* mgx_mu_ptr,
-    hipStream_t rocm_stream,
-    Ort::KernelContext& ctx,
-    migraphx::program& prog,
-    migraphx::program_parameters& m,
-    const std::vector<std::size_t>& prog_output_indices,
-    std::size_t original_batch_size = 0,
-    std::size_t padded_batch_size = 0)
-{
-  std::optional<migraphx::arguments> prog_outputs;
-  {
-    std::lock_guard<std::mutex> lock(*mgx_mu_ptr);
-    prog_outputs = prog.run_async(m, rocm_stream);
-  }
 
-  bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 &&
-                        original_batch_size < padded_batch_size);
-
-  auto output_num = prog_outputs->size();
-
-  // Fast path: no padding/slicing and all outputs were pre-allocated — nothing to do.
-  if (!needs_slicing && prog_output_indices.size() == output_num)
-    return;
-
-  std::unordered_set<std::size_t> prog_output_indices_set(prog_output_indices.begin(), prog_output_indices.end());
-
-  if (needs_slicing && !prog_output_indices_set.empty()) {
-    // Must sync before reallocating any pre-allocated output buffer for slicing.
-    HIP_CALL_THROW(hipStreamSynchronize(rocm_stream));
-
-    for (std::size_t i = 0; i < output_num; ++i) {
-      if (prog_output_indices_set.count(i) == 0) continue;
-
-      auto gpu_res = (*prog_outputs)[i];
-      migraphx::shape res_shape = gpu_res.get_shape();
-      auto res_lens = res_shape.lengths();
-
-      std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
-      if (!ort_shape.empty() && static_cast<std::size_t>(ort_shape[0]) != original_batch_size) {
-        ort_shape[0] = static_cast<int64_t>(original_batch_size);
-
-        std::size_t bytes_per_batch = res_shape.bytes() / padded_batch_size;
-        std::size_t bytes_to_copy = bytes_per_batch * original_batch_size;
-
-        const void* src_data = gpu_res.data();
-        auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
-        void* output_data = output_tensor.GetTensorMutableRawData();
-
-        if (output_data != src_data) {
-          HIP_CALL_THROW(hipMemcpyWithStream(output_data,
-                                             src_data,
-                                             bytes_to_copy,
-                                             hipMemcpyDeviceToDevice,
-                                             rocm_stream));
-        }
-      }
-    }
-  }
-
-  // Copy outputs that were not pre-allocated into ORT output tensors.
-  // All copies are async on rocm_stream — no sync needed here.
-  for (std::size_t i = 0; i < output_num; ++i) {
-    if (prog_output_indices_set.count(i) > 0) continue;
-
-    auto gpu_res = (*prog_outputs)[i];
-    migraphx::shape res_shape = gpu_res.get_shape();
-    auto res_lens = res_shape.lengths();
-
-    std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
-    if (needs_slicing && !ort_shape.empty()) {
-      ort_shape[0] = original_batch_size;
-    }
-
-    auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
-    void* output_data = output_tensor.GetTensorMutableRawData();
-
-    std::size_t bytes_to_copy = res_shape.bytes();
-    if (needs_slicing && !res_lens.empty()) {
-      bytes_to_copy = (res_shape.bytes() / padded_batch_size) * original_batch_size;
-    }
-
-    HIP_CALL_THROW(hipMemcpyWithStream(output_data,
-                                       gpu_res.data(),
-                                       bytes_to_copy,
-                                       hipMemcpyDeviceToDevice,
-                                       rocm_stream));
-  }
-}
 
 // Helper: Handle input shape mismatch by recompiling the model with new input shapes
 // This function is called when runtime input shapes differ from compiled shapes
@@ -2346,25 +2502,33 @@ static bool execute_ultra_fast_path(
                 .GetTensorTypeAndShapeInfo().GetShape()[0])
           : 0);
   std::size_t compiled_batch = padded_batch_size > 0 ? padded_batch_size : actual_batch;
-  bool needs_pinned = (actual_batch < compiled_batch) && mgx_state->pinned_io.allocated;
+  // hipGraph requires stable buffer addresses → always route through pinned I/O
+  bool needs_pinned = ((actual_batch < compiled_batch) || mgx_state->hip_graph_enabled)
+                      && mgx_state->pinned_io.allocated;
 
   if (needs_pinned && mgx_state->cached_mgx_param_shapes.has_value()) {
-    // Pinned I/O path: pad inputs -> run -> slice outputs
+    LOGS_DEFAULT(INFO) << "[UltraFastPath] batch=" << actual_batch
+                       << " compiled_batch=" << compiled_batch
+                       << " mode=PINNED_IO"
+                       << " hipGraph=" << (mgx_state->hip_graph_enabled ? "ON" : "OFF");
     const auto& param_shapes = mgx_state->cached_mgx_param_shapes.value();
     const auto& output_shapes = mgx_state->cached_mgx_output_shapes.value();
 
     copy_inputs_to_pinned(mgx_state, param_shapes, ctx, actual_batch, compiled_batch, rocm_stream);
 
     auto& m = mgx_state->cached_prog_params.value();
-    run_migraphx_program(mgx_state->mgx_mu_ptr, rocm_stream, ctx, prog, m,
-                         mgx_state->cached_prog_output_indices);
+    run_program_or_hip_graph(mgx_state, rocm_stream, ctx, prog, m,
+                             mgx_state->cached_prog_output_indices,
+                             mgx_state->last_input_shape_hash);
 
     copy_pinned_outputs_to_ort(mgx_state, output_shapes, mgx_state->cached_prog_output_indices,
                                ctx, actual_batch, rocm_stream);
     return true;
   }
 
-  // Direct ORT pointer path: bind ORT tensors directly — zero memcpy overhead
+  LOGS_DEFAULT(INFO) << "[UltraFastPath] batch=" << actual_batch
+                     << " compiled_batch=" << compiled_batch
+                     << " mode=DIRECT_ORT_POINTERS";
   auto& m = mgx_state->cached_prog_params.value();
   for (const auto& inp : mgx_state->cached_inputs) {
     const auto& input_tensor = ctx.GetInput(inp.ort_index);
@@ -2503,10 +2667,17 @@ static bool execute_fast_path(
     }
   }
   std::size_t compiled_batch = padded_batch_size > 0 ? padded_batch_size : actual_batch;
-  bool needs_pinned = (actual_batch < compiled_batch) && mgx_state->pinned_io.allocated;
+  // hipGraph requires stable buffer addresses → always route through pinned I/O
+  bool needs_pinned = ((actual_batch < compiled_batch) || mgx_state->hip_graph_enabled)
+                      && mgx_state->pinned_io.allocated;
 
   if (needs_pinned) {
-    // Pinned I/O path: pad inputs -> run on compiled shape -> slice outputs
+    LOGS_DEFAULT(INFO) << "[FastPath] batch=" << actual_batch
+                       << " compiled_batch=" << compiled_batch
+                       << " padded=" << (needs_padding ? "YES" : "NO")
+                       << " mode=PINNED_IO"
+                       << " hipGraph=" << (mgx_state->hip_graph_enabled ? "ON" : "OFF")
+                       << " program_changed=" << (program_changed ? "YES" : "NO");
     copy_inputs_to_pinned(mgx_state, param_shapes, ctx, actual_batch, compiled_batch, rocm_stream);
     auto [m, out_indices] = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
 
@@ -2517,16 +2688,20 @@ static bool execute_fast_path(
     mgx_state->last_input_shape_hash = current_hash;
     mgx_state->caches_valid = true;
 
-    run_migraphx_program(mgx_state->mgx_mu_ptr, rocm_stream, ctx, prog,
-                         mgx_state->cached_prog_params.value(),
-                         mgx_state->cached_prog_output_indices);
+    run_program_or_hip_graph(mgx_state, rocm_stream, ctx, prog,
+                             mgx_state->cached_prog_params.value(),
+                             mgx_state->cached_prog_output_indices,
+                             effective_program_hash);
 
     copy_pinned_outputs_to_ort(mgx_state, output_shapes, mgx_state->cached_prog_output_indices,
                                ctx, actual_batch, rocm_stream);
     return true;
   }
 
-  // Direct ORT pointer path: bind ORT tensors directly — zero memcpy overhead
+  LOGS_DEFAULT(INFO) << "[FastPath] batch=" << actual_batch
+                     << " compiled_batch=" << compiled_batch
+                     << " mode=DIRECT_ORT_POINTERS"
+                     << " program_changed=" << (program_changed ? "YES" : "NO");
   auto [m, prog_output_indices] = handle_program_input_outputs(
       param_shapes, output_shapes, map_input_name_index, ctx);
 
@@ -2628,22 +2803,23 @@ static void compile_dynamic_batch_models(
     const std::string& mxr_filename_prefix,
     const Ort::KernelContext& ctx) {
   
-  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ==== ENTERING compile_dynamic_batch_models ====";
-  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] has_dynamic_batch = " << mgx_state->has_dynamic_batch;
-  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] compiled_batch_sizes.size() = "
-                     << mgx_state->compiled_batch_sizes.size();
-  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] max_dynamic_batch = " << mgx_state->max_dynamic_batch;
+  LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] ==== ENTERING compile_dynamic_batch_models ====";
+  LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] has_dynamic_batch=" << mgx_state->has_dynamic_batch
+                     << " batch_sizes_count=" << mgx_state->compiled_batch_sizes.size()
+                     << " max_dynamic_batch=" << mgx_state->max_dynamic_batch;
   
   if (!mgx_state->has_dynamic_batch || mgx_state->compiled_batch_sizes.empty()) {
-    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Skipping - dynamic batch disabled or no batch sizes";
+    LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] Skipping - dynamic batch disabled or no batch sizes";
     return;
   }
   
-  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Compiling models for " 
-                     << mgx_state->compiled_batch_sizes.size() << " batch sizes";
-  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Batch sizes: ";
-  for (const auto& bs : mgx_state->compiled_batch_sizes) {
-    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE]   - " << bs;
+  {
+    std::ostringstream bs_list;
+    for (std::size_t i = 0; i < mgx_state->compiled_batch_sizes.size(); ++i) {
+      if (i > 0) bs_list << ", ";
+      bs_list << mgx_state->compiled_batch_sizes[i];
+    }
+    LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] Batch sizes to compile: [" << bs_list.str() << "]";
   }
   
   // Get input names and base shapes (without batch dimension)
@@ -2651,15 +2827,15 @@ static void compile_dynamic_batch_models(
   std::vector<std::string> input_names;
   std::vector<std::vector<std::int64_t>> all_input_base_shapes;
   
-  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Processing " << map_input_name_index.size() << " input parameters";
+  LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] Processing " << map_input_name_index.size() << " input parameters";
   for (const auto& [name, index] : map_input_name_index) {
     input_names.push_back(name);
     auto input_tensor = ctx.GetInput(index);
     auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
     const auto tensor_shape = tensor_info.GetShape();
     
-    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Input '" << name << "' (index " << index 
-                       << ") runtime shape: [" << [&]() {
+    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Input '" << name << "' (index " << index
+                          << ") runtime shape: [" << [&]() {
                          std::ostringstream ss;
                          for (size_t i = 0; i < tensor_shape.size(); ++i) {
                            if (i > 0) ss << ", ";
@@ -2687,9 +2863,8 @@ static void compile_dynamic_batch_models(
   
   // Compile a model for each configured batch size
   for (const auto& batch_size : mgx_state->compiled_batch_sizes) {
-    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ---- Processing batch size: " << batch_size << " ----";
+    LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] Processing batch_size=" << batch_size;
     
-    // Build cache key for this batch size
     std::vector<std::int64_t> batch_shape_key;
     for (size_t i = 0; i < input_names.size(); ++i) {
       batch_shape_key.push_back(batch_size);
@@ -2699,40 +2874,24 @@ static void compile_dynamic_batch_models(
     }
     auto cache_hash = make_hash(batch_shape_key);
     
-    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Shape key for batch " << batch_size << ": [" << [&]() {
-                         std::ostringstream ss;
-                         for (size_t i = 0; i < batch_shape_key.size(); ++i) {
-                           if (i > 0) ss << ", ";
-                           ss << batch_shape_key[i];
-                         }
-                         return ss.str();
-                       }() << "]";
-    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Cache hash: " << cache_hash;
-    
-    // Check if already cached
     if (mgx_state->cached_programs_ref.has_value()) {
       auto& cached_progs = mgx_state->cached_programs_ref.value().get();
-      LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Checking in-memory cache (size: " 
-                         << cached_progs.size() << ")";
       if (cached_progs.find(cache_hash) != cached_progs.end()) {
-        LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ✓ Batch size " << batch_size 
-                          << " already in memory cache, skipping";
+        LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] batch_size=" << batch_size
+                           << " CACHE HIT (in-memory), skipping";
         continue;
       }
-      LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Cache miss - need to compile/load";
+      LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] batch_size=" << batch_size
+                         << " CACHE MISS (in-memory cache_size=" << cached_progs.size() << ")";
     }
     
-    // Build cache file path
     std::filesystem::path batch_cache_file;
     if (!model_cache_path.empty()) {
       batch_cache_file = model_cache_path / (mxr_filename_prefix + cache_hash + ".mxr");
-      LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Disk cache file: " << batch_cache_file.string();
-    } else {
-      LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] No disk cache path configured";
+      LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] Disk cache: " << batch_cache_file.string();
     }
     
-    // Compile or load the model for this batch size
-    LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Calling load_or_compile_model for batch " << batch_size;
+    LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] load_or_compile batch_size=" << batch_size << " hash=" << cache_hash.substr(0, 12) << "...";
     migraphx::program batch_prog = load_or_compile_model(
         batch_cache_file,
         mgx_state->onnx_string,
@@ -2752,24 +2911,19 @@ static void compile_dynamic_batch_models(
         all_input_base_shapes,
         batch_size);
     
-    // Store in cache
     if (mgx_state->cached_programs_ref.has_value()) {
       mgx_state->cached_programs_ref.value().get()[cache_hash] = batch_prog;
-      LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ✓ Stored program for batch size " << batch_size 
-                         << " in memory cache with hash " << cache_hash;
-      LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Memory cache now contains " 
-                         << mgx_state->cached_programs_ref.value().get().size() << " programs";
+      LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] batch_size=" << batch_size
+                         << " STORED in cache (total_programs="
+                         << mgx_state->cached_programs_ref.value().get().size() << ")";
     }
   }
   
-  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ==== All batch models compiled and cached ====";
-  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Setting max_dynamic_batch to 0 to disable future compilation";
+  LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] ==== All batch models compiled/loaded ====";
   
-  // Disable dynamic batch compilation for subsequent runs (set max_dynamic_batch to 0)
   mgx_state->max_dynamic_batch = 0;
-  
   mgx_state->defer_compilation = false;
-  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] Set defer_compilation = false";
+  LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] defer_compilation=false, max_dynamic_batch=0";
 
   // Allocate pinned I/O now that all batch models are compiled
   if (!mgx_state->pinned_io.allocated && mgx_state->cached_programs_ref.has_value()) {
@@ -2789,7 +2943,7 @@ static void compile_dynamic_batch_models(
     }
   }
 
-  LOGS_DEFAULT(VERBOSE) << "[DynamicBatch][COMPILE] ==== EXITING compile_dynamic_batch_models ====";
+  LOGS_DEFAULT(INFO) << "[DynamicBatch][COMPILE] ==== EXITING compile_dynamic_batch_models ====";
 }
 
 // Standard path: Shape checking, potential recompilation, and execution
@@ -2812,12 +2966,25 @@ static void execute_standard_path(
   // NOTE: max_dynamic_batch > 0 means compilation was deferred to runtime (not precompiled)
   // If precompilation happened during Compile(), max_dynamic_batch will be > 0 but defer_compilation = false
   // In that case, the programs are already in cache and we can skip runtime compilation
+  LOGS_DEFAULT(INFO) << "[StandardPath] Entered: defer_compilation=" << mgx_state->defer_compilation
+                     << " has_dynamic_batch=" << mgx_state->has_dynamic_batch
+                     << " max_dynamic_batch=" << mgx_state->max_dynamic_batch
+                     << " hipGraph=" << (mgx_state->hip_graph_enabled ? "ON" : "OFF")
+                     << " pinned_allocated=" << (mgx_state->pinned_io.allocated ? "YES" : "NO");
+
   if (mgx_state->has_dynamic_batch && mgx_state->max_dynamic_batch > 0 && mgx_state->defer_compilation) {
-    // Runtime compilation path - used when precompilation was not possible (e.g., non-pure dynamic batch)
-    
-    // Compile all batch models at runtime
+    LOGS_DEFAULT(INFO) << "[StandardPath] Triggering DEFERRED COMPILATION for all batch sizes";
     compile_dynamic_batch_models(mgx_state, model_cache_path, model_path, mxr_filename_prefix, ctx);
-    
+
+    // Validate newly compiled programs for hipGraph compatibility
+    if (mgx_state->hip_graph_enabled && mgx_state->cached_programs_ref.has_value()) {
+      for (const auto& [hash, cached_prog] : mgx_state->cached_programs_ref.value().get()) {
+        if (!check_hip_graph_compatibility(cached_prog, "runtime_dynamic_batch")) {
+          mgx_state->hip_graph_enabled = false;
+          break;
+        }
+      }
+    }
   } else if (mgx_state->has_dynamic_batch) {
   }
 
@@ -2870,15 +3037,19 @@ static void execute_standard_path(
         if (prog_it != cached_progs.end()) {
           prog = prog_it->second;
           
-          // Get shapes for the cached program
           auto param_shapes = prog.get_parameter_shapes();
           auto output_shapes = prog.get_output_shapes();
           
           populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index,
                                     original_batch_size, padded_batch_size);
 
-          if (needs_padding) {
-            // Padding required — use pinned I/O for pad + slice
+          bool use_pinned = needs_padding || mgx_state->hip_graph_enabled;
+          if (use_pinned) {
+            LOGS_DEFAULT(INFO) << "[StandardPath] batch=" << original_batch_size
+                              << " padded_batch=" << padded_batch_size
+                              << " padded=" << (needs_padding ? "YES" : "NO")
+                              << " mode=PINNED_IO (dynamic batch cache hit)"
+                              << " hipGraph=" << (mgx_state->hip_graph_enabled ? "ON" : "OFF");
             if (!mgx_state->pinned_io.allocated) {
               std::size_t max_batch = padded_batch_size;
               if (!mgx_state->compiled_batch_sizes.empty()) {
@@ -2888,7 +3059,8 @@ static void execute_standard_path(
               allocate_pinned_io(mgx_state, param_shapes, output_shapes, max_batch, rocm_stream);
             }
 
-            copy_inputs_to_pinned(mgx_state, param_shapes, ctx, original_batch_size, padded_batch_size, rocm_stream);
+            std::size_t copy_actual = needs_padding ? original_batch_size : padded_batch_size;
+            copy_inputs_to_pinned(mgx_state, param_shapes, ctx, copy_actual, padded_batch_size, rocm_stream);
             auto [m, out_indices] = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
 
             mgx_state->cached_prog_params = m;
@@ -2898,12 +3070,15 @@ static void execute_standard_path(
             mgx_state->last_input_shape_hash = padded_hash;
             mgx_state->caches_valid = true;
 
-            run_migraphx_program(mgx_state->mgx_mu_ptr, rocm_stream, ctx, prog, m, out_indices);
+            run_program_or_hip_graph(mgx_state, rocm_stream, ctx, prog, m,
+                                     out_indices, padded_hash);
 
             copy_pinned_outputs_to_ort(mgx_state, output_shapes, out_indices,
-                                       ctx, original_batch_size, rocm_stream);
+                                       ctx, copy_actual, rocm_stream);
           } else {
-            // Exact batch match — direct ORT pointer binding
+            LOGS_DEFAULT(INFO) << "[StandardPath] batch=" << original_batch_size
+                              << " padded_batch=" << padded_batch_size
+                              << " mode=DIRECT_ORT_POINTERS (dynamic batch cache hit, exact match)";
             auto [m, prog_output_indices] = handle_program_input_outputs(
                 param_shapes, output_shapes, map_input_name_index, ctx);
 
@@ -2925,7 +3100,7 @@ static void execute_standard_path(
       mgx_state->defer_compilation, map_input_name_index, ctx, cmp_options, prog);
 
   if (!input_shape_match) {
-    // Invalidate caches before recompilation
+    LOGS_DEFAULT(INFO) << "[StandardPath] Input shape MISMATCH — triggering recompilation";
     mgx_state->caches_valid = false;
 
     handle_input_shape_mismatch(
@@ -2937,16 +3112,19 @@ static void execute_standard_path(
         param_shapes,
         input_shapes);
 
-    // Re-fetch param_shapes after recompilation
     param_shapes = prog.get_parameter_shapes();
+    LOGS_DEFAULT(INFO) << "[StandardPath] Recompilation complete";
+
+    if (mgx_state->hip_graph_enabled && !check_hip_graph_compatibility(prog, "standard_path_recompile")) {
+      mgx_state->hip_graph_enabled = false;
+    }
   }
 
   auto output_shapes = prog.get_output_shapes();
 
   populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index);
 
-  // Lazily allocate pinned I/O for future pad/slice use (e.g. first inference after JIT compile).
-  // The buffers are not used on this path since the program was compiled for the exact shape.
+  // Allocate pinned I/O: required for hipGraph (stable addresses), also useful for future pad/slice.
   if (!mgx_state->pinned_io.allocated) {
     std::size_t batch_for_alloc = 0;
     if (!mgx_state->compiled_batch_sizes.empty()) {
@@ -2964,7 +3142,43 @@ static void execute_standard_path(
     }
   }
 
-  // Direct ORT pointer path: program compiled for exact runtime shape — no padding needed
+  if (mgx_state->hip_graph_enabled && mgx_state->pinned_io.allocated) {
+    std::size_t actual_batch = 0;
+    for (const auto& [name, index] : map_input_name_index) {
+      auto shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
+      if (!shape.empty()) { actual_batch = static_cast<std::size_t>(shape[0]); break; }
+    }
+    LOGS_DEFAULT(INFO) << "[StandardPath] batch=" << actual_batch
+                       << " mode=PINNED_IO (hipGraph static path)"
+                       << " hipGraph=ON";
+
+    copy_inputs_to_pinned(mgx_state, param_shapes, ctx, actual_batch, actual_batch, rocm_stream);
+    auto [m, prog_output_indices] = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
+
+    mgx_state->cached_prog_params = m;
+    mgx_state->cached_prog_output_indices = prog_output_indices;
+    mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(mgx_state, ctx, 0);
+    mgx_state->last_input_shape_hash = current_hash;
+    mgx_state->caches_valid = true;
+
+    run_program_or_hip_graph(mgx_state, rocm_stream, ctx, prog, m,
+                             prog_output_indices, current_hash);
+
+    copy_pinned_outputs_to_ort(mgx_state, output_shapes, prog_output_indices,
+                               ctx, actual_batch, rocm_stream);
+    return;
+  }
+
+  {
+    std::size_t actual_batch = 0;
+    for (const auto& [name, index] : map_input_name_index) {
+      auto shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
+      if (!shape.empty()) { actual_batch = static_cast<std::size_t>(shape[0]); break; }
+    }
+    LOGS_DEFAULT(INFO) << "[StandardPath] batch=" << actual_batch
+                       << " mode=DIRECT_ORT_POINTERS (static fallback)"
+                       << " hipGraph=OFF";
+  }
   auto [m, prog_output_indices] = handle_program_input_outputs(
       param_shapes, output_shapes, map_input_name_index, ctx);
 
@@ -3940,13 +4154,28 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     NodeComputeInfo compute_info;
     compute_info.create_state_func = [=](ComputeContext* context, FunctionState* state) {
       std::unique_ptr<MIGraphXFuncState> p = std::make_unique<MIGraphXFuncState>();
-      *p = {context->allocate_func, context->release_func, context->allocator_handle, map_progs_[context->node_name],
-            map_onnx_string_[context->node_name], options, t_, map_input_index_[context->node_name], &mgx_mu_,
-            map_defer_compilation_[context->node_name], fp16_enable_, bf16_enable_, fp8_enable_, int8_enable_,
-            int8_calibration_cache_available_, dynamic_range_map_,
-            model_cache_path_, dump_model_ops_, exhaustive_tune_, max_dynamic_batch_,
-            std::ref(cached_programs_[context->node_name])};
+      p->allocate_func = context->allocate_func;
+      p->release_func = context->release_func;
+      p->allocate_handle = context->allocator_handle;
+      p->prog = map_progs_[context->node_name];
+      p->onnx_string = map_onnx_string_[context->node_name];
+      p->options = options;
+      p->t = t_;
+      p->input_name_indexes = map_input_index_[context->node_name];
+      p->mgx_mu_ptr = &mgx_mu_;
       p->stream = stream_;
+      p->defer_compilation = map_defer_compilation_[context->node_name];
+      p->fp16_enable = fp16_enable_;
+      p->bf16_enable = bf16_enable_;
+      p->fp8_enable = fp8_enable_;
+      p->int8_enable = int8_enable_;
+      p->int8_calibration_cache_available = int8_calibration_cache_available_;
+      p->dynamic_range_map = dynamic_range_map_;
+      p->model_cache_dir = model_cache_path_;
+      p->dump_model_ops = dump_model_ops_;
+      p->exhaustive_tune = exhaustive_tune_;
+      p->max_dynamic_batch = max_dynamic_batch_;
+      p->cached_programs_ref = std::ref(cached_programs_[context->node_name]);
 
       // Initialize dynamic batch support if max_dynamic_batch > 0
       if (max_dynamic_batch_ > 0) {
@@ -4018,6 +4247,22 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         }
       }
 
+      // hipGraph: set per-node enable flag and validate cached programs
+      p->hip_graph_enabled = hip_graph_enable_;
+      if (p->hip_graph_enabled && p->cached_programs_ref.has_value()) {
+        for (const auto& [hash, cached_prog] : p->cached_programs_ref.value().get()) {
+          if (!check_hip_graph_compatibility(cached_prog, context->node_name)) {
+            p->hip_graph_enabled = false;
+            break;
+          }
+        }
+        if (p->hip_graph_enabled) {
+          LOGS_DEFAULT(INFO) << "[HipGraph] Enabled for node '" << context->node_name << "'";
+        } else {
+          LOGS_DEFAULT(INFO) << "[HipGraph] Disabled for node '" << context->node_name << "'";
+        }
+      }
+
       *state = p.release();
       return 0;
     };
@@ -4025,6 +4270,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     compute_info.release_state_func = [](FunctionState state) {
       if (state) {
         auto* s = static_cast<MIGraphXFuncState*>(state);
+        destroy_hip_graphs(s);
         free_pinned_io(s, s->stream);
         delete s;
       }
@@ -4036,8 +4282,12 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
       const auto& map_input_name_index = mgx_state->input_name_indexes;
 
-      // stream_ is always valid: either the user's external stream or an
-      // EP-owned hipStreamNonBlocking created in the constructor.
+      // Determine batch size from first input for logging
+      std::size_t log_batch = 0;
+      for (const auto& [name, index] : map_input_name_index) {
+        const auto& shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
+        if (!shape.empty()) { log_batch = static_cast<std::size_t>(shape[0]); break; }
+      }
 
       // ═══════════════════════════════════════════════════════════════════════
       // ULTRA-FAST PATH: Shapes unchanged from last run
@@ -4049,6 +4299,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       // ═══════════════════════════════════════════════════════════════════════
       // Build input shape hash - only computed when shapes change
       // ═══════════════════════════════════════════════════════════════════════
+      LOGS_DEFAULT(INFO) << "[Compute] UltraFast miss — building hash for batch=" << log_batch
+                         << " inputs=" << map_input_name_index.size()
+                         << " hipGraph=" << (mgx_state->hip_graph_enabled ? "ON" : "OFF");
       std::vector<std::int64_t> all_input_shapes;
       all_input_shapes.reserve(map_input_name_index.size() * 4);
       for (const auto& [name, index] : map_input_name_index) {
@@ -4063,6 +4316,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       if (execute_fast_path(mgx_state, stream_, ctx, current_hash, all_input_shapes)) {
         return Status::OK();
       }
+
+      LOGS_DEFAULT(INFO) << "[Compute] FastPath miss — entering StandardPath for batch=" << log_batch
+                         << " hash=" << current_hash.substr(0, 12) << "...";
 
       // ═══════════════════════════════════════════════════════════════════════
       // STANDARD PATH: Shape checking and potential recompilation

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1915,6 +1915,14 @@ static void replay_hip_graph(MIGraphXFuncState* mgx_state,
   HIP_CALL_THROW(hipGraphLaunch(entry.exec, stream));
 }
 
+// Forward declaration (defined after run_program_or_hip_graph)
+static void materialize_extra_outputs(
+    Ort::KernelContext& ctx,
+    hipStream_t stream,
+    const std::vector<MIGraphXFuncState::ExtraOutputInfo>& extras,
+    std::size_t original_batch_size,
+    std::size_t padded_batch_size);
+
 // Direct-bind capture: bind ORT tensor pointers directly (no pinned buffers)
 // and capture the hipGraph.  Requires stable pointers from pool allocator.
 static bool warmup_and_capture_hip_graph_direct(
@@ -3206,6 +3214,7 @@ static void execute_standard_path(
       for (const auto& [hash, cached_prog] : mgx_state->cached_programs_ref.value().get()) {
         if (!check_hip_graph_compatibility(cached_prog, "runtime_dynamic_batch")) {
           mgx_state->hip_graph_enabled = false;
+          mgx_state->use_direct_hip_graph = false;
           break;
         }
       }
@@ -3267,6 +3276,39 @@ static void execute_standard_path(
           
           populate_ultra_fast_caches(mgx_state, param_shapes, output_shapes, map_input_name_index,
                                     original_batch_size, padded_batch_size);
+
+          // Direct-bind hipGraph for exact-match batch (no padding)
+          if (mgx_state->use_direct_hip_graph && !needs_padding) {
+            auto [m, prog_output_indices] = handle_program_input_outputs(
+                param_shapes, output_shapes, map_input_name_index, ctx);
+
+            std::unordered_map<std::string, void*> input_ptrs, output_ptrs;
+            for (const auto& name : param_shapes.names()) {
+              auto inp_it = map_input_name_index.find(name);
+              if (inp_it != map_input_name_index.end()) {
+                input_ptrs[name] = const_cast<void*>(ctx.GetInput(inp_it->second).GetTensorRawData());
+              } else {
+                const auto oi = compute_output_index(name);
+                if (oi != -1) {
+                  const auto& lens = output_shapes[oi].lengths();
+                  std::vector<int64_t> ort_shape(lens.begin(), lens.end());
+                  auto ot = ctx.GetOutput(oi, ort_shape.data(), ort_shape.size());
+                  output_ptrs[name] = ot.GetTensorMutableRawData();
+                }
+              }
+            }
+
+            mgx_state->cached_prog_params = m;
+            mgx_state->cached_prog_output_indices = prog_output_indices;
+            mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(mgx_state, ctx, 0);
+            mgx_state->last_input_shape_hash = padded_hash;
+            mgx_state->caches_valid = true;
+
+            run_program_or_hip_graph_direct(mgx_state, rocm_stream, ctx, prog, m,
+                                             prog_output_indices, padded_hash,
+                                             input_ptrs, output_ptrs);
+            return;
+          }
 
           bool use_pinned = needs_padding || mgx_state->hip_graph_enabled;
           if (use_pinned) {
@@ -3354,6 +3396,7 @@ static void execute_standard_path(
 
     if (mgx_state->hip_graph_enabled && !check_hip_graph_compatibility(prog, "standard_path_recompile")) {
       mgx_state->hip_graph_enabled = false;
+      mgx_state->use_direct_hip_graph = false;
     }
   }
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -216,6 +216,34 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
   GET_ENV_STRING(migraphx_env_vars::kCompileBatches, compile_batches_);
   GET_ENV_BOOL(migraphx_env_vars::kHipGraphEnable, hip_graph_enable_);
 
+  // hipGraph requires single-stream MIGraphX execution (MIGRAPHX_NSTREAMS=1).
+  if (hip_graph_enable_) {
+    const auto nstreams_env = GetEnvironmentVar("MIGRAPHX_NSTREAMS");
+    int nstreams = nstreams_env.empty() ? 1 : std::stoi(nstreams_env);
+    if (nstreams > 1) {
+      LOGS_DEFAULT(WARNING)
+          << "[MIGraphX EP] MIGRAPHX_NSTREAMS=" << nstreams
+          << " is incompatible with hipGraph capture. Disabling hipGraph.";
+      hip_graph_enable_ = false;
+    }
+
+    const auto trace_env = GetEnvironmentVar("MIGRAPHX_TRACE_EVAL");
+    if (!trace_env.empty() && std::stoi(trace_env) != 0) {
+      LOGS_DEFAULT(WARNING)
+          << "[MIGraphX EP] MIGRAPHX_TRACE_EVAL is enabled, which calls hipStreamSynchronize "
+          << "per instruction. Disabling hipGraph.";
+      hip_graph_enable_ = false;
+    }
+
+    const auto null_stream_env = GetEnvironmentVar("MIGRAPHX_ENABLE_NULL_STREAM");
+    if (!null_stream_env.empty() && std::stoi(null_stream_env) != 0) {
+      LOGS_DEFAULT(WARNING)
+          << "[MIGraphX EP] MIGRAPHX_ENABLE_NULL_STREAM is enabled (default stream = illegal "
+          << "during capture). Disabling hipGraph.";
+      hip_graph_enable_ = false;
+    }
+  }
+
   // If compile_batches is set, auto-derive max_dynamic_batch from the spec's max value
   if (!compile_batches_.empty()) {
     auto explicit_sizes = parse_compile_batches(compile_batches_);

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1481,18 +1481,13 @@ static void allocate_pinned_io(
 {
   auto& pio = mgx_state->pinned_io;
   if (pio.allocated) {
-    LOGS_DEFAULT(WARNING) << "[PinnedIO] Already allocated (max_batch=" << pio.max_batch_size
-                       << "), skipping re-allocation for max_batch=" << max_batch_size;
     return;
   }
-
-  LOGS_DEFAULT(WARNING) << "[PinnedIO] Allocating buffers: max_batch=" << max_batch_size;
 
   const auto& map_input_name_index = mgx_state->input_name_indexes;
 
   pio.inputs.clear();
   pio.input_name_to_idx.clear();
-  std::size_t input_total_bytes = 0;
   for (const auto& name : param_shapes.names()) {
     if (map_input_name_index.find(name) == map_input_name_index.end()) continue;
     const auto& base_shape = param_shapes[name];
@@ -1500,7 +1495,6 @@ static void allocate_pinned_io(
     if (!lens.empty()) lens[0] = max_batch_size;
     auto max_shape = migraphx::shape(base_shape.type(), lens);
     std::size_t bytes = max_shape.bytes();
-    input_total_bytes += bytes;
 
     pio.input_name_to_idx[name] = pio.inputs.size();
     void* ptr = nullptr;
@@ -1511,7 +1505,6 @@ static void allocate_pinned_io(
 
   pio.outputs.clear();
   pio.output_name_to_idx.clear();
-  std::size_t output_total_bytes = 0;
   std::size_t output_alloc_idx = 0;
   for (const auto& name : param_shapes.names()) {
     if (map_input_name_index.find(name) != map_input_name_index.end()) continue;
@@ -1525,7 +1518,6 @@ static void allocate_pinned_io(
     if (!lens.empty()) lens[0] = max_batch_size;
     auto max_shape = migraphx::shape(out_shape.type(), lens);
     std::size_t bytes = max_shape.bytes();
-    output_total_bytes += bytes;
 
     pio.output_name_to_idx[name] = pio.outputs.size();
     void* ptr = nullptr;
@@ -1539,14 +1531,6 @@ static void allocate_pinned_io(
 
   pio.max_batch_size = max_batch_size;
   pio.allocated = true;
-
-  std::size_t total_bytes = input_total_bytes + output_total_bytes;
-  LOGS_DEFAULT(WARNING) << "[PinnedIO] Allocated: max_batch=" << max_batch_size
-                     << " inputs=" << pio.inputs.size()
-                     << " (" << (input_total_bytes / (1024.0 * 1024.0)) << " MB)"
-                     << " outputs=" << pio.outputs.size()
-                     << " (" << (output_total_bytes / (1024.0 * 1024.0)) << " MB)"
-                     << " total=" << (total_bytes / (1024.0 * 1024.0)) << " MB";
 }
 
 static void free_pinned_io(MIGraphXFuncState* mgx_state, hipStream_t stream) {
@@ -1709,15 +1693,11 @@ static void run_migraphx_program(
     std::size_t original_batch_size = 0,
     std::size_t padded_batch_size = 0)
 {
-  LOGS_DEFAULT(WARNING) << "[RunMIGraphX] run_async START"
-                     << " original_batch=" << original_batch_size
-                     << " padded_batch=" << padded_batch_size;
   std::optional<migraphx::arguments> prog_outputs;
   {
     std::lock_guard<std::mutex> lock(*mgx_mu_ptr);
     prog_outputs = prog.run_async(m, rocm_stream);
   }
-  LOGS_DEFAULT(WARNING) << "[RunMIGraphX] run_async DONE";
 
   bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 &&
                         original_batch_size < padded_batch_size);
@@ -1869,14 +1849,12 @@ static bool warmup_and_capture_hip_graph(
     HIP_CALL_THROW(hipMemsetAsync(pin.data, 0, pin.size_bytes, stream));
   }
 
-  LOGS_DEFAULT(WARNING) << "[HipGraph] WARMUP: running eager execution for hash=" << shape_hash.substr(0, 12) << "...";
   std::optional<migraphx::arguments> warmup_outputs;
   {
     std::lock_guard<std::mutex> lock(*mgx_state->mgx_mu_ptr);
     warmup_outputs = prog.run_async(m, stream);
   }
   HIP_CALL_THROW(hipStreamSynchronize(stream));
-  LOGS_DEFAULT(WARNING) << "[HipGraph] WARMUP complete, starting CAPTURE";
 
   auto& entry = mgx_state->hip_graph_cache[shape_hash];
 
@@ -1888,8 +1866,6 @@ static bool warmup_and_capture_hip_graph(
     }
     hipError_t err = hipStreamEndCapture(stream, &entry.graph);
     if (err != hipSuccess || entry.graph == nullptr) {
-      LOGS_DEFAULT(WARNING) << "[HipGraph] CAPTURE FAILED (err=" << err
-                            << "). Falling back to eager execution.";
       entry.graph = nullptr;
       entry.captured = false;
       mgx_state->hip_graph_enabled = false;
@@ -1913,19 +1889,10 @@ static bool warmup_and_capture_hip_graph(
         entry.extra_outputs.push_back({i, std::move(ort_shape),
                                        gpu_res.data(), res_shape.bytes()});
       }
-      if (!entry.extra_outputs.empty()) {
-        LOGS_DEFAULT(WARNING) << "[HipGraph] Recorded " << entry.extra_outputs.size()
-                           << " extra (non-pre-allocated) outputs for hash="
-                           << shape_hash.substr(0, 12) << "...";
-      }
     }
 
-    LOGS_DEFAULT(WARNING) << "[HipGraph] CAPTURE SUCCESS: instantiated graph for hash="
-                       << shape_hash.substr(0, 12) << "..."
-                       << " total_graphs=" << mgx_state->hip_graph_cache.size();
     return true;
   } catch (...) {
-    LOGS_DEFAULT(WARNING) << "[HipGraph] CAPTURE EXCEPTION. Falling back to eager execution.";
     hipGraph_t dummy = nullptr;
     (void)hipStreamEndCapture(stream, &dummy);
     if (dummy) (void)hipGraphDestroy(dummy);
@@ -1940,7 +1907,6 @@ static bool warmup_and_capture_hip_graph(
 static void replay_hip_graph(MIGraphXFuncState* mgx_state,
                              hipStream_t stream,
                              const std::string& shape_hash) {
-  LOGS_DEFAULT(WARNING) << "[HipGraph] REPLAY launch for hash=" << shape_hash.substr(0, 12) << "...";
   auto& entry = mgx_state->hip_graph_cache.at(shape_hash);
   HIP_CALL_THROW(hipGraphLaunch(entry.exec, stream));
 }
@@ -1993,8 +1959,6 @@ static void run_program_or_hip_graph(
     std::size_t padded_batch_size = 0)
 {
   if (!mgx_state->hip_graph_enabled) {
-    LOGS_DEFAULT(WARNING) << "[Dispatch] EAGER run_async (hipGraph disabled)"
-                       << " hash=" << shape_hash.substr(0, 12) << "...";
     run_migraphx_program(mgx_state->mgx_mu_ptr, stream, ctx, prog, m,
                          prog_output_indices, original_batch_size, padded_batch_size);
     return;
@@ -2002,9 +1966,6 @@ static void run_program_or_hip_graph(
 
   auto it = mgx_state->hip_graph_cache.find(shape_hash);
   if (it != mgx_state->hip_graph_cache.end() && it->second.captured) {
-    LOGS_DEFAULT(WARNING) << "[Dispatch] REPLAY hipGraph"
-                       << " hash=" << shape_hash.substr(0, 12) << "..."
-                       << " cache_size=" << mgx_state->hip_graph_cache.size();
     replay_hip_graph(mgx_state, stream, shape_hash);
 
     if (!it->second.extra_outputs.empty()) {
@@ -2012,12 +1973,8 @@ static void run_program_or_hip_graph(
                                 original_batch_size, padded_batch_size);
     }
   } else {
-    LOGS_DEFAULT(WARNING) << "[Dispatch] WARMUP+CAPTURE hipGraph"
-                       << " hash=" << shape_hash.substr(0, 12) << "..."
-                       << " cache_size=" << mgx_state->hip_graph_cache.size();
     if (!warmup_and_capture_hip_graph(mgx_state, stream, prog, m,
                                        prog_output_indices, shape_hash)) {
-      LOGS_DEFAULT(WARNING) << "[Dispatch] Capture FAILED — falling back to EAGER";
       run_migraphx_program(mgx_state->mgx_mu_ptr, stream, ctx, prog, m,
                            prog_output_indices, original_batch_size, padded_batch_size);
     } else {
@@ -2228,12 +2185,7 @@ static migraphx::program load_or_compile_model(
 {
   migraphx::program prog;
 
-  LOGS_DEFAULT(WARNING) << "[LoadOrCompile] batch_size=" << (batch_size > 0 ? std::to_string(batch_size) : "(default)")
-                     << " cache_file=" << (cache_file.empty() ? "(none)" : cache_file.string());
-
   if (!load_precompiled_model(prog, cache_file)) {
-    LOGS_DEFAULT(WARNING) << "[LoadOrCompile] DISK CACHE MISS — COMPILING batch_size="
-                       << (batch_size > 0 ? std::to_string(batch_size) : "(default)");
 
     prog = CompileProgramWithBatch(
         onnx_string,
@@ -2253,17 +2205,7 @@ static migraphx::program load_or_compile_model(
         all_input_base_shapes,
         batch_size);
 
-    LOGS_DEFAULT(WARNING) << "[LoadOrCompile] Compilation DONE batch_size="
-                       << (batch_size > 0 ? std::to_string(batch_size) : "(default)");
-    
     save_compiled_model(prog, cache_file);
-    if (!cache_file.empty()) {
-      LOGS_DEFAULT(WARNING) << "[LoadOrCompile] Saved to disk: " << cache_file.string();
-    }
-  } else {
-    LOGS_DEFAULT(WARNING) << "[LoadOrCompile] DISK CACHE HIT — loaded batch_size="
-                       << (batch_size > 0 ? std::to_string(batch_size) : "(default)")
-                       << " from " << cache_file.string();
   }
   return prog;
 }
@@ -2610,10 +2552,6 @@ static bool execute_ultra_fast_path(
                       && mgx_state->pinned_io.allocated;
 
   if (needs_pinned && mgx_state->cached_mgx_param_shapes.has_value()) {
-    LOGS_DEFAULT(WARNING) << "[UltraFastPath] batch=" << actual_batch
-                       << " compiled_batch=" << compiled_batch
-                       << " mode=PINNED_IO"
-                       << " hipGraph=" << (mgx_state->hip_graph_enabled ? "ON" : "OFF");
     const auto& param_shapes = mgx_state->cached_mgx_param_shapes.value();
     const auto& output_shapes = mgx_state->cached_mgx_output_shapes.value();
 
@@ -2630,9 +2568,6 @@ static bool execute_ultra_fast_path(
     return true;
   }
 
-  LOGS_DEFAULT(WARNING) << "[UltraFastPath] batch=" << actual_batch
-                     << " compiled_batch=" << compiled_batch
-                     << " mode=DIRECT_ORT_POINTERS";
   auto& m = mgx_state->cached_prog_params.value();
   for (const auto& inp : mgx_state->cached_inputs) {
     const auto& input_tensor = ctx.GetInput(inp.ort_index);
@@ -2776,12 +2711,6 @@ static bool execute_fast_path(
                       && mgx_state->pinned_io.allocated;
 
   if (needs_pinned) {
-    LOGS_DEFAULT(WARNING) << "[FastPath] batch=" << actual_batch
-                       << " compiled_batch=" << compiled_batch
-                       << " padded=" << (needs_padding ? "YES" : "NO")
-                       << " mode=PINNED_IO"
-                       << " hipGraph=" << (mgx_state->hip_graph_enabled ? "ON" : "OFF")
-                       << " program_changed=" << (program_changed ? "YES" : "NO");
     copy_inputs_to_pinned(mgx_state, param_shapes, ctx, actual_batch, compiled_batch, rocm_stream);
     auto bind_result = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
 
@@ -2804,10 +2733,6 @@ static bool execute_fast_path(
     return true;
   }
 
-  LOGS_DEFAULT(WARNING) << "[FastPath] batch=" << actual_batch
-                     << " compiled_batch=" << compiled_batch
-                     << " mode=DIRECT_ORT_POINTERS"
-                     << " program_changed=" << (program_changed ? "YES" : "NO");
   auto [m, prog_output_indices] = handle_program_input_outputs(
       param_shapes, output_shapes, map_input_name_index, ctx);
 
@@ -2909,23 +2834,8 @@ static void compile_dynamic_batch_models(
     const std::string& mxr_filename_prefix,
     const Ort::KernelContext& ctx) {
   
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ==== ENTERING compile_dynamic_batch_models ====";
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] has_dynamic_batch=" << mgx_state->has_dynamic_batch
-                     << " batch_sizes_count=" << mgx_state->compiled_batch_sizes.size()
-                     << " max_dynamic_batch=" << mgx_state->max_dynamic_batch;
-  
   if (!mgx_state->has_dynamic_batch || mgx_state->compiled_batch_sizes.empty()) {
-    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Skipping - dynamic batch disabled or no batch sizes";
     return;
-  }
-  
-  {
-    std::ostringstream bs_list;
-    for (std::size_t i = 0; i < mgx_state->compiled_batch_sizes.size(); ++i) {
-      if (i > 0) bs_list << ", ";
-      bs_list << mgx_state->compiled_batch_sizes[i];
-    }
-    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Batch sizes to compile: [" << bs_list.str() << "]";
   }
   
   // Get input names and base shapes (without batch dimension)
@@ -2933,7 +2843,6 @@ static void compile_dynamic_batch_models(
   std::vector<std::string> input_names;
   std::vector<std::vector<std::int64_t>> all_input_base_shapes;
   
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Processing " << map_input_name_index.size() << " input parameters";
   for (const auto& [name, index] : map_input_name_index) {
     input_names.push_back(name);
     auto input_tensor = ctx.GetInput(index);
@@ -2969,7 +2878,6 @@ static void compile_dynamic_batch_models(
   
   // Compile a model for each configured batch size
   for (const auto& batch_size : mgx_state->compiled_batch_sizes) {
-    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Processing batch_size=" << batch_size;
     
     std::vector<std::int64_t> batch_shape_key;
     for (size_t i = 0; i < input_names.size(); ++i) {
@@ -2983,21 +2891,15 @@ static void compile_dynamic_batch_models(
     if (mgx_state->cached_programs_ref.has_value()) {
       auto& cached_progs = mgx_state->cached_programs_ref.value().get();
       if (cached_progs.find(cache_hash) != cached_progs.end()) {
-        LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] batch_size=" << batch_size
-                           << " CACHE HIT (in-memory), skipping";
         continue;
       }
-      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] batch_size=" << batch_size
-                         << " CACHE MISS (in-memory cache_size=" << cached_progs.size() << ")";
     }
     
     std::filesystem::path batch_cache_file;
     if (!model_cache_path.empty()) {
       batch_cache_file = model_cache_path / (mxr_filename_prefix + cache_hash + ".mxr");
-      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] Disk cache: " << batch_cache_file.string();
     }
     
-    LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] load_or_compile batch_size=" << batch_size << " hash=" << cache_hash.substr(0, 12) << "...";
     migraphx::program batch_prog = load_or_compile_model(
         batch_cache_file,
         mgx_state->onnx_string,
@@ -3019,17 +2921,11 @@ static void compile_dynamic_batch_models(
     
     if (mgx_state->cached_programs_ref.has_value()) {
       mgx_state->cached_programs_ref.value().get()[cache_hash] = batch_prog;
-      LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] batch_size=" << batch_size
-                         << " STORED in cache (total_programs="
-                         << mgx_state->cached_programs_ref.value().get().size() << ")";
     }
   }
   
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ==== All batch models compiled/loaded ====";
-  
   mgx_state->max_dynamic_batch = 0;
   mgx_state->defer_compilation = false;
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] defer_compilation=false, max_dynamic_batch=0";
 
   // Allocate pinned I/O now that all batch models are compiled.
   // Must use the largest-batch program's shapes so the buffer count and
@@ -3070,7 +2966,6 @@ static void compile_dynamic_batch_models(
     }
   }
 
-  LOGS_DEFAULT(WARNING) << "[DynamicBatch][COMPILE] ==== EXITING compile_dynamic_batch_models ====";
 }
 
 // Standard path: Shape checking, potential recompilation, and execution
@@ -3093,14 +2988,7 @@ static void execute_standard_path(
   // NOTE: max_dynamic_batch > 0 means compilation was deferred to runtime (not precompiled)
   // If precompilation happened during Compile(), max_dynamic_batch will be > 0 but defer_compilation = false
   // In that case, the programs are already in cache and we can skip runtime compilation
-  LOGS_DEFAULT(WARNING) << "[StandardPath] Entered: defer_compilation=" << mgx_state->defer_compilation
-                     << " has_dynamic_batch=" << mgx_state->has_dynamic_batch
-                     << " max_dynamic_batch=" << mgx_state->max_dynamic_batch
-                     << " hipGraph=" << (mgx_state->hip_graph_enabled ? "ON" : "OFF")
-                     << " pinned_allocated=" << (mgx_state->pinned_io.allocated ? "YES" : "NO");
-
   if (mgx_state->has_dynamic_batch && mgx_state->max_dynamic_batch > 0 && mgx_state->defer_compilation) {
-    LOGS_DEFAULT(WARNING) << "[StandardPath] Triggering DEFERRED COMPILATION for all batch sizes";
     compile_dynamic_batch_models(mgx_state, model_cache_path, model_path, mxr_filename_prefix, ctx);
 
     // Validate newly compiled programs for hipGraph compatibility
@@ -3172,11 +3060,6 @@ static void execute_standard_path(
 
           bool use_pinned = needs_padding || mgx_state->hip_graph_enabled;
           if (use_pinned) {
-            LOGS_DEFAULT(WARNING) << "[StandardPath] batch=" << original_batch_size
-                              << " padded_batch=" << padded_batch_size
-                              << " padded=" << (needs_padding ? "YES" : "NO")
-                              << " mode=PINNED_IO (dynamic batch cache hit)"
-                              << " hipGraph=" << (mgx_state->hip_graph_enabled ? "ON" : "OFF");
             if (!mgx_state->pinned_io.allocated) {
               std::size_t max_batch = padded_batch_size;
               if (!mgx_state->compiled_batch_sizes.empty()) {
@@ -3225,9 +3108,6 @@ static void execute_standard_path(
                                        bind_result.pinned_output_indices,
                                        ctx, copy_actual, rocm_stream);
           } else {
-            LOGS_DEFAULT(WARNING) << "[StandardPath] batch=" << original_batch_size
-                              << " padded_batch=" << padded_batch_size
-                              << " mode=DIRECT_ORT_POINTERS (dynamic batch cache hit, exact match)";
             auto [m, prog_output_indices] = handle_program_input_outputs(
                 param_shapes, output_shapes, map_input_name_index, ctx);
 
@@ -3249,7 +3129,6 @@ static void execute_standard_path(
       mgx_state->defer_compilation, map_input_name_index, ctx, cmp_options, prog);
 
   if (!input_shape_match) {
-    LOGS_DEFAULT(WARNING) << "[StandardPath] Input shape MISMATCH — triggering recompilation";
     mgx_state->caches_valid = false;
 
     handle_input_shape_mismatch(
@@ -3262,7 +3141,6 @@ static void execute_standard_path(
         input_shapes);
 
     param_shapes = prog.get_parameter_shapes();
-    LOGS_DEFAULT(WARNING) << "[StandardPath] Recompilation complete";
 
     if (mgx_state->hip_graph_enabled && !check_hip_graph_compatibility(prog, "standard_path_recompile")) {
       mgx_state->hip_graph_enabled = false;
@@ -3297,10 +3175,6 @@ static void execute_standard_path(
       auto shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
       if (!shape.empty()) { actual_batch = static_cast<std::size_t>(shape[0]); break; }
     }
-    LOGS_DEFAULT(WARNING) << "[StandardPath] batch=" << actual_batch
-                       << " mode=PINNED_IO (hipGraph static path)"
-                       << " hipGraph=ON";
-
     copy_inputs_to_pinned(mgx_state, param_shapes, ctx, actual_batch, actual_batch, rocm_stream);
     auto bind_result = bind_pinned_program_params(mgx_state, param_shapes, output_shapes);
 
@@ -3320,16 +3194,6 @@ static void execute_standard_path(
     return;
   }
 
-  {
-    std::size_t actual_batch = 0;
-    for (const auto& [name, index] : map_input_name_index) {
-      auto shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
-      if (!shape.empty()) { actual_batch = static_cast<std::size_t>(shape[0]); break; }
-    }
-    LOGS_DEFAULT(WARNING) << "[StandardPath] batch=" << actual_batch
-                       << " mode=DIRECT_ORT_POINTERS (static fallback)"
-                       << " hipGraph=OFF";
-  }
   auto [m, prog_output_indices] = handle_program_input_outputs(
       param_shapes, output_shapes, map_input_name_index, ctx);
 
@@ -3509,53 +3373,19 @@ extract_base_shapes_from_graph(
       const NodeArg* nodearg = it->second;
       auto tensor_shape = nodearg->Shape();
       if (tensor_shape != nullptr && tensor_shape->dim_size() > 1) {
-        LOGS_DEFAULT(VERBOSE) << "[extract_base_shapes_from_graph] Processing input '" << name 
-                              << "' with " << tensor_shape->dim_size() << " dimensions";
-        // Extract non-batch dimensions (skip dim 0)
         for (int j = 1; j < tensor_shape->dim_size(); ++j) {
           const auto& dim = tensor_shape->dim(j);
           if (dim.has_dim_value()) {
             base_shape.push_back(dim.dim_value());
-            LOGS_DEFAULT(VERBOSE) << "[extract_base_shapes_from_graph]   dim[" << j << "] = " << dim.dim_value();
           } else {
-            // Symbolic non-batch dimension found - cannot precompile
-            // Do NOT default to any value - mark as failure
-            LOGS_DEFAULT(WARNING) << "[extract_base_shapes_from_graph] Input '" << name
-                                  << "' dim " << j << " is symbolic - cannot extract concrete base shapes";
             all_concrete = false;
           }
         }
-      } else if (tensor_shape != nullptr && tensor_shape->dim_size() == 1) {
-        // Single dimension input (just batch) - no base shape needed
-        LOGS_DEFAULT(VERBOSE) << "[extract_base_shapes_from_graph] Input '" << name 
-                              << "' has only 1 dimension (batch only) - empty base shape";
-      } else {
-        LOGS_DEFAULT(WARNING) << "[extract_base_shapes_from_graph] Input '" << name 
-                              << "' has null or empty shape";
       }
-    } else {
-      LOGS_DEFAULT(WARNING) << "[extract_base_shapes_from_graph] Input '" << name 
-                            << "' not found in NodeArg map - may be subgraph-only input";
     }
     base_shapes.push_back(base_shape);
-    
-    // Log the extracted base shape
-    std::ostringstream ss;
-    ss << "[";
-    for (std::size_t k = 0; k < base_shape.size(); ++k) {
-      if (k > 0) ss << ", ";
-      ss << base_shape[k];
-    }
-    ss << "]";
-    LOGS_DEFAULT(VERBOSE) << "[extract_base_shapes_from_graph] Input '" << name << "' base_shape: " << ss.str();
   }
   
-  if (all_concrete) {
-    LOGS_DEFAULT(VERBOSE) << "[extract_base_shapes_from_graph] Successfully extracted " << ordered_names.size() 
-                          << " input base shapes (all concrete)";
-  } else {
-    LOGS_DEFAULT(WARNING) << "[extract_base_shapes_from_graph] Failed - found symbolic non-batch dimensions";
-  }
   return {all_concrete, ordered_names, base_shapes};
 }
 
@@ -3903,9 +3733,6 @@ static inline void precompile_static_model(
           }
         }
       }
-    } else {
-      LOGS_DEFAULT(WARNING) << "[precompile_static_model] Input '" << name 
-                            << "' not found in NodeArg map - skipping";
     }
     full_shapes.push_back(shape);
   }
@@ -4408,11 +4235,6 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             break;
           }
         }
-        if (p->hip_graph_enabled) {
-          LOGS_DEFAULT(WARNING) << "[HipGraph] Enabled for node '" << context->node_name << "'";
-        } else {
-          LOGS_DEFAULT(WARNING) << "[HipGraph] Disabled for node '" << context->node_name << "'";
-        }
       }
 
       *state = p.release();
@@ -4434,26 +4256,10 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
       const auto& map_input_name_index = mgx_state->input_name_indexes;
 
-      // Determine batch size from first input for logging
-      std::size_t log_batch = 0;
-      for (const auto& [name, index] : map_input_name_index) {
-        const auto& shape = ctx.GetInput(index).GetTensorTypeAndShapeInfo().GetShape();
-        if (!shape.empty()) { log_batch = static_cast<std::size_t>(shape[0]); break; }
-      }
-
-      // ═══════════════════════════════════════════════════════════════════════
-      // ULTRA-FAST PATH: Shapes unchanged from last run
-      // ═══════════════════════════════════════════════════════════════════════
       if (execute_ultra_fast_path(mgx_state, stream_, ctx)) {
         return Status::OK();
       }
 
-      // ═══════════════════════════════════════════════════════════════════════
-      // Build input shape hash - only computed when shapes change
-      // ═══════════════════════════════════════════════════════════════════════
-      LOGS_DEFAULT(WARNING) << "[Compute] UltraFast miss — building hash for batch=" << log_batch
-                         << " inputs=" << map_input_name_index.size()
-                         << " hipGraph=" << (mgx_state->hip_graph_enabled ? "ON" : "OFF");
       std::vector<std::int64_t> all_input_shapes;
       all_input_shapes.reserve(map_input_name_index.size() * 4);
       for (const auto& [name, index] : map_input_name_index) {
@@ -4462,19 +4268,10 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       }
       const auto current_hash = make_hash(all_input_shapes);
 
-      // ═══════════════════════════════════════════════════════════════════════
-      // FAST PATH: Check cached programs for this shape hash
-      // ═══════════════════════════════════════════════════════════════════════
       if (execute_fast_path(mgx_state, stream_, ctx, current_hash, all_input_shapes)) {
         return Status::OK();
       }
 
-      LOGS_DEFAULT(WARNING) << "[Compute] FastPath miss — entering StandardPath for batch=" << log_batch
-                         << " hash=" << current_hash.substr(0, 12) << "...";
-
-      // ═══════════════════════════════════════════════════════════════════════
-      // STANDARD PATH: Shape checking and potential recompilation
-      // ═══════════════════════════════════════════════════════════════════════
       execute_standard_path(mgx_state, stream_, ctx, current_hash, std::move(all_input_shapes),
                             model_cache_path_, model_path_, mxr_filename_prefix);
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -9,6 +9,7 @@
 #include <functional>
 #include <future>
 #include <iterator>
+#include <numeric>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -1461,10 +1462,10 @@ static void allocate_pinned_io(
   }
 
   pio.outputs.clear();
-  for (std::size_t i = 0; i < output_shapes.size(); ++i) {
-    auto lens = output_shapes[i].lengths();
+  for (const auto& out_shape : output_shapes) {
+    auto lens = out_shape.lengths();
     if (!lens.empty()) lens[0] = max_batch_size;
-    auto max_shape = migraphx::shape(output_shapes[i].type(), lens);
+    auto max_shape = migraphx::shape(out_shape.type(), lens);
     std::size_t bytes = max_shape.bytes();
 
     void* ptr = nullptr;
@@ -1522,8 +1523,8 @@ static void copy_inputs_to_pinned(
     const auto& base_shape = param_shapes[name];
     auto lens = base_shape.lengths();
 
-    std::size_t elements_per_batch = 1;
-    for (std::size_t d = 1; d < lens.size(); ++d) elements_per_batch *= lens[d];
+    std::size_t elements_per_batch = std::accumulate(
+        lens.begin() + 1, lens.end(), std::size_t{1}, std::multiplies<>{});
 
     std::size_t total_elems = 1;
     for (auto l : lens) total_elems *= l;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -328,8 +328,12 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
 
 std::vector<AllocatorPtr> MIGraphXExecutionProvider::CreatePreferredAllocators() {
   AllocatorCreationInfo default_memory_info(
-      [](OrtDevice::DeviceId device_id) {
-        return std::make_unique<MIGraphXAllocator>(device_id, onnxruntime::CUDA);
+      [this](OrtDevice::DeviceId device_id) {
+        auto alloc = std::make_unique<MIGraphXAllocator>(device_id, onnxruntime::CUDA);
+        if (hip_graph_enable_) {
+          alloc->EnablePoolMode();
+        }
+        return alloc;
       },
       device_id_);
   AllocatorCreationInfo pinned_allocator_info(

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1915,6 +1915,139 @@ static void replay_hip_graph(MIGraphXFuncState* mgx_state,
   HIP_CALL_THROW(hipGraphLaunch(entry.exec, stream));
 }
 
+// Direct-bind capture: bind ORT tensor pointers directly (no pinned buffers)
+// and capture the hipGraph.  Requires stable pointers from pool allocator.
+static bool warmup_and_capture_hip_graph_direct(
+    MIGraphXFuncState* mgx_state,
+    hipStream_t stream,
+    migraphx::program& prog,
+    migraphx::program_parameters& m,
+    const std::vector<std::size_t>& prog_output_indices,
+    const std::string& shape_hash,
+    const std::unordered_map<std::string, void*>& input_ptrs,
+    const std::unordered_map<std::string, void*>& output_ptrs)
+{
+  std::optional<migraphx::arguments> warmup_outputs;
+  {
+    std::lock_guard<std::mutex> lock(*mgx_state->mgx_mu_ptr);
+    warmup_outputs = prog.run_async(m, stream);
+  }
+  HIP_CALL_THROW(hipStreamSynchronize(stream));
+
+  auto& entry = mgx_state->hip_graph_cache[shape_hash];
+
+  try {
+    HIP_CALL_THROW(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+    {
+      std::lock_guard<std::mutex> lock(*mgx_state->mgx_mu_ptr);
+      prog.run_async(m, stream);
+    }
+    hipError_t err = hipStreamEndCapture(stream, &entry.graph);
+    if (err != hipSuccess || entry.graph == nullptr) {
+      entry.graph = nullptr;
+      entry.captured = false;
+      mgx_state->use_direct_hip_graph = false;
+      return false;
+    }
+
+    HIP_CALL_THROW(hipGraphInstantiate(&entry.exec, entry.graph, nullptr, nullptr, 0));
+    entry.captured = true;
+    entry.captured_input_ptrs = input_ptrs;
+    entry.captured_output_ptrs = output_ptrs;
+
+    std::unordered_set<std::size_t> pre_alloc_set(prog_output_indices.begin(),
+                                                   prog_output_indices.end());
+    entry.extra_outputs.clear();
+    if (warmup_outputs) {
+      auto output_num = warmup_outputs->size();
+      for (std::size_t i = 0; i < output_num; ++i) {
+        if (pre_alloc_set.count(i) > 0) continue;
+        auto gpu_res = (*warmup_outputs)[i];
+        migraphx::shape res_shape = gpu_res.get_shape();
+        auto res_lens = res_shape.lengths();
+        std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
+        entry.extra_outputs.push_back({i, std::move(ort_shape),
+                                       gpu_res.data(), res_shape.bytes()});
+      }
+    }
+
+    return true;
+  } catch (...) {
+    hipGraph_t dummy = nullptr;
+    (void)hipStreamEndCapture(stream, &dummy);
+    if (dummy) (void)hipGraphDestroy(dummy);
+    entry.graph = nullptr;
+    entry.exec = nullptr;
+    entry.captured = false;
+    mgx_state->use_direct_hip_graph = false;
+    return false;
+  }
+}
+
+// Check whether ORT's current tensor pointers match the addresses stored
+// during capture.  Returns true if all pointers match.
+static bool check_captured_ptrs_match(
+    const MIGraphXFuncState::CapturedHipGraph& entry,
+    const std::unordered_map<std::string, void*>& current_input_ptrs,
+    const std::unordered_map<std::string, void*>& current_output_ptrs)
+{
+  for (const auto& [name, ptr] : current_input_ptrs) {
+    auto it = entry.captured_input_ptrs.find(name);
+    if (it == entry.captured_input_ptrs.end() || it->second != ptr) return false;
+  }
+  for (const auto& [name, ptr] : current_output_ptrs) {
+    auto it = entry.captured_output_ptrs.find(name);
+    if (it == entry.captured_output_ptrs.end() || it->second != ptr) return false;
+  }
+  return true;
+}
+
+// Direct-bind dispatch: replay or capture hipGraph using ORT tensor pointers
+// directly.  Falls back to the pinned-copy path on pointer mismatch.
+static void run_program_or_hip_graph_direct(
+    MIGraphXFuncState* mgx_state,
+    hipStream_t stream,
+    Ort::KernelContext& ctx,
+    migraphx::program& prog,
+    migraphx::program_parameters& m,
+    const std::vector<std::size_t>& prog_output_indices,
+    const std::string& shape_hash,
+    const std::unordered_map<std::string, void*>& input_ptrs,
+    const std::unordered_map<std::string, void*>& output_ptrs,
+    std::size_t original_batch_size = 0,
+    std::size_t padded_batch_size = 0)
+{
+  auto it = mgx_state->hip_graph_cache.find(shape_hash);
+  if (it != mgx_state->hip_graph_cache.end() && it->second.captured) {
+    if (!check_captured_ptrs_match(it->second, input_ptrs, output_ptrs)) {
+      // Pointer drift -- destroy old graph and re-capture
+      if (it->second.exec) { (void)hipGraphExecDestroy(it->second.exec); it->second.exec = nullptr; }
+      if (it->second.graph) { (void)hipGraphDestroy(it->second.graph); it->second.graph = nullptr; }
+      it->second.captured = false;
+    } else {
+      HIP_CALL_THROW(hipGraphLaunch(it->second.exec, stream));
+      if (!it->second.extra_outputs.empty()) {
+        materialize_extra_outputs(ctx, stream, it->second.extra_outputs,
+                                  original_batch_size, padded_batch_size);
+      }
+      return;
+    }
+  }
+
+  if (!warmup_and_capture_hip_graph_direct(mgx_state, stream, prog, m,
+                                            prog_output_indices, shape_hash,
+                                            input_ptrs, output_ptrs)) {
+    run_migraphx_program(mgx_state->mgx_mu_ptr, stream, ctx, prog, m,
+                         prog_output_indices, original_batch_size, padded_batch_size);
+  } else {
+    auto& entry = mgx_state->hip_graph_cache.at(shape_hash);
+    if (!entry.extra_outputs.empty()) {
+      materialize_extra_outputs(ctx, stream, entry.extra_outputs,
+                                original_batch_size, padded_batch_size);
+    }
+  }
+}
+
 // Materialize extra (non-pre-allocated) outputs recorded during hipGraph capture.
 // These are MIGraphX outputs not exposed as named parameters — their GPU data
 // pointers are stable across replays because hipGraph replays the same kernels.
@@ -4232,10 +4365,12 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
       // hipGraph: set per-node enable flag and validate cached programs
       p->hip_graph_enabled = hip_graph_enable_;
+      p->use_direct_hip_graph = hip_graph_enable_;
       if (p->hip_graph_enabled && p->cached_programs_ref.has_value()) {
         for (const auto& [hash, cached_prog] : p->cached_programs_ref.value().get()) {
           if (!check_hip_graph_compatibility(cached_prog, context->node_name)) {
             p->hip_graph_enabled = false;
+            p->use_direct_hip_graph = false;
             break;
           }
         }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -2684,8 +2684,35 @@ static bool execute_ultra_fast_path(
                 .GetTensorTypeAndShapeInfo().GetShape()[0])
           : 0);
   std::size_t compiled_batch = padded_batch_size > 0 ? padded_batch_size : actual_batch;
-  // hipGraph requires stable buffer addresses → always route through pinned I/O
-  bool needs_pinned = ((actual_batch < compiled_batch) || mgx_state->hip_graph_enabled)
+  bool needs_padding = (actual_batch < compiled_batch);
+
+  // Direct-bind hipGraph: no copies, bind ORT pointers and replay
+  if (mgx_state->use_direct_hip_graph && !needs_padding) {
+    auto& m = mgx_state->cached_prog_params.value();
+    std::unordered_map<std::string, void*> input_ptrs, output_ptrs;
+    for (const auto& inp : mgx_state->cached_inputs) {
+      const auto& input_tensor = ctx.GetInput(inp.ort_index);
+      void* ptr = const_cast<void*>(input_tensor.GetTensorRawData());
+      m.add(inp.name.c_str(), migraphx::argument(inp.mgx_shape, ptr));
+      input_ptrs[inp.name] = ptr;
+    }
+    for (std::size_t i = 0; i < mgx_state->cached_outputs.size(); ++i) {
+      const auto& out = mgx_state->cached_outputs[i];
+      const auto& ort_shape = mgx_state->cached_output_ort_shapes[i];
+      auto output_tensor = ctx.GetOutput(out.output_index, ort_shape.data(), ort_shape.size());
+      void* ptr = output_tensor.GetTensorMutableRawData();
+      m.add(out.name.c_str(), migraphx::argument(out.mgx_shape, ptr));
+      output_ptrs[out.name] = ptr;
+    }
+    run_program_or_hip_graph_direct(mgx_state, rocm_stream, ctx, prog, m,
+                                     mgx_state->cached_prog_output_indices,
+                                     mgx_state->last_input_shape_hash,
+                                     input_ptrs, output_ptrs);
+    return true;
+  }
+
+  // Pinned-copy path: padding needed or legacy hipGraph path
+  bool needs_pinned = (needs_padding || mgx_state->hip_graph_enabled)
                       && mgx_state->pinned_io.allocated;
 
   if (needs_pinned && mgx_state->cached_mgx_param_shapes.has_value()) {
@@ -2843,8 +2870,45 @@ static bool execute_fast_path(
     }
   }
   std::size_t compiled_batch = padded_batch_size > 0 ? padded_batch_size : actual_batch;
-  // hipGraph requires stable buffer addresses → always route through pinned I/O
-  bool needs_pinned = ((actual_batch < compiled_batch) || mgx_state->hip_graph_enabled)
+  bool fast_needs_padding = (actual_batch < compiled_batch);
+
+  // Direct-bind hipGraph path: bind ORT pointers and replay, no copies
+  if (mgx_state->use_direct_hip_graph && !fast_needs_padding) {
+    auto [m, prog_output_indices] = handle_program_input_outputs(
+        param_shapes, output_shapes, map_input_name_index, ctx);
+
+    std::unordered_map<std::string, void*> input_ptrs, output_ptrs;
+    for (const auto& name : param_shapes.names()) {
+      auto inp_it = map_input_name_index.find(name);
+      if (inp_it != map_input_name_index.end()) {
+        input_ptrs[name] = const_cast<void*>(ctx.GetInput(inp_it->second).GetTensorRawData());
+      } else {
+        const auto oi = compute_output_index(name);
+        if (oi != -1) {
+          const auto& lens = output_shapes[oi].lengths();
+          std::vector<int64_t> ort_shape(lens.begin(), lens.end());
+          auto ot = ctx.GetOutput(oi, ort_shape.data(), ort_shape.size());
+          output_ptrs[name] = ot.GetTensorMutableRawData();
+        }
+      }
+    }
+
+    mgx_state->cached_prog_params = std::move(m);
+    mgx_state->cached_prog_output_indices = std::move(prog_output_indices);
+    mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(mgx_state, ctx, 0);
+    mgx_state->last_input_shape_hash = current_hash;
+    mgx_state->caches_valid = true;
+
+    run_program_or_hip_graph_direct(mgx_state, rocm_stream, ctx, prog,
+                                     mgx_state->cached_prog_params.value(),
+                                     mgx_state->cached_prog_output_indices,
+                                     effective_program_hash,
+                                     input_ptrs, output_ptrs);
+    return true;
+  }
+
+  // Pinned-copy path: padding needed or legacy hipGraph
+  bool needs_pinned = (fast_needs_padding || mgx_state->hip_graph_enabled)
                       && mgx_state->pinned_io.allocated;
 
   if (needs_pinned) {
@@ -3304,6 +3368,39 @@ static void execute_standard_path(
     if (batch_for_alloc > 0) {
       allocate_pinned_io(mgx_state, param_shapes, output_shapes, batch_for_alloc, rocm_stream);
     }
+  }
+
+  // Direct-bind hipGraph for standard path (no padding case)
+  if (mgx_state->use_direct_hip_graph) {
+    auto [m, prog_output_indices] = handle_program_input_outputs(
+        param_shapes, output_shapes, map_input_name_index, ctx);
+
+    std::unordered_map<std::string, void*> input_ptrs, output_ptrs;
+    for (const auto& name : param_shapes.names()) {
+      auto inp_it = map_input_name_index.find(name);
+      if (inp_it != map_input_name_index.end()) {
+        input_ptrs[name] = const_cast<void*>(ctx.GetInput(inp_it->second).GetTensorRawData());
+      } else {
+        const auto oi = compute_output_index(name);
+        if (oi != -1) {
+          const auto& lens = output_shapes[oi].lengths();
+          std::vector<int64_t> ort_shape(lens.begin(), lens.end());
+          auto ot = ctx.GetOutput(oi, ort_shape.data(), ort_shape.size());
+          output_ptrs[name] = ot.GetTensorMutableRawData();
+        }
+      }
+    }
+
+    mgx_state->cached_prog_params = m;
+    mgx_state->cached_prog_output_indices = prog_output_indices;
+    mgx_state->last_input_shapes_raw = build_input_shapes_in_cached_order(mgx_state, ctx, 0);
+    mgx_state->last_input_shape_hash = current_hash;
+    mgx_state->caches_valid = true;
+
+    run_program_or_hip_graph_direct(mgx_state, rocm_stream, ctx, prog, m,
+                                     prog_output_indices, current_hash,
+                                     input_ptrs, output_ptrs);
+    return;
   }
 
   if (mgx_state->hip_graph_enabled && mgx_state->pinned_io.allocated) {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -168,7 +168,8 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
       external_free_{info.external_free},
       external_empty_cache_{info.external_empty_cache},
       max_dynamic_batch_{info.max_dynamic_batch},
-      compile_batches_{info.compile_batches} {
+      compile_batches_{info.compile_batches},
+      hip_graph_enable_{info.hip_graph_enable} {
   InitProviderOrtApi();
 
   // Set GPU device to be used and read device properties for feature usage.
@@ -213,6 +214,7 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
   GET_ENV_BOOL(migraphx_env_vars::kDumpModelOps, dump_model_ops_);
   GET_ENV_BOOL(migraphx_env_vars::kExhaustiveTune, exhaustive_tune_);
   GET_ENV_STRING(migraphx_env_vars::kCompileBatches, compile_batches_);
+  GET_ENV_BOOL(migraphx_env_vars::kHipGraphEnable, hip_graph_enable_);
 
   // If compile_batches is set, auto-derive max_dynamic_batch from the spec's max value
   if (!compile_batches_.empty()) {
@@ -292,7 +294,8 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
                         << "\n " << migraphx_provider_option::kInt8UseNativeCalibTable << ": " << int8_use_native_calibration_table_
                         << "\n " << migraphx_provider_option::kModelCacheDir << ": " << model_cache_path_
                         << "\n " << migraphx_provider_option::kModelMaxDynamicBatch << ": " << max_dynamic_batch_
-                        << "\n " << migraphx_provider_option::kCompileBatches << ": " << (compile_batches_.empty() ? "(not set)" : compile_batches_);
+                        << "\n " << migraphx_provider_option::kCompileBatches << ": " << (compile_batches_.empty() ? "(not set)" : compile_batches_)
+                        << "\n " << migraphx_provider_option::kHipGraphEnable << ": " << hip_graph_enable_;
 }
 
 std::vector<AllocatorPtr> MIGraphXExecutionProvider::CreatePreferredAllocators() {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1836,6 +1836,8 @@ static void destroy_hip_graphs(MIGraphXFuncState* mgx_state) {
 
 // Warmup run (ensures lazy GPU allocations are finalized) then capture the graph.
 // Stores extra (non-pre-allocated) output metadata so replay can materialize them.
+static constexpr int kHipGraphWarmInIterations = 8;
+
 static bool warmup_and_capture_hip_graph(
     MIGraphXFuncState* mgx_state,
     hipStream_t stream,
@@ -1853,8 +1855,10 @@ static bool warmup_and_capture_hip_graph(
     HIP_CALL_THROW(hipMemsetAsync(pin.data, 0, pin.size_bytes, stream));
   }
 
+  // Run multiple eager warmup iterations before capture to let MIGraphX
+  // internal workspace buffers (scratch, reductions, etc.) stabilize.
   std::optional<migraphx::arguments> warmup_outputs;
-  {
+  for (int i = 0; i < kHipGraphWarmInIterations; ++i) {
     std::lock_guard<std::mutex> lock(*mgx_state->mgx_mu_ptr);
     warmup_outputs = prog.run_async(m, stream);
   }
@@ -1878,6 +1882,13 @@ static bool warmup_and_capture_hip_graph(
 
     HIP_CALL_THROW(hipGraphInstantiate(&entry.exec, entry.graph, nullptr, nullptr, 0));
     entry.captured = true;
+
+    // Replay the captured graph several more times post-capture to ensure
+    // workspace is fully settled before the first real inference.
+    for (int i = 0; i < kHipGraphWarmInIterations; ++i) {
+      HIP_CALL_THROW(hipGraphLaunch(entry.exec, stream));
+    }
+    HIP_CALL_THROW(hipStreamSynchronize(stream));
 
     std::unordered_set<std::size_t> pre_alloc_set(prog_output_indices.begin(),
                                                    prog_output_indices.end());
@@ -1936,7 +1947,7 @@ static bool warmup_and_capture_hip_graph_direct(
     const std::unordered_map<std::string, void*>& output_ptrs)
 {
   std::optional<migraphx::arguments> warmup_outputs;
-  {
+  for (int i = 0; i < kHipGraphWarmInIterations; ++i) {
     std::lock_guard<std::mutex> lock(*mgx_state->mgx_mu_ptr);
     warmup_outputs = prog.run_async(m, stream);
   }
@@ -1962,6 +1973,11 @@ static bool warmup_and_capture_hip_graph_direct(
     entry.captured = true;
     entry.captured_input_ptrs = input_ptrs;
     entry.captured_output_ptrs = output_ptrs;
+
+    for (int i = 0; i < kHipGraphWarmInIterations; ++i) {
+      HIP_CALL_THROW(hipGraphLaunch(entry.exec, stream));
+    }
+    HIP_CALL_THROW(hipStreamSynchronize(stream));
 
     std::unordered_set<std::size_t> pre_alloc_set(prog_output_indices.begin(),
                                                    prog_output_indices.end());

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -143,6 +143,12 @@ static std::string_view GetArenaExtendStrategyName(ArenaExtendStrategy strategy)
 
 static std::vector<std::size_t> parse_compile_batches(const std::string& spec);
 
+// Serializes remaining synchronous hipMalloc calls (e.g. temp output buffers)
+// across all MIGraphX EP instances in the process.  The primary pinned I/O
+// allocation paths use hipMallocAsync/hipFreeAsync which are per-stream safe,
+// but a few fallback paths still use synchronous hipMalloc.
+static std::mutex g_hip_alloc_mutex;
+
 MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProviderInfo& info)
     : IExecutionProvider{kMIGraphXExecutionProvider, OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, OrtDevice::VendorIds::AMD, info.device_id)},
       device_id_{info.device_id},
@@ -1439,7 +1445,8 @@ static void allocate_pinned_io(
     MIGraphXFuncState* mgx_state,
     const migraphx::program_parameter_shapes& param_shapes,
     const migraphx::shapes& output_shapes,
-    std::size_t max_batch_size)
+    std::size_t max_batch_size,
+    hipStream_t stream)
 {
   auto& pio = mgx_state->pinned_io;
   if (pio.allocated) return;
@@ -1456,8 +1463,8 @@ static void allocate_pinned_io(
     std::size_t bytes = max_shape.bytes();
 
     void* ptr = nullptr;
-    HIP_CALL_THROW(hipMalloc(&ptr, bytes));
-    HIP_CALL_THROW(hipMemset(ptr, 0, bytes));
+    HIP_CALL_THROW(hipMallocAsync(&ptr, bytes, stream));
+    HIP_CALL_THROW(hipMemsetAsync(ptr, 0, bytes, stream));
     pio.inputs.push_back({ptr, bytes, max_shape});
   }
 
@@ -1469,10 +1476,12 @@ static void allocate_pinned_io(
     std::size_t bytes = max_shape.bytes();
 
     void* ptr = nullptr;
-    HIP_CALL_THROW(hipMalloc(&ptr, bytes));
-    HIP_CALL_THROW(hipMemset(ptr, 0, bytes));
+    HIP_CALL_THROW(hipMallocAsync(&ptr, bytes, stream));
+    HIP_CALL_THROW(hipMemsetAsync(ptr, 0, bytes, stream));
     pio.outputs.push_back({ptr, bytes, max_shape});
   }
+
+  HIP_CALL_THROW(hipStreamSynchronize(stream));
 
   pio.max_batch_size = max_batch_size;
   pio.allocated = true;
@@ -1486,15 +1495,16 @@ static void allocate_pinned_io(
                      << " total=" << (total_bytes / (1024.0 * 1024.0)) << " MB";
 }
 
-static void free_pinned_io(MIGraphXFuncState* mgx_state) {
+static void free_pinned_io(MIGraphXFuncState* mgx_state, hipStream_t stream) {
   auto& pio = mgx_state->pinned_io;
   for (auto& buf : pio.inputs) {
-    if (buf.data) { (void)hipFree(buf.data); buf.data = nullptr; }
+    if (buf.data) { (void)hipFreeAsync(buf.data, stream); buf.data = nullptr; }
   }
-  pio.inputs.clear();
   for (auto& buf : pio.outputs) {
-    if (buf.data) { (void)hipFree(buf.data); buf.data = nullptr; }
+    if (buf.data) { (void)hipFreeAsync(buf.data, stream); buf.data = nullptr; }
   }
+  HIP_CALL_THROW(hipStreamSynchronize(stream));
+  pio.inputs.clear();
   pio.outputs.clear();
   pio.allocated = false;
 }
@@ -2111,9 +2121,12 @@ std::pair<migraphx::program_parameters, std::vector<std::size_t>> handle_program
               temp_buffer = (*temp_output_buffers)[temp_buffer_count];
             } else {
               // Allocate new buffer (first run or buffer list is empty)
-              auto hip_status = hipMalloc(&temp_buffer, output_size_bytes);
-              if (hip_status != hipSuccess) {
-                ORT_THROW("hipMalloc failed for temporary output buffer");
+              {
+                std::lock_guard<std::mutex> alloc_lock(g_hip_alloc_mutex);
+                auto hip_status = hipMalloc(&temp_buffer, output_size_bytes);
+                if (hip_status != hipSuccess) {
+                  ORT_THROW("hipMalloc failed for temporary output buffer");
+                }
               }
               temp_output_buffers->push_back(temp_buffer);
             }
@@ -2740,7 +2753,7 @@ static void compile_dynamic_batch_models(
       auto ps = last_prog.get_parameter_shapes();
       auto os = last_prog.get_output_shapes();
       if (max_batch > 0) {
-        allocate_pinned_io(mgx_state, ps, os, max_batch);
+        allocate_pinned_io(mgx_state, ps, os, max_batch, mgx_state->stream);
       }
     }
   }
@@ -2841,7 +2854,7 @@ static void execute_standard_path(
                 max_batch = *std::max_element(mgx_state->compiled_batch_sizes.begin(),
                                               mgx_state->compiled_batch_sizes.end());
               }
-              allocate_pinned_io(mgx_state, param_shapes, output_shapes, max_batch);
+              allocate_pinned_io(mgx_state, param_shapes, output_shapes, max_batch, rocm_stream);
             }
 
             copy_inputs_to_pinned(mgx_state, param_shapes, ctx, original_batch_size, padded_batch_size, rocm_stream);
@@ -2916,7 +2929,7 @@ static void execute_standard_path(
       }
     }
     if (batch_for_alloc > 0) {
-      allocate_pinned_io(mgx_state, param_shapes, output_shapes, batch_for_alloc);
+      allocate_pinned_io(mgx_state, param_shapes, output_shapes, batch_for_alloc, rocm_stream);
     }
   }
 
@@ -3902,7 +3915,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             int8_calibration_cache_available_, dynamic_range_map_,
             model_cache_path_, dump_model_ops_, exhaustive_tune_, max_dynamic_batch_,
             std::ref(cached_programs_[context->node_name])};
-      
+      p->stream = stream_;
+
       // Initialize dynamic batch support if max_dynamic_batch > 0
       if (max_dynamic_batch_ > 0) {
         p->has_dynamic_batch = true;
@@ -3959,7 +3973,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         if (largest_prog && max_batch > 0) {
           auto ps = largest_prog->get_parameter_shapes();
           auto os = largest_prog->get_output_shapes();
-          allocate_pinned_io(p.get(), ps, os, max_batch);
+          allocate_pinned_io(p.get(), ps, os, max_batch, stream_);
         }
 
         // If all batch sizes are pre-loaded, disable deferred compilation
@@ -3980,7 +3994,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     compute_info.release_state_func = [](FunctionState state) {
       if (state) {
         auto* s = static_cast<MIGraphXFuncState*>(state);
-        free_pinned_io(s);
+        free_pinned_io(s, s->stream);
         delete s;
       }
     };

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -96,6 +96,32 @@ struct MIGraphXFuncState {
   PinnedIOSet pinned_io;
 
   // ═══════════════════════════════════════════════════════════════════════════
+  // SCRATCH BUFFERS (one per compiled program / shape_hash)
+  //
+  // MIGraphX programs expose a "scratch" parameter that the EP must bind to
+  // a device buffer; otherwise MIGraphX falls back to its own internal scratch
+  // arena whose contents persist across runs and whose lifetime is opaque to
+  // hipGraph capture/replay.  When we capture a hipGraph that contains kernels
+  // which read scratch before writing within a single invocation (common with
+  // split-K reductions, fused-attention epilogues, etc.), the captured kernel
+  // sees whatever bytes happened to be in that opaque arena at capture time,
+  // and every subsequent replay inherits the same dependency on whatever the
+  // *previous* replay left behind.  That is the root cause of non-deterministic
+  // back-to-back replays on identical input.
+  //
+  // By owning the scratch buffer in the EP and zeroing it before every replay
+  // (and before capture), we anchor each replay to the same memory baseline
+  // and eliminate the cross-run state bleed.  One buffer per shape_hash means
+  // every compiled batch-size variant gets its own correctly-sized arena.
+  // ═══════════════════════════════════════════════════════════════════════════
+  struct ScratchBuf {
+    void* data = nullptr;
+    std::size_t size_bytes = 0;
+    migraphx::shape mgx_shape;
+  };
+  std::unordered_map<std::string, ScratchBuf> scratch_bufs;
+
+  // ═══════════════════════════════════════════════════════════════════════════
   // PERFORMANCE CACHES - Avoid redundant MIGraphX API calls per inference
   // ═══════════════════════════════════════════════════════════════════════════
 
@@ -173,6 +199,13 @@ struct MIGraphXFuncState {
     // Used to detect pointer drift and trigger re-capture.
     std::unordered_map<std::string, void*> captured_input_ptrs;
     std::unordered_map<std::string, void*> captured_output_ptrs;
+
+    // Scratch buffer pointer baked into the captured graph.  Compared against
+    // the current scratch buffer pointer on every replay; a mismatch (e.g.
+    // because the buffer was reallocated for a shape-size change) forces a
+    // re-capture.  nullptr means the program has no "scratch" parameter and
+    // no EP-owned scratch was bound.
+    void* captured_scratch_ptr = nullptr;
   };
 
   bool hip_graph_enabled = false;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -206,6 +206,21 @@ struct MIGraphXFuncState {
     // re-capture.  nullptr means the program has no "scratch" parameter and
     // no EP-owned scratch was bound.
     void* captured_scratch_ptr = nullptr;
+
+    // Output buffers (ptr + byte size) we need to memset to zero before every
+    // replay.  Required because some captured kernels do read-modify-write on
+    // their output (split-K reductions, fused-attention accumulators, etc.).
+    // Without this the first replay after a batch-size transition inherits
+    // residue from the previously-recycled ORT-pool buffer and produces a
+    // small but real numerical drift relative to eager (observed on the
+    // larger-reduction outputs 2/7/11 of feed-gen-rec).  Populated at capture
+    // time from output_ptrs + param_shapes; size is the program-side bytes
+    // (not the original-batch slice), which is what the captured kernels
+    // actually touch.  "Extra" outputs (those returned by prog.run_async
+    // rather than pre-allocated) are intentionally excluded -- they live in
+    // MIGraphX-managed memory and are materialized via a fresh memcpy after
+    // every replay.
+    std::vector<std::pair<void*, std::size_t>> captured_output_zeroes;
   };
 
   bool hip_graph_enabled = false;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -68,7 +68,7 @@ struct MIGraphXFuncState {
   std::filesystem::path model_cache_dir;
   bool dump_model_ops = false;
   bool exhaustive_tune = false;
-  size_t max_dynamic_batch;
+  size_t max_dynamic_batch = 0;
   // Reference to the cached programs map for this node (keyed by input shape hash)
   std::optional<std::reference_wrapper<std::unordered_map<std::string, migraphx::program>>> cached_programs_ref = std::nullopt;
   

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -74,17 +74,22 @@ struct MIGraphXFuncState {
   bool has_dynamic_batch = false;
   std::vector<std::size_t> compiled_batch_sizes;
   
-  // Padded input buffers for dynamic batching (allocated on GPU)
-  struct PaddedBuffer {
-    void* data = nullptr;          // GPU buffer pointer
-    std::size_t size_bytes = 0;    // Buffer size in bytes
-    migraphx::shape mgx_shape;     // Padded MIGraphX shape
+  // Pinned I/O buffers: allocated once at max compiled batch, reused across all inferences.
+  // Eliminates per-inference hipMalloc/hipFree for padding and temp outputs.
+  struct PinnedIOBuffer {
+    void* data = nullptr;
+    std::size_t size_bytes = 0;
+    migraphx::shape max_shape;     // Shape at max_batch_size
   };
-  std::vector<PaddedBuffer> padded_input_buffers;  // One per input when padding is active
 
-  // Track last batch sizes to avoid re-allocation when batch size is unchanged
-  std::size_t last_original_batch_size = 0;  // Original batch size from last run
-  std::size_t last_padded_batch_size = 0;    // Padded batch size from last run
+  struct PinnedIOSet {
+    std::vector<PinnedIOBuffer> inputs;
+    std::vector<PinnedIOBuffer> outputs;
+    std::size_t max_batch_size = 0;
+    bool allocated = false;
+  };
+
+  PinnedIOSet pinned_io;
 
   // ═══════════════════════════════════════════════════════════════════════════
   // PERFORMANCE CACHES - Avoid redundant MIGraphX API calls per inference
@@ -142,20 +147,7 @@ struct MIGraphXFuncState {
   // Track which program hash the cached shapes belong to (invalidate when program changes)
   std::string cached_program_hash;
   
-  // ═══════════════════════════════════════════════════════════════════════════
-  // OPTIMIZATION: Reusable temporary output buffers (for slicing mode)
-  // ═══════════════════════════════════════════════════════════════════════════
   
-  // Temporary output buffers for slicing (allocated at padded size)
-  struct TempOutputBuffer {
-    void* data = nullptr;           // GPU buffer pointer
-    std::size_t size_bytes = 0;     // Buffer size in bytes
-    migraphx::shape mgx_shape;      // Padded MIGraphX shape
-  };
-  std::vector<TempOutputBuffer> temp_output_buffers;
-  
-  // Track padded batch size for temp output buffers
-  std::size_t temp_output_padded_batch_size = 0;
 };
 
 // Logical device representation.

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -87,6 +87,8 @@ struct MIGraphXFuncState {
   struct PinnedIOSet {
     std::vector<PinnedIOBuffer> inputs;
     std::vector<PinnedIOBuffer> outputs;
+    std::unordered_map<std::string, std::size_t> input_name_to_idx;
+    std::unordered_map<std::string, std::size_t> output_name_to_idx;
     std::size_t max_batch_size = 0;
     bool allocated = false;
   };
@@ -123,6 +125,7 @@ struct MIGraphXFuncState {
 
   // Cached output indices for pre-allocated outputs (used by run_migraphx_program)
   std::vector<std::size_t> cached_prog_output_indices;
+  std::vector<std::size_t> cached_pinned_output_indices;
 
   // Last input shapes for quick comparison (avoids hash computation in ultra-fast path)
   std::vector<std::int64_t> last_input_shapes_raw;
@@ -153,10 +156,18 @@ struct MIGraphXFuncState {
   // hipGraph CAPTURE / REPLAY
   // ═══════════════════════════════════════════════════════════════════════════
 
+  struct ExtraOutputInfo {
+    std::size_t output_index;
+    std::vector<int64_t> ort_shape;
+    void* gpu_data;
+    std::size_t bytes;
+  };
+
   struct CapturedHipGraph {
     hipGraph_t graph = nullptr;
     hipGraphExec_t exec = nullptr;
     bool captured = false;
+    std::vector<ExtraOutputInfo> extra_outputs;
   };
 
   bool hip_graph_enabled = false;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -37,6 +37,7 @@ constexpr auto kExhaustiveTune = "ORT_MIGRAPHX_EXHAUSTIVE_TUNE"sv;
 constexpr auto kModelCachePath = "ORT_MIGRAPHX_MODEL_CACHE_PATH"sv;
 constexpr auto kModelMaxDynamicBatch = "ORT_MIGRAPHX_MAX_DYNAMIC_BATCH"sv;
 constexpr auto kCompileBatches = "ORT_MIGRAPHX_COMPILE_BATCHES"sv;
+constexpr auto kHipGraphEnable = "ORT_MIGRAPHX_HIP_GRAPH_ENABLE"sv;
 }  // namespace migraphx_env_vars
 
 // Tracks which dimensions are symbolic for a given input
@@ -206,6 +207,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
         {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_path_)},
         {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(max_dynamic_batch_)},
         {std::string{migraphx_provider_option::kCompileBatches}, compile_batches_},
+        {std::string{migraphx_provider_option::kHipGraphEnable}, MakeStringWithClassicLocale(hip_graph_enable_)},
         {std::string{migraphx_provider_option::kHasUserComputeStream}, MakeStringWithClassicLocale(external_stream_)},
         {std::string{migraphx_provider_option::kUserComputeStream}, MakeStringWithClassicLocale(reinterpret_cast<size_t>(stream_))}};
    }
@@ -250,6 +252,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   bool first_start_ = true;
   size_t max_dynamic_batch_{0};
   std::string compile_batches_{};  // Comma-separated list of batch sizes to compile, e.g. "1,4,8,16,32"
+  bool hip_graph_enable_{false};
 };
 
 }; // namespace onnxruntime

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -179,6 +179,9 @@ struct MIGraphXFuncState {
   // When true, capture/replay binds ORT tensor pointers directly (no pinned copies).
   // Requires the pool allocator to provide stable addresses.
   bool use_direct_hip_graph = false;
+  // If pointer drift causes too many re-captures, disable direct mode permanently.
+  static constexpr int kMaxDirectRecaptures = 3;
+  int direct_recapture_count = 0;
   // shape_hash -> captured graph (one per compiled program variant)
   std::unordered_map<std::string, CapturedHipGraph> hip_graph_cache;
 };

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -148,8 +148,20 @@ struct MIGraphXFuncState {
   
   // Track which program hash the cached shapes belong to (invalidate when program changes)
   std::string cached_program_hash;
-  
-  
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // hipGraph CAPTURE / REPLAY
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  struct CapturedHipGraph {
+    hipGraph_t graph = nullptr;
+    hipGraphExec_t exec = nullptr;
+    bool captured = false;
+  };
+
+  bool hip_graph_enabled = false;
+  // shape_hash -> captured graph (one per compiled program variant)
+  std::unordered_map<std::string, CapturedHipGraph> hip_graph_cache;
 };
 
 // Logical device representation.

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -168,9 +168,17 @@ struct MIGraphXFuncState {
     hipGraphExec_t exec = nullptr;
     bool captured = false;
     std::vector<ExtraOutputInfo> extra_outputs;
+
+    // Addresses captured in the graph for direct-bind mode.
+    // Used to detect pointer drift and trigger re-capture.
+    std::unordered_map<std::string, void*> captured_input_ptrs;
+    std::unordered_map<std::string, void*> captured_output_ptrs;
   };
 
   bool hip_graph_enabled = false;
+  // When true, capture/replay binds ORT tensor pointers directly (no pinned copies).
+  // Requires the pool allocator to provide stable addresses.
+  bool use_direct_hip_graph = false;
   // shape_hash -> captured graph (one per compiled program variant)
   std::unordered_map<std::string, CapturedHipGraph> hip_graph_cache;
 };

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -56,6 +56,7 @@ struct MIGraphXFuncState {
   migraphx::target t{};
   std::unordered_map<std::string, std::size_t> input_name_indexes;
   std::mutex* mgx_mu_ptr = nullptr;
+  hipStream_t stream = nullptr;
   bool defer_compilation = false;
   bool fp16_enable = false;
   bool bf16_enable = false;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
@@ -74,6 +74,7 @@ MIGraphXExecutionProviderInfo::MIGraphXExecutionProviderInfo(const ProviderOptio
           .AddAssignmentToEnumReference(migraphx_provider_option::kArenaExtendStrategy, arena_extend_strategy_mapping, arena_extend_strategy)
           .AddAssignmentToReference(migraphx_provider_option::kModelMaxDynamicBatch, max_dynamic_batch)
           .AddAssignmentToReference(migraphx_provider_option::kCompileBatches, compile_batches)
+          .AddAssignmentToReference(migraphx_provider_option::kHipGraphEnable, hip_graph_enable)
           .AddAssignmentToReference(migraphx_provider_option::kHasUserComputeStream, has_user_compute_stream)
           .AddValueParser(
               migraphx_provider_option::kUserComputeStream,
@@ -118,6 +119,7 @@ ProviderOptions MIGraphXExecutionProviderInfo::ToProviderOptions() const {
       {std::string{migraphx_provider_option::kModelCacheDir}, MakeStringWithClassicLocale(model_cache_dir)},
       {std::string{migraphx_provider_option::kModelMaxDynamicBatch}, MakeStringWithClassicLocale(max_dynamic_batch)},
       {std::string{migraphx_provider_option::kCompileBatches}, compile_batches},
+      {std::string{migraphx_provider_option::kHipGraphEnable}, MakeStringWithClassicLocale(hip_graph_enable)},
       {std::string{migraphx_provider_option::kHasUserComputeStream}, MakeStringWithClassicLocale(has_user_compute_stream)},
       {std::string{migraphx_provider_option::kUserComputeStream}, MakeStringWithClassicLocale(reinterpret_cast<size_t>(user_compute_stream))},
   };

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
@@ -36,6 +36,7 @@ constexpr auto kGpuExternalEmptyCache = "migraphx_external_empty_cache"sv;
 constexpr auto kModelCacheDir = "migraphx_model_cache_dir"sv;
 constexpr auto kModelMaxDynamicBatch = "migraphx_max_dynamic_batch"sv;
 constexpr auto kCompileBatches = "migraphx_compile_batches"sv;
+constexpr auto kHipGraphEnable = "migraphx_hip_graph_enable"sv;
 constexpr auto kHasUserComputeStream = "has_user_compute_stream"sv;
 constexpr auto kUserComputeStream = "user_compute_stream"sv;
 }  // namespace migraphx_provider_option
@@ -61,6 +62,7 @@ struct MIGraphXExecutionProviderInfo {
   OrtArenaCfg* default_memory_arena_cfg{nullptr};
   size_t max_dynamic_batch{static_cast<size_t>(0)};
   std::string compile_batches{};  // Comma-separated list of batch sizes to compile, e.g. "1,4,8,16,32"
+  bool hip_graph_enable{false};
 
   void* external_alloc{nullptr};
   void* external_free{nullptr};
@@ -94,7 +96,8 @@ struct std::hash<::onnxruntime::MIGraphXExecutionProviderInfo> {
                   (static_cast<size_t>(info.int8_enable) << 19) ^
                   (static_cast<size_t>(info.int8_use_native_calibration_table) << 20) ^
                   (static_cast<size_t>(info.exhaustive_tune) << 21) ^
-                  (static_cast<size_t>(info.bf16_enable) << 22);
+                  (static_cast<size_t>(info.bf16_enable) << 22) ^
+                  (static_cast<size_t>(info.hip_graph_enable) << 23);
 
     onnxruntime::HashCombine(data, value);
 

--- a/onnxruntime/core/providers/migraphx/migraphx_stream_handle.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_stream_handle.cc
@@ -67,8 +67,11 @@ std::unique_ptr<synchronize::Notification> MIGraphXStream::CreateNotification(si
 }
 
 void MIGraphXStream::Flush() {
-  if (auto* handle = GetHandle())
-    HIP_CALL_THROW(hipStreamSynchronize(static_cast<hipStream_t>(handle)));
+  // Only sync streams we own. External streams are caller-managed; implicit sync
+  // here would break async pipelines (e.g. Triton) by serializing every Run().
+  if(own_stream_)
+    if (auto* handle = GetHandle())
+      HIP_CALL_THROW(hipStreamSynchronize(static_cast<hipStream_t>(handle)));
 }
 
 void MIGraphXStream::EnqueDeferredCPUBuffer(void* cpu_buffer) {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Adds capture replay of hipGraph and associated infrastructure to allow for us to reduce launch overhead of captured MIGraphX models. where this shines is when we have models with lots of smaller kernel launches or when launch overhead overtakes the time in a run relative to compute time. This is seen in customer models with smaller batch sizes 

We pin buffers to ensure IO consistency for captures and to guarentee pointers on replay don't reference stale/reseated addresses - As a byproduct we also save on overhead as we're not alloc/dealloc new inputs in the fly during the hot perf path overall lowering latency.

A huge win with this changeset is in CPU heavy use systems - a capture shows significant performance improvement as we can reuse work and remove CPU bound requirements of getting the GPU kernels into the work queues by replaying the capture and eliminating the need for any GPU "setup" operations outside the replay - In English, the only kernel launch should be at the start of the replay and not during the run, meaning we can pipeline work more effectively for a workload with minimal CPU overhead as buffers and operations are already predefined. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Requirements to ensure hipGraph works
- Add pinned memory to ensure stable input/output buffers for each run
- Reuse largest batch for input buffer alloc once for all batches-> keeps us from blowing up memory
- Ensure async event based hipMemCpyAsync handle larger batch size transfers
- Move and minimize input syncs so we can load up work queue of GPU for captures

HipGraph
- Capture/replay of MIGraphX graph from compile or MXR load after warmup
- Zero out inputs before warmup to ensure no stale data in buffering
- Allow captured graphs to be cached similar to cached programs

Most of this infrastructer also relies on the cache batch size mechanism using max_dynamic_batch as well as compile_batches to cherry-pick which batches are used. 

Slicing/pad logic for IO need not change as that logic should just use and reference the preallocated pinned buffers


