### PR TITLE
Fix external ONNX data path

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -3206,7 +3206,7 @@ static void handle_input_shape_mismatch(
       mgx_state->int8_calibration_cache_available,
       mgx_state->dynamic_range_map,
       mgx_state->exhaustive_tune,
-      mgx_state->model_cache_dir,
+      model_path,
       &ctx,
       &map_input_name_index);
 


### PR DESCRIPTION
### Description
Pass the original ONNX model path during MIGraphX runtime recompilation instead of the compiled-model cache directory. 



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


