### PR TITLE
[AIMIGRAPHX-885] Update sync stream to make MIGraphx EP stream aware

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1966,91 +1966,83 @@ static void run_migraphx_program(
     std::size_t padded_batch_size = 0)
 {
   std::optional<migraphx::arguments> prog_outputs;
-  {  // Scoped lock for thread safety
+  {
     std::lock_guard<std::mutex> lock(*mgx_mu_ptr);
     prog_outputs = prog.run_async(m, rocm_stream);
   }
 
-  bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 && 
+  bool needs_slicing = (original_batch_size > 0 && padded_batch_size > 0 &&
                         original_batch_size < padded_batch_size);
 
-  // Process ALL outputs for proper slicing when needed
   auto output_num = prog_outputs->size();
-  
+
+  // Fast path: no padding/slicing and all outputs were pre-allocated — nothing to do.
+  if (!needs_slicing && prog_output_indices.size() == output_num)
+    return;
+
   std::unordered_set<std::size_t> prog_output_indices_set(prog_output_indices.begin(), prog_output_indices.end());
-  std::vector<std::size_t> outputs_to_copy;  // Outputs that need memcpy (not pre-allocated)
-  
-  for (std::size_t i = 0; i < output_num; ++i) {
-    if (prog_output_indices_set.count(i) == 0) {
-      outputs_to_copy.push_back(i);
-    }
-  }
-  
-  // Defensive path for pre-allocated outputs that need slicing.
-  // Callers should use temp output buffers when slicing is needed so this path
-  // is not reached in normal operation; it exists only as a safety net.
+
   if (needs_slicing && !prog_output_indices_set.empty()) {
-    // Sync once to ensure MIGraphX has finished writing all pre-allocated outputs
-    // before any buffer may be reallocated by GetOutput below.
+    // Must sync before reallocating any pre-allocated output buffer for slicing.
     HIP_CALL_THROW(hipStreamSynchronize(rocm_stream));
 
     for (std::size_t i = 0; i < output_num; ++i) {
-      if (prog_output_indices_set.count(i) > 0) {
-        auto gpu_res = (*prog_outputs)[i];
-        migraphx::shape res_shape = gpu_res.get_shape();
-        auto res_lens = res_shape.lengths();
+      if (prog_output_indices_set.count(i) == 0) continue;
 
-        std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
-        if (!ort_shape.empty() && static_cast<std::size_t>(ort_shape[0]) != original_batch_size) {
-          ort_shape[0] = static_cast<int64_t>(original_batch_size);
+      auto gpu_res = (*prog_outputs)[i];
+      migraphx::shape res_shape = gpu_res.get_shape();
+      auto res_lens = res_shape.lengths();
 
-          std::size_t bytes_per_batch = res_shape.bytes() / padded_batch_size;
-          std::size_t bytes_to_copy = bytes_per_batch * original_batch_size;
+      std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
+      if (!ort_shape.empty() && static_cast<std::size_t>(ort_shape[0]) != original_batch_size) {
+        ort_shape[0] = static_cast<int64_t>(original_batch_size);
 
-          const void* src_data = gpu_res.data();
-          auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
-          void* output_data = output_tensor.GetTensorMutableRawData();
+        std::size_t bytes_per_batch = res_shape.bytes() / padded_batch_size;
+        std::size_t bytes_to_copy = bytes_per_batch * original_batch_size;
 
-          if (output_data != src_data) {
-            HIP_CALL_THROW(hipMemcpyWithStream(output_data,
-                                               src_data,
-                                               bytes_to_copy,
-                                               hipMemcpyDeviceToDevice,
-                                               rocm_stream));
-          }
+        const void* src_data = gpu_res.data();
+        auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
+        void* output_data = output_tensor.GetTensorMutableRawData();
+
+        if (output_data != src_data) {
+          HIP_CALL_THROW(hipMemcpyWithStream(output_data,
+                                             src_data,
+                                             bytes_to_copy,
+                                             hipMemcpyDeviceToDevice,
+                                             rocm_stream));
         }
       }
     }
   }
-  
-  // Now handle outputs that need memcpy (not pre-allocated)
-  if (prog_output_indices.size() < output_num) {
-    for (std::size_t i : outputs_to_copy) {
-      auto gpu_res = (*prog_outputs)[i];
-      migraphx::shape res_shape = gpu_res.get_shape();
-      auto res_lens = res_shape.lengths();
-      
-      std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
-      if (needs_slicing && !ort_shape.empty()) {
-        ort_shape[0] = original_batch_size;
-      }
-      
-      auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
-      void* output_data = output_tensor.GetTensorMutableRawData();
 
-      std::size_t bytes_to_copy = res_shape.bytes();
-      if (needs_slicing && res_lens.size() > 0) {
-        bytes_to_copy = (res_shape.bytes() / padded_batch_size) * original_batch_size;
-      }
+  // Copy outputs that were not pre-allocated into ORT output tensors.
+  // All copies are async on rocm_stream — no sync needed here.
+  for (std::size_t i = 0; i < output_num; ++i) {
+    if (prog_output_indices_set.count(i) > 0) continue;
 
-      HIP_CALL_THROW(hipMemcpyWithStream(output_data,
-                                         gpu_res.data(),
-                                         bytes_to_copy,
-                                         hipMemcpyDeviceToDevice,
-                                         rocm_stream));
+    auto gpu_res = (*prog_outputs)[i];
+    migraphx::shape res_shape = gpu_res.get_shape();
+    auto res_lens = res_shape.lengths();
+
+    std::vector<int64_t> ort_shape{res_lens.begin(), res_lens.end()};
+    if (needs_slicing && !ort_shape.empty()) {
+      ort_shape[0] = original_batch_size;
     }
-  }
 
+    auto output_tensor = ctx.GetOutput(i, ort_shape.data(), ort_shape.size());
+    void* output_data = output_tensor.GetTensorMutableRawData();
+
+    std::size_t bytes_to_copy = res_shape.bytes();
+    if (needs_slicing && !res_lens.empty()) {
+      bytes_to_copy = (res_shape.bytes() / padded_batch_size) * original_batch_size;
+    }
+
+    HIP_CALL_THROW(hipMemcpyWithStream(output_data,
+                                       gpu_res.data(),
+                                       bytes_to_copy,
+                                       hipMemcpyDeviceToDevice,
+                                       rocm_stream));
+  }
 }
 
 // Helper: Handle input shape mismatch by recompiling the model with new input shapes

--- a/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
@@ -205,25 +205,18 @@ namespace {
 
 struct MIGraphXErrorHelper {
   static const OrtApi* ort_api;
-
-  static OrtStatus* ToOrtStatus(const onnxruntime::Status& status) {
-    if (status.IsOK()) return nullptr;
-    return ort_api->CreateStatus(static_cast<OrtErrorCode>(status.Code()),
-                                 status.ErrorMessage().c_str());
-  }
 };
 
 const OrtApi* MIGraphXErrorHelper::ort_api = nullptr;
 
-#define MIGRAPHX_RETURN_IF_STATUS_NOTOK(fn)              \
-  do {                                                   \
-    onnxruntime::Status _status = (fn);                  \
-    if (!_status.IsOK()) {                               \
-      return MIGraphXErrorHelper::ToOrtStatus(_status);  \
-    }                                                    \
+#define HIP_FACTORY_RETURN_IF_ERROR(expr)                                       \
+  do {                                                                          \
+    hipError_t _hip_err = (expr);                                               \
+    if (_hip_err != hipSuccess) {                                               \
+      return MIGraphXErrorHelper::ort_api->CreateStatus(                        \
+          ORT_EP_FAIL, hipGetErrorString(_hip_err));                            \
+    }                                                                           \
   } while (0)
-
-#define HIP_FACTORY_RETURN_IF_ERROR(expr) MIGRAPHX_RETURN_IF_STATUS_NOTOK(HIP_CALL(expr))
 
 struct MIGraphXSyncNotificationImpl : OrtSyncNotificationImpl {
   static OrtStatus* Create(hipStream_t stream, const OrtApi& ort_api,
@@ -234,7 +227,7 @@ struct MIGraphXSyncNotificationImpl : OrtSyncNotificationImpl {
   }
 
   ~MIGraphXSyncNotificationImpl() {
-    if (event_) hipEventDestroy(event_);
+    if (event_) (void)hipEventDestroy(event_);
   }
 
   static void ReleaseImpl(_In_ OrtSyncNotificationImpl* this_ptr) noexcept {
@@ -277,9 +270,8 @@ struct MIGraphXSyncNotificationImpl : OrtSyncNotificationImpl {
 };
 
 struct MIGraphXSyncStreamImpl : OrtSyncStreamImpl {
-  MIGraphXSyncStreamImpl(hipStream_t stream, const OrtDevice& device,
-                         const OrtApi& ort_api_in)
-      : hip_stream_{stream}, device_{device}, ort_api{ort_api_in} {
+  MIGraphXSyncStreamImpl(hipStream_t stream, const OrtApi& ort_api_in)
+      : hip_stream_{stream}, ort_api{ort_api_in} {
     ort_version_supported = ORT_API_VERSION;
     GetHandle = GetHandleImpl;
     CreateNotification = CreateNotificationImpl;
@@ -327,7 +319,6 @@ struct MIGraphXSyncStreamImpl : OrtSyncStreamImpl {
 
  private:
   hipStream_t hip_stream_;
-  OrtDevice device_;
   const OrtApi& ort_api;
 };
 
@@ -462,8 +453,7 @@ struct MigraphXEpFactory : OrtEpFactory {
     HIP_FACTORY_RETURN_IF_ERROR(hipSetDevice(device_id));
     HIP_FACTORY_RETURN_IF_ERROR(hipStreamCreateWithFlags(&hip_stream, hipStreamNonBlocking));
 
-    const auto* ort_device = static_cast<const OrtDevice*>(memory_device);
-    auto impl = std::make_unique<MIGraphXSyncStreamImpl>(hip_stream, *ort_device, factory->ort_api);
+    auto impl = std::make_unique<MIGraphXSyncStreamImpl>(hip_stream, factory->ort_api);
     *stream = impl.release();
 
     return nullptr;

--- a/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
@@ -22,6 +22,7 @@
 #include "core/framework/provider_options.h"
 
 #include "core/session/onnxruntime_c_api.h"
+#include "core/providers/migraphx/migraphx_stream_handle.h"
 
 namespace onnxruntime {
 
@@ -200,6 +201,138 @@ struct MIGraphX_Provider final : Provider {
 
 #include "core/framework/error_code_helper.h"
 
+namespace {
+
+struct MIGraphXErrorHelper {
+  static const OrtApi* ort_api;
+
+  static OrtStatus* ToOrtStatus(const onnxruntime::Status& status) {
+    if (status.IsOK()) return nullptr;
+    return ort_api->CreateStatus(static_cast<OrtErrorCode>(status.Code()),
+                                 status.ErrorMessage().c_str());
+  }
+};
+
+const OrtApi* MIGraphXErrorHelper::ort_api = nullptr;
+
+#define MIGRAPHX_RETURN_IF_STATUS_NOTOK(fn)              \
+  do {                                                   \
+    onnxruntime::Status _status = (fn);                  \
+    if (!_status.IsOK()) {                               \
+      return MIGraphXErrorHelper::ToOrtStatus(_status);  \
+    }                                                    \
+  } while (0)
+
+#define HIP_FACTORY_RETURN_IF_ERROR(expr) MIGRAPHX_RETURN_IF_STATUS_NOTOK(HIP_CALL(expr))
+
+struct MIGraphXSyncNotificationImpl : OrtSyncNotificationImpl {
+  static OrtStatus* Create(hipStream_t stream, const OrtApi& ort_api,
+                           std::unique_ptr<MIGraphXSyncNotificationImpl>& notification) {
+    notification.reset(new MIGraphXSyncNotificationImpl(stream, ort_api));
+    HIP_FACTORY_RETURN_IF_ERROR(hipEventCreateWithFlags(&notification->event_, hipEventDisableTiming));
+    return nullptr;
+  }
+
+  ~MIGraphXSyncNotificationImpl() {
+    if (event_) hipEventDestroy(event_);
+  }
+
+  static void ReleaseImpl(_In_ OrtSyncNotificationImpl* this_ptr) noexcept {
+    delete static_cast<MIGraphXSyncNotificationImpl*>(this_ptr);
+  }
+
+  static OrtStatus* ActivateImpl(_In_ OrtSyncNotificationImpl* this_ptr) noexcept {
+    auto& impl = *static_cast<MIGraphXSyncNotificationImpl*>(this_ptr);
+    HIP_FACTORY_RETURN_IF_ERROR(hipEventRecord(impl.event_, impl.stream_));
+    return nullptr;
+  }
+
+  static OrtStatus* WaitOnDeviceImpl(_In_ OrtSyncNotificationImpl* this_ptr,
+                                     _In_ OrtSyncStream* consumer_stream) noexcept {
+    auto& impl = *static_cast<MIGraphXSyncNotificationImpl*>(this_ptr);
+    void* consumer_handle = impl.ort_api.SyncStream_GetHandle(consumer_stream);
+    HIP_FACTORY_RETURN_IF_ERROR(hipStreamWaitEvent(static_cast<hipStream_t>(consumer_handle), impl.event_, 0));
+    return nullptr;
+  }
+
+  static OrtStatus* WaitOnHostImpl(_In_ OrtSyncNotificationImpl* this_ptr) noexcept {
+    auto& impl = *static_cast<MIGraphXSyncNotificationImpl*>(this_ptr);
+    HIP_FACTORY_RETURN_IF_ERROR(hipEventSynchronize(impl.event_));
+    return nullptr;
+  }
+
+ private:
+  MIGraphXSyncNotificationImpl(hipStream_t stream, const OrtApi& ort_api_in)
+      : stream_{stream}, ort_api{ort_api_in} {
+    ort_version_supported = ORT_API_VERSION;
+    Activate = ActivateImpl;
+    WaitOnDevice = WaitOnDeviceImpl;
+    WaitOnHost = WaitOnHostImpl;
+    Release = ReleaseImpl;
+  }
+
+  hipStream_t stream_;
+  hipEvent_t event_{nullptr};
+  const OrtApi& ort_api;
+};
+
+struct MIGraphXSyncStreamImpl : OrtSyncStreamImpl {
+  MIGraphXSyncStreamImpl(hipStream_t stream, const OrtDevice& device,
+                         const OrtApi& ort_api_in)
+      : hip_stream_{stream}, device_{device}, ort_api{ort_api_in} {
+    ort_version_supported = ORT_API_VERSION;
+    GetHandle = GetHandleImpl;
+    CreateNotification = CreateNotificationImpl;
+    Flush = FlushImpl;
+    OnSessionRunEnd = OnSessionRunEndImpl;
+    Release = ReleaseImpl;
+  }
+
+  ~MIGraphXSyncStreamImpl() {
+    if (hip_stream_) {
+      (void)hipStreamSynchronize(hip_stream_);
+      (void)hipStreamDestroy(hip_stream_);
+    }
+  }
+
+  static void ReleaseImpl(_In_ OrtSyncStreamImpl* this_ptr) noexcept {
+    delete static_cast<MIGraphXSyncStreamImpl*>(this_ptr);
+  }
+
+  static void* GetHandleImpl(_In_ OrtSyncStreamImpl* this_ptr) noexcept {
+    return static_cast<MIGraphXSyncStreamImpl*>(this_ptr)->hip_stream_;
+  }
+
+  static OrtStatus* CreateNotificationImpl(_In_ OrtSyncStreamImpl* this_ptr,
+                                           _Outptr_ OrtSyncNotificationImpl** notification_impl) noexcept {
+    auto& impl = *static_cast<MIGraphXSyncStreamImpl*>(this_ptr);
+    *notification_impl = nullptr;
+    std::unique_ptr<MIGraphXSyncNotificationImpl> notification;
+    auto* status = MIGraphXSyncNotificationImpl::Create(impl.hip_stream_, impl.ort_api, notification);
+    if (status) return status;
+    *notification_impl = notification.release();
+    return nullptr;
+  }
+
+  static OrtStatus* FlushImpl(_In_ OrtSyncStreamImpl* this_ptr) noexcept {
+    auto& impl = *static_cast<MIGraphXSyncStreamImpl*>(this_ptr);
+    HIP_FACTORY_RETURN_IF_ERROR(hipStreamSynchronize(impl.hip_stream_));
+    return nullptr;
+  }
+
+  static OrtStatus* OnSessionRunEndImpl(_In_ OrtSyncStreamImpl* this_ptr) noexcept {
+    (void)this_ptr;
+    return nullptr;
+  }
+
+ private:
+  hipStream_t hip_stream_;
+  OrtDevice device_;
+  const OrtApi& ort_api;
+};
+
+}  // namespace
+
 // OrtEpApi infrastructure to be able to use the MigraphX/AMDGPU EP as an OrtEpFactory for auto EP selection.
 struct MigraphXEpFactory : OrtEpFactory {
   MigraphXEpFactory(const OrtApi& ort_api_in,
@@ -314,18 +447,26 @@ struct MigraphXEpFactory : OrtEpFactory {
   }
 
   static bool ORT_API_CALL IsStreamAwareImpl(const OrtEpFactory* /*this_ptr*/) noexcept {
-    return false;
+    return true;
   }
 
   static OrtStatus* ORT_API_CALL CreateSyncStreamForDeviceImpl(OrtEpFactory* this_ptr,
-                                                               const OrtMemoryDevice* /*memory_device*/,
+                                                               const OrtMemoryDevice* memory_device,
                                                                const OrtKeyValuePairs* /*stream_options*/,
                                                                OrtSyncStreamImpl** stream) noexcept {
     auto* factory = static_cast<MigraphXEpFactory*>(this_ptr);
+    const OrtEpApi& ep_api = *factory->ort_api.GetEpApi();
+    auto device_id = ep_api.MemoryDevice_GetDeviceId(memory_device);
 
-    *stream = nullptr;
-    return factory->ort_api.CreateStatus(
-        ORT_INVALID_ARGUMENT, "CreateSyncStreamForDevice should not be called as IsStreamAware returned false.");
+    hipStream_t hip_stream = nullptr;
+    HIP_FACTORY_RETURN_IF_ERROR(hipSetDevice(device_id));
+    HIP_FACTORY_RETURN_IF_ERROR(hipStreamCreateWithFlags(&hip_stream, hipStreamNonBlocking));
+
+    const auto* ort_device = static_cast<const OrtDevice*>(memory_device);
+    auto impl = std::make_unique<MIGraphXSyncStreamImpl>(hip_stream, *ort_device, factory->ort_api);
+    *stream = impl.release();
+
+    return nullptr;
   }
 
   const OrtApi& ort_api;
@@ -347,6 +488,7 @@ OrtStatus* CreateEpFactories(const char* /*registration_name*/, const OrtApiBase
                              const OrtLogger* default_logger,
                              OrtEpFactory** factories, size_t max_factories, size_t* num_factories) {
   const OrtApi* ort_api = ort_api_base->GetApi(ORT_API_VERSION);
+  MIGraphXErrorHelper::ort_api = ort_api;
 
   // Factory could use registration_name or define its own EP name.
   auto factory_gpu = std::make_unique<MigraphXEpFactory>(*ort_api,


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Allows MIGraphX EP to be stream aware in order to leverage copy async 


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Used to ensure that were using hipMemCpyAsync for our copies when using external compute streams instead of the default hipStream causing contention/. 

As a byproduct this makes slices and padding a bit faster as well

