### PR TITLE
Fix MXR cache hash collision in MIGraphX legacy EP

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1321,7 +1321,7 @@ std::string to_hex(const uint64_t v) {
 template <typename T>
 std::string make_hash(T v) {
   std::array<std::uint32_t, 4> temp{};
-  MurmurHash3::x86_128(v.data(), gsl::narrow_cast<int32_t>(v.size()), temp.front(), temp.data());
+  MurmurHash3::x86_128(v.data(), gsl::narrow_cast<int32_t>(v.size() * sizeof(*v.data())), temp.front(), temp.data());
   return to_hex(temp.at(0) | static_cast<uint64_t>(temp.at(1)) << 32);
 }
 
@@ -1476,10 +1476,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       } else {
         LOGS_DEFAULT(VERBOSE) << "Assigning inputs, and parameters from compiled model";
         param_shapes = prog.get_parameter_shapes();
-        auto prog_output_shapes = prog.get_output_shapes();
 
         // check whether input shapes match with shapes of program inputs
-        // migraphx::onnx_options cmp_options;
         if (param_shapes.size() > 0) {
           for (auto&& name : param_shapes.names()) {
             if (map_input_name_index.count(name) > 0) {
@@ -1500,10 +1498,21 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
                 cmp_options.set_input_parameter_shape(name, ort_lens);
                 input_shape_match = false;
               }
-              input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
             }
           }
         }
+      }
+
+      // Compute hash over all model inputs, consistent across both branches.
+      // The shape comparison above iterates param_shapes.names() which may be
+      // a subset of map_input_name_index. Using map_input_name_index ensures
+      // the cache key is identical for identical input shapes regardless of
+      // which program is currently active.
+      for (auto& [name, index] : map_input_name_index) {
+        auto input_tensor = ctx.GetInput(index);
+        auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
+        const auto tensor_shape = tensor_info.GetShape();
+        input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
       }
 
       // input shapes are different, needs to re-parse onnx and


### PR DESCRIPTION
### Description

Fix two bugs in the MXR cache hash computation in the MIGraphX EP that cause different input shape configurations (prefill vs decode) to produce identical `.mxr` cache filenames, and prevent cache reuse across prompts.

**Bug 1: `make_hash` uses element count instead of byte count (line 1324)**

`MurmurHash3::x86_128` expects byte length but receives `v.size()` (element count). For `vector<int64_t>` shapes like `{1,256}` and `{1,1}`, both have `size()=2`. MurmurHash3 only reads the first 2 bytes — which are identical (`0x01, 0x00`). Prefill and decode shapes hash to the same value, producing a single `.mxr` file instead of two.

Fix: `v.size() * sizeof(*v.data())` passes actual byte count. No behavior change for `string_view` (`sizeof(char)=1`).

**Bug 2: Inconsistent hash iteration between first and subsequent Compute calls (line ~1498)**

The first Compute call (`no_input_shape=true`) does not populate `input_shapes`. Subsequent calls populate it inside `param_shapes.names()` loop — which may be a subset of all model inputs if MIGraphX optimized away parameters during compilation. Different set → different hash for identical input shapes → cache miss.

Fix: Move `input_shapes` population to a separate loop over `map_input_name_index` after both branches, ensuring consistent cache keys regardless of which program is currently active.

### Motivation and Context

When running multi-prompt LLM inference through OGA (reusing the same `og.Model` across multiple `og.Generator` instances), we observed 3 MIGraphX compilations where only 2 should be needed:

1. **Prompt 1 prefill** (`input_ids={1,256}`): compiles and saves `.mxr` — expected
2. **Prompt 1 decode** (`input_ids={1,1}`): compiles and saves `.mxr` — expected
3. **Prompt 2 prefill** (`input_ids={1,256}`): should cache-hit on compilation 1's `.mxr` but **misses and recompiles** — unnecessary

The 3rd compilation occurs because of the two hash bugs described above. Bug 1 causes prefill and decode to share the same `.mxr` filename (hash collision). Bug 2 causes prompt 2's prefill hash to differ from prompt 1's prefill hash despite identical input shapes (inconsistent iteration set).

This was originally identified during MIGraphX Plugin EP testing, where the same hash bugs cause a `Tensor size mismatch` error — the Plugin EP's cross-device output copy path validates shapes, surfacing the collision as a runtime error. The legacy EP does not error (same-device copies bypass shape validation) but still incurs unnecessary recompilations that waste several minutes of GPU time per prompt transition for large models. The equivalent fix has been submitted separately to the Plugin EP repository.

---

Related:
- Plugin EP JIRA: https://ontrack-internal.amd.com/browse/SWDEV-587761
- Plugin EP PR: https://github.amd.com/ArchSWTech/onnxruntime-execution-providers/pull/35
- This will also fix this behavior: https://ontrack-internal.amd.com/browse/SWDEV-565749