### PR TITLE
Fix MIGraphX EP shape-hash collision in make_hash

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -2570,7 +2570,7 @@ std::string to_hex(const uint64_t v) {
 template <typename T>
 std::string make_hash(T v) {
   std::array<std::uint32_t, 4> temp{};
-  MurmurHash3::x86_128(v.data(), gsl::narrow_cast<int32_t>(v.size()), temp[0], temp.data());
+  MurmurHash3::x86_128(v.data(), gsl::narrow_cast<int32_t>(v.size() * sizeof(*v.data())), temp[0], temp.data());
   return to_hex(temp[0] | static_cast<uint64_t>(temp[1]) << 32);
 }
 


### PR DESCRIPTION
### Description
  make_hash passed v.size() (element count) as MurmurHash3's length
  argument, which expects bytes. For a std::vector<int64_t> shape key only
  the first 4 bytes were hashed -- the low half of shape[0] (the batch
  dim) -- so every shape with the same batch collided regardless of
  H/W/C. In static mode (migraphx_max_dynamic_batch=0) a later spatial
  shape collided with the first compiled program's hash, so the EP reused
  the stale program via execute_fast_path and returned the original-sized
  output for the new input. Downstream consumers that resized their output
  buffer to the new shape overflowed -> heap corruption
  (malloc_consolidate(): invalid chunk size), SIGABRT. The disk cache was
  likewise corrupted: one .mxr where there should be one per shape.

### Motivation and Context
Compilation was not occurring for model that was previously compiled and cached with different input shape (height, width).  Session was still created and inference proceeded with cached model causing to heap corruption.

JIRA: AIMIGRAPHX-1155