### PR TITLE
[SWDEV-595896] Add hook for model_cache_path to use model_cache_dir in provider options

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -200,7 +200,12 @@ MIGraphXExecutionProvider::MIGraphXExecutionProvider(const MIGraphXExecutionProv
   GET_ENV(migraphx_env_vars::kINT8CalibrationTableName, int8_calibration_cache_name_);
   GET_ENV(migraphx_env_vars::kINT8UseNativeMIGraphXCalibrationTable, int8_use_native_migraphx_calibration_table_);
   GET_ENV_STRING(migraphx_env_vars::kCachePath, calibration_cache_path_);
-  GET_ENV_STRING(migraphx_env_vars::kModelCachePath, model_cache_path_);
+
+  // Only consult the env var when the provider option didn't supply a path,
+  // so an explicit migraphx_model_cache_dir is never silently overridden.
+  if (model_cache_path_.empty()) {
+    GET_ENV_STRING(migraphx_env_vars::kModelCachePath, model_cache_path_);
+  }
 
   // Strip surrounding quotes from cache path.
   {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
@@ -95,6 +95,13 @@ MIGraphXExecutionProviderInfo::MIGraphXExecutionProviderInfo(const OrtMIGraphXPr
       bf16_enable{options.migraphx_bf16_enable != 0},
       fp8_enable{options.migraphx_fp8_enable != 0},
       int8_enable{options.migraphx_int8_enable != 0},
+      int8_calibration_table_name{options.migraphx_int8_calibration_table_name != nullptr
+                                      ? options.migraphx_int8_calibration_table_name
+                                      : ""},
+      int8_use_native_calibration_table{options.migraphx_use_native_calibration_table != 0},
+      model_cache_dir{options.migraphx_cache_dir != nullptr
+                          ? ToPathString(std::string{options.migraphx_cache_dir})
+                          : std::filesystem::path{}},
       exhaustive_tune{options.migraphx_exhaustive_tune != 0},
       mem_limit{options.migraphx_mem_limit},
       arena_extend_strategy{options.migraphx_arena_extend_strategy},

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
@@ -100,7 +100,7 @@ MIGraphXExecutionProviderInfo::MIGraphXExecutionProviderInfo(const OrtMIGraphXPr
                                       : ""},
       int8_use_native_calibration_table{options.migraphx_use_native_calibration_table != 0},
       model_cache_dir{options.migraphx_cache_dir != nullptr
-                          ? ToPathString(std::string{options.migraphx_cache_dir})
+                          ? std::filesystem::path{ToPathString(std::string{options.migraphx_cache_dir})}
                           : std::filesystem::path{}},
       exhaustive_tune{options.migraphx_exhaustive_tune != 0},
       mem_limit{options.migraphx_mem_limit},


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Ensures model_cache_dir parameter is found in provider options


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


Need this to ensure provider options for model cache dir doesn't get overwritten during parse